### PR TITLE
Add use case about running DVC on remote machine

### DIFF
--- a/static/docs/use-cases/dvc-on-remote-machine.md
+++ b/static/docs/use-cases/dvc-on-remote-machine.md
@@ -1,0 +1,67 @@
+DVC on Remote Machine
+---------------------
+
+DVC can be run a remote machine. You can have a data remote in DVC. DVC remotess provide
+a central place to keep and share data and model files. With a remote data sotroge,
+you can pull models and data files created without spending time and resources
+in re-build models and re-process files. You can think of DVC remote storage as remote
+Git server or GitHub storing and sharing your code. This document describes how you
+can ssh in a remote machine and run DVC.
+
+- SSH in remote machine
+
+  ```
+	$ ssh root@ip
+	```
+
+	You might require a `~/.ssh/id_rsa.pub` while sshing.
+
+- Setup repository
+
+  ```
+  $ cd dvc_git_repository
+  $ dvc init
+	```
+
+  You can also clone a remote git repository using
+
+	```
+  $ git clone https://github.com/dataversioncontrol/coderepository.git
+  $ cd coderepository
+  # Reproduce data files
+  $ dev repro
+  Reproducing 'output.p':
+    python cnn_train.py --seed 20180227 --epoch 20 input.csv model.pkl results.csv
+    Reproducing 'plots.jpg':
+      Rscript plot.R result.csv plots.jpg
+	```
+
+- Get the dataset
+
+  For using `dvc pull` the remote storage should be defined. For an existing project
+	a remote can be defined and you can use dvc remote list listing dvc remotes. Let's
+	setup an SSH remote with the dvc remote command:
+
+  ```
+  $ dvc remote add remote1 ssh://_username_@_host_/path/to/dvc/cache/directory
+  $ dvc remote list
+  remote1 ssh://_username_@_host_/path/to/dvc/cache/directory
+	```
+
+	DVC supports several protocols for remote storage. You can find the information about
+	[remote add](https://github.com/iterative/dvc.org/blob/master/static/docs/commands-reference/remote:add.md).
+
+	You can then run a
+
+	```
+  $ dvc pull --remote remote1
+	```
+	or
+
+	```
+  $ dvc pull sample.zip.dvc
+	```
+
+- Training the models
+
+  You can then run `dvc run` and `dvc repro` which can train the models.


### PR DESCRIPTION
Fix #194.

Hi folks,

I am a GSoD applicant, have read [your ideas list](https://blog.dataversioncontrol.com/dvc-project-ideas-for-google-summer-of-docs-2019-defe3a73b248) and working on closing tickets present in the list.  

I have participated in multiple SoC/WoC and have been involved w/ open source since years. I have worked with Jupyter and have worked w/ ML algorithms. I am fully familiar with these areas. DVC.org is great fit for me but as a product new for me. 

On docs I like detailed docs having every step present so that the user can be spoon feeded, makes it easily usable. 

I see a scope of writing more on `dvc run` and `dvc pull` command lines. Please let me know what you think would be best for your org. Thanks for the read!