### PR TITLE
Add documentation for `dvc version` command

### DIFF
--- a/src/Documentation/Markdown/lang/dvc.js
+++ b/src/Documentation/Markdown/lang/dvc.js
@@ -48,7 +48,8 @@ let _javascript = function(hljs) {
               built_in:
                 'help dvc init add import checkout run pull push fetch status ' +
                 'repro remove move gc config remote metrics install root lock ' +
-                'unlock pipeline destroy unprotect commit cache pkg tag diff',
+                'unlock pipeline destroy unprotect commit cache pkg tag diff ' +
+                'version',
             },
             className: 'strong',
           },

--- a/src/Documentation/Markdown/lang/usage.js
+++ b/src/Documentation/Markdown/lang/usage.js
@@ -36,7 +36,7 @@ var _javascript = function(hljs) {
               built_in:
               'help dvc init add import checkout run pull push fetch status repro ' +
               'remove move gc config remote metrics install root lock unlock ' +
-              'pipeline destroy unprotect commit cache diff tag pkg',
+              'pipeline destroy unprotect commit cache diff tag pkg version',
             },
             className: 'strong',
           }

--- a/src/Documentation/sidebar.json
+++ b/src/Documentation/sidebar.json
@@ -123,8 +123,8 @@
       "run.md",
       "status.md",
       "unlock.md",
