### PR TITLE
docs: get-started metrics correction

### DIFF
--- a/static/docs/get-started/metrics.md
+++ b/static/docs/get-started/metrics.md
@@ -26,7 +26,7 @@ options and details.
 Let's again commit and save results:
 
 ```dvc
-    $ git add evaluate.dvc
+    $ git add evaluate.dvc auc.metric
     $ git commit -m "add evaluation step to the pipeline"
     $ dvc push
 ```


### PR DESCRIPTION
Proposing a minor change here as following the initial docs I encountered an error down the line where I could not compare model metrics across. My understanding is it didn't work because I hadn't committed the `auc.metric` file because the docs explicitly indicate not to.

Please let me know if I missed something here or blatantly misunderstood how dvc works.

Also, super cool tool thanks for all the hard work 😄 