### PR TITLE
Fix training step command in tutorial

### DIFF
--- a/static/docs/get-started/pipeline.md
+++ b/static/docs/get-started/pipeline.md
@@ -22,7 +22,7 @@ The third stage, training:
 ```dvc
     $ dvc run -d src/train.py -d data/features \
               -o model.pkl \
-              python src/train.py -d data/features model.pkl
+              python src/train.py data/features model.pkl
 ```
 
 Let's commit DVC files that describe our pipeline so far:

--- a/static/docs/get-started/pipeline.md
+++ b/static/docs/get-started/pipeline.md
@@ -20,7 +20,8 @@ step), feature extraction:
 The third stage, training:
 
 ```dvc
-    $ dvc run -d src/train.py -d data/features \
+    $ dvc run -f train.dvc \
+              -d src/train.py -d data/features \
               -o model.pkl \
               python src/train.py data/features model.pkl
 ```


### PR DESCRIPTION
Hello,

This is a proposed fix for the issue https://github.com/iterative/dvc.org/issues/220 i opened
This should fix the error message I get when running the training step command in the tutorial:

```
$ dvc run -d src/train.py -d data/features \
              -o model.pkl \
              python src/train.py -d data/features model.pkl 

Running command:
	python src/train.py -d data/features model.pkl
Arguments error. Usage:
	python train.py features model
Error: failed to run command - stage 'model.pkl.dvc' cmd python src/train.py -d data/features model.pkl failed
```