### PR TITLE
docs: add 'User Guide' and 'Use Cases' sections

### DIFF
--- a/src/Documentation/sidebar.json
+++ b/src/Documentation/sidebar.json
@@ -9,6 +9,26 @@
     ]
   },
   {
+    "name": "Use Cases",
+    "folder": "/static/docs/use-cases",
+    "files": [
+      "how-to-store-files-in-dvc.md"
+    ],
+    "labels": [
+      "how-to-store-files-in-dvc.md": "How To Store Files In DVC"
+    ]
+  },
+  {
+    "name": "User Guide",
+    "folder": "/static/docs/user-guide",
+    "files": [
+      "dvc-file-format.md"
+    ],
+    "labels": [
+      "dvc-file-format.md": "DVC File Format"
+    ]
+  },
+  {
     "name": "Commands Reference",
     "folder": "/static/docs/commands-reference",
     "indexFile": "index.md",

--- a/static/docs/use-cases/how-to-store-files-in-dvc.md
+++ b/static/docs/use-cases/how-to-store-files-in-dvc.md
@@ -1,0 +1,93 @@
+# How To Store Files In DVC
+
+DVC allows storing and versioning files with Git, without checking the file
+contents into Git. It is useful when dealing with files that are too large
+for Git to handle. DVC stores information about your data file in a special
+.dvc file, that has a description of a file that can be used for versioning.
+DVC supports various types of remote locations for your cache files and
+allows you to easily store and share your data alongside your code.
+
+Let's say you already have a project that uses a bunch of images that are
+stored in `assets` directory.
+
+```
+    $ ls assets
+    favicon-16x16.png favicon-32x32.png favicon.ico social-share.png
+```
+
+To start using dvc we need to first initialize it in your repository:
+
+```
+    $ dvc init
+```
+
+DVC will create a `.dvc` directory that will store special files and also
+a `.dvc/cache` directory that will be used to store cache for your data.
+
+```
+    $ git status
+    ...
+            new file:   .dvc/.gitignore
+	    new file:   .dvc/config
+    $ git commit -m "Initialize dvc"
+```
+
+Start tracking assets with dvc:
+
+```
+    $ dvc add assets
+```
+
+Commit your changes:
+
+```
+    $ git status
+    ...
+    Untracked files:
+        .gitignore
+        assets.dvc
+    $ git add .gitignore assets.dvc
+    $ git commit -m "Track assets with dvc"
+```
+
+To share your data with others you need to setup ```dvc remote``` repository.
+DVC supports a variety of remote types (see
+[`dvc remote`](https://dvc.org/doc/commands-reference/remote) for more info),
+but for this example let's use AWS S3 remote to store your cache. To add
+your S3 repository and set it as a default one run:
+
+```
+    $ dvc remote add -d myremote s3://mybucket/mycache
+    Setting 'myremote' as a default remote.
+```
+
+This will add `myremote` to your `.dvc/config`. Commit your changes and push
+your code:
+
+```
+    $ git add .dvc/config
+    $ git push
+```
+
+Now, to upload your cache use:
+
+```
+    $ dvc push
+    (1/5): [##############################] 100% 3caf879afa11fc750cac4e15721a8741
+    (2/5): [##############################] 100% f83c01a5634a9e7b8a04177a5533f67b
+    (3/5): [##############################] 100% 2579801f17b00b0014d4e2a4847e3064.dir
+    (4/5): [##############################] 100% 82986e112ecefabbcfbaf960e2c8fb36
+    (5/5): [##############################] 100% 18d51187e9602848514499047bb6de7f
+```
+
+In order for your collagues to obtain the cache, they will simply need to run:
+
+```
+   $ git pull
+   $ dvc pull
+   (1/5): [##############################] 100% 3caf879afa11fc750cac4e15721a8741
+   (2/5): [##############################] 100% f83c01a5634a9e7b8a04177a5533f67b
+   (3/5): [##############################] 100% 2579801f17b00b0014d4e2a4847e3064.dir
+   (4/5): [##############################] 100% 82986e112ecefabbcfbaf960e2c8fb36
+   (5/5): [##############################] 100% 18d51187e9602848514499047bb6de7f
+```

--- a/static/docs/user-guide/dvc-file-format.md
+++ b/static/docs/user-guide/dvc-file-format.md
@@ -1,0 +1,46 @@
+# DVC File Format
+
+When you add a file or a stage to your pipeline, DVC creates a special ```.dvc```
+file that contains all the needed information to track your data. The file
+itself is in a simple YAML format and could be easily written or altered
+(after being created by `dvc run`) by hand.
+
+Here is an example of dvc file:
+
+```
+    cmd: python cleanup.py
+    deps:
+    - md5: da2259ee7c12ace6db43644aef2b754c
+      path: common.py
+    - md5: e309de87b02312e746ec5a500844ce77
+      path: cleanup.py
+    - md5: 129a6b44831a9344e493b974cfa1ac9a
+      path: ../raw/data
+    md5: 521ac615cfc7323604059d81d052ce00
+    outs:
+    - cache: true
+      md5: 70f3c9157e3b92a6d2c93eb51439f822
+      metric: false
+      path: data
+```
+
+## Structure
+
+On the top level, ```.dvc``` file consists of such fields:
+
+* `cmd`: a command that is being run in this stage of the pipeline;
+* `deps`: a list of dependencies for this stage;
+* `outs`: a list of outputs for this stage;
+* `md5`: md5 checksum for this dvc file;
+
+A dependency entry consists of such fields:
+
+* `path`: path to the dependency, relative to the location of dvc file;
+* `md5`: md5 checksum for the dependency;
+
+An output entry consists of such fields:
+
+* `path`: path to the output, relative to the location of dvc file;
+* `md5`: md5 checksum for the output;
+* `cache`: whether or not dvc should cache the output;
+* `metric`: whether or not this file is a metric file;


### PR DESCRIPTION
Starting off with 'How to store files in dvc' and 'DVC file format'.

Signed-off-by: Ruslan Kuprieiev <kupruser@gmail.com>