-	    "unprotect.md",
-	    "version.md"
+      "unprotect.md",
+      "version.md"
     ],
     "labels": {
       "run.md": "run",

--- a/src/Documentation/sidebar.json
+++ b/src/Documentation/sidebar.json
@@ -123,7 +123,8 @@
       "run.md",
       "status.md",
       "unlock.md",
-      "unprotect.md"
+	  "unprotect.md",
+	  "version.md"
     ],
     "labels": {
       "run.md": "run",
@@ -162,7 +163,8 @@
       "unprotect.md": "unprotect",
       "cache.md": "cache",
       "cache:dir.md": "cache dir",
-      "commit.md": "commit"
+	  "commit.md": "commit",
+	  "version.md": "version"
     }
   },
   {

--- a/src/Documentation/sidebar.json
+++ b/src/Documentation/sidebar.json
@@ -123,8 +123,8 @@
       "run.md",
       "status.md",
       "unlock.md",
-	  "unprotect.md",
-	  "version.md"
+	    "unprotect.md",
+	    "version.md"
     ],
     "labels": {
       "run.md": "run",
@@ -163,8 +163,8 @@
       "unprotect.md": "unprotect",
       "cache.md": "cache",
       "cache:dir.md": "cache dir",
-	  "commit.md": "commit",
-	  "version.md": "version"
+      "commit.md": "commit",
+      "version.md": "version"
     }
   },
   {

--- a/static/docs/commands-reference/version.md
+++ b/static/docs/commands-reference/version.md
@@ -1,6 +1,6 @@
 # version
 
-This command shows the system/environment information along with the DVC version
+This command shows the system/environment information along with the DVC version.
 
 ## Synopsis
 
@@ -19,17 +19,18 @@ This command shows the system/environment information along with the DVC version
 
 ## Details
 
-Running the command [`dvc version`](/doc/commands-reference/version) outputs the following information about the system/environment:
+Running the command [`dvc version`](/doc/commands-reference/version) outputs the
+following information about the system/environment:
 
 Type | Detail
 ---- | ------
-`DVC version` | Version of the data version control along with information about the git repository
-`Python version` | Version of the python being used for the project in which dvc is iniitialized
+`DVC version` | Version of DVC along with information about the project's Git repository
+`Python version` | Version of the Python being used for the project in which DVC is iniitialized
 `Platform` | Information about the operating system of the machine
 
 ## Examples
 
-* Running the command:
+* Getting the DVC version and environment information:
 
 ```dvc
     $ dvc version

--- a/static/docs/commands-reference/version.md
+++ b/static/docs/commands-reference/version.md
@@ -8,6 +8,17 @@ This command shows the system/environment information along with the DVC version
     usage: dvc version [-h] [-q | -v]
 ```
 
+## Description
+
+Running the command `dvc version` outputs the
+following information about the system/environment:
+
+Type | Detail
+---- | ------
+`DVC version` | Version of DVC along with information about the project's Git repository
+`Python version` | Version of the Python being used for the project in which DVC is initialized
+`Platform` | Information about the operating system of the machine
+
 ## Options
 
 * `-h`, `--help` - prints the usage/help message, and exit.
@@ -17,20 +28,9 @@ This command shows the system/environment information along with the DVC version
 
 * `-v`, `--verbose` - displays detailed tracing information.
 
-## Details
+## Example
 
-Running the command [`dvc version`](/doc/commands-reference/version) outputs the
-following information about the system/environment:
-
-Type | Detail
----- | ------
-`DVC version` | Version of DVC along with information about the project's Git repository
-`Python version` | Version of the Python being used for the project in which DVC is iniitialized
-`Platform` | Information about the operating system of the machine
-
-## Examples
-
-* Getting the DVC version and environment information:
+Getting the DVC version and environment information:
 
 ```dvc
     $ dvc version

--- a/static/docs/commands-reference/version.md
+++ b/static/docs/commands-reference/version.md
@@ -1,6 +1,7 @@
 # version
 
-This command shows the system/environment information along with the DVC version.
+This command shows the system/environment information along with the DVC
+version.
 
 ## Synopsis
 
@@ -10,8 +11,8 @@ This command shows the system/environment information along with the DVC version
 
 ## Description
 
-Running the command `dvc version` outputs the
-following information about the system/environment:
+Running the command `dvc version` outputs the following information about the
+system/environment:
 
 Type | Detail
 ---- | ------
@@ -34,7 +35,7 @@ Getting the DVC version and environment information:
 
 ```dvc
     $ dvc version
-    
+
     DVC version: 0.40.0+45f94e
     Python version: 3.6.7
     Platform: Linux-4.15.0-47-generic-x86_64-with-Ubuntu-18.04-bionic

--- a/static/docs/commands-reference/version.md
+++ b/static/docs/commands-reference/version.md
@@ -1,0 +1,40 @@
+# version
+
+This command shows the system/environment information along with the DVC version
+
+## Synopsis
+
+```usage
+    usage: dvc version [-h] [-q | -v]
+```
+
+## Options
+
+* `-h`, `--help` - prints the usage/help message, and exit.
+
+* `-q`, `--quiet` - does not write anything to standard output. Exit with 0 if
+  no problems arise, otherwise 1.
+
+* `-v`, `--verbose` - displays detailed tracing information.
+
+## Details
+
+Running the command [`dvc version`](/doc/commands-reference/version) outputs the following information about the system/environment:
+
+Type | Detail
+---- | ------
+`DVC version` | Version of the data version control along with information about the git repository
+`Python version` | Version of the python being used for the project in which dvc is iniitialized
+`Platform` | Information about the operating system of the machine
+
+## Examples
+
+* Running the command:
+
+```dvc
+    $ dvc version
+    
+    DVC version: 0.40.0+45f94e
+    Python version: 3.6.7
+    Platform: Linux-4.15.0-47-generic-x86_64-with-Ubuntu-18.04-bionic
+```


### PR DESCRIPTION
Fixes #307 
These changes add the documentation for the command `dvc version` which was added in [iterative/dvc#1963](https://github.com/iterative/dvc/pull/1963).

I had one doubt though.
![Screenshot from 2019-05-11 03-21-58](https://user-images.githubusercontent.com/35191225/57558756-985f8500-739c-11e9-9f21-712eafc6b4e8.png)
This is how the usage appears. The name of the command here is black in color but for rest of the command it is blue in color. Why is that so?
![Screenshot from 2019-05-11 03-27-34](https://user-images.githubusercontent.com/35191225/57558780-bf1dbb80-739c-11e9-8f08-d5c13cc193ff.png)
