### PR TITLE
pipeline: document --locked option

### DIFF
--- a/static/docs/commands-reference/pipeline:show.md
+++ b/static/docs/commands-reference/pipeline:show.md
@@ -29,6 +29,9 @@ to third party visualization utilities.
 
 * `--tree` - list dependencies tree like recursive directory listing.
 
+* `--locked` - print locked DVC stages.
+
+
 ## Examples
 
 * Default mode, show stages `output.dvc` recursively depends on:


### PR DESCRIPTION
Document `--locked` option on `pipeline show`. re dvc#1864