### PR TITLE
Fixes #266

### DIFF
--- a/src/Footer/index.js
+++ b/src/Footer/index.js
@@ -15,7 +15,7 @@ export default props => (
         <Logo href="/">
           <img
             src="/static/img/logo_white.png"
-            alt="DVC.org"
+            alt="site logo"
             width={36}
             height={23}
           />


### PR DESCRIPTION
Fixes #266. From Google - their search engine can independently assign a title for the site, for example, if the title in the <title> tag does not match the page content. Given that the string "DVC" in search results is uppercase, Google took it from the 'alt' attribute of the logo in footer. After the changes on the site, you need to make a request for re-indexing, the instruction is here https://support.google.com/webmasters/answer/6065812/?hl=ru, the indexing tool itself is https://search.google.com/search-console/welcome, http://joxi.ru/gmv4VBOtqnyN5A. Because of the difference in time zones, I don’t know when the next PR will be accepted for merging, so I didn’t request indexing myself, this requires making changes to the site without leaving the search-console page.