### PR TITLE
Add pre-commit hook instructions to contribution documentation guide

### DIFF
--- a/static/docs/user-guide/contributing-documentation.md
+++ b/static/docs/user-guide/contributing-documentation.md
@@ -42,9 +42,11 @@ follow the steps below:
 - Get the latest development version by
   [forking](https://help.github.com/en/articles/fork-a-repo) and cloning the
   repo from GitHub:
+
   ```dvc
   $ git clone git@github.com:<username>/dvc.org.git
   ```
+
 - Make sure you have the latest version of [Node.js](https://nodejs.org/en/)
   installed.
 - Install the dependencies by running the command `npm install`.
@@ -55,11 +57,13 @@ follow the steps below:
   environment](https://virtualenv.pypa.io/en/latest/userguide/) before
   installing the required libraries for style checkers. Follow the instructions
   to create one:
+
   ```dvc
   $ cd dvc.org
   $ virtualenv --python python3 .env
   $ source .env/bin/activate
   ```
+
 - Install the style checker's requirements using `pip install -r requirements.txt`.
 - Install coding style pre-commit hook with `pre-commit install`.
 - Start the development server using `npm run dev` which will start the server

--- a/static/docs/user-guide/contributing-documentation.md
+++ b/static/docs/user-guide/contributing-documentation.md
@@ -48,6 +48,20 @@ follow the steps below:
 - Make sure you have the latest version of [Node.js](https://nodejs.org/en/)
   installed.
 - Install the dependencies by running the command `npm install`.
+- Make sure you have python 3.6 or higher installed. It will be required to run
+  style checkers on pre-commit. On Mac OS, use `brew` to install the lastest
+  version of python.
+- We **strongly** recommend initializing a [virtual
+  environment](https://virtualenv.pypa.io/en/latest/userguide/) before
+  installing the required libraries for style checkers. Follow the instructions
+  to create one:
+  ```dvc
+    $ cd dvc.org
+    $ virtualenv --python python3 .env
+    $ source .env/bin/activate
+  ```
+- Install the style checker's requirements using `pip install -r requirements.txt`.
+- Install coding style pre-commit hook with `pre-commit install`.
 - Start the development server using `npm run dev` which will start the server
   on the default port `3000`.
 - Visit `http://localhost:3000/` and navigate to the docs in question.

--- a/static/docs/user-guide/contributing-documentation.md
+++ b/static/docs/user-guide/contributing-documentation.md
@@ -43,7 +43,7 @@ follow the steps below:
   [forking](https://help.github.com/en/articles/fork-a-repo) and cloning the
   repo from GitHub:
   ```dvc
-      $ git clone git@github.com:<username>/dvc.org.git
+  $ git clone git@github.com:<username>/dvc.org.git
   ```
 - Make sure you have the latest version of [Node.js](https://nodejs.org/en/)
   installed.
@@ -56,9 +56,9 @@ follow the steps below:
   installing the required libraries for style checkers. Follow the instructions
   to create one:
   ```dvc
-    $ cd dvc.org
-    $ virtualenv --python python3 .env
-    $ source .env/bin/activate
+  $ cd dvc.org
+  $ virtualenv --python python3 .env
+  $ source .env/bin/activate
   ```
 - Install the style checker's requirements using `pip install -r requirements.txt`.
 - Install coding style pre-commit hook with `pre-commit install`.
@@ -111,17 +111,17 @@ We will review your PR as soon as possible. Thank you for contributing!
 Format:
 
 ```
-    (short description)
+(short description)
 
-    (long description)
+(long description)
 
-    Fixes #(github issue id).
+Fixes #(github issue id).
 ```
 
 Example:
 
 ```
-    Add documentation for `dvc version` command
+Add documentation for `dvc version` command
 
-    Fixes #123
+Fixes #123
 ```

--- a/static/docs/user-guide/contributing-documentation.md
+++ b/static/docs/user-guide/contributing-documentation.md
@@ -53,8 +53,8 @@ follow the steps below:
 - Make sure you have python 3.6 or higher installed. It will be required to run
   style checkers on pre-commit. On Mac OS, use `brew` to install the lastest
   version of python.
-- We **strongly** recommend initializing a [virtual
-  environment](https://virtualenv.pypa.io/en/latest/userguide/) before
+- We **strongly** recommend initializing a
+  [virtual environment](https://virtualenv.pypa.io/en/latest/userguide/) before
   installing the required libraries for style checkers. Follow the instructions
   to create one:
 
@@ -64,8 +64,11 @@ follow the steps below:
   $ source .env/bin/activate
   ```
 
-- Install the style checker's requirements using `pip install -r requirements.txt`.
+- Install the style checker's requirements using
+  `pip install -r requirements.txt`.
 - Install coding style pre-commit hook with `pre-commit install`.
+- Once the `pre-commit` hook is installed, you may deactivate the virtual
+  environment by running `deactivate`.
 - Start the development server using `npm run dev` which will start the server
   on the default port `3000`.
 - Visit `http://localhost:3000/` and navigate to the docs in question.
@@ -83,7 +86,6 @@ Otherwise, please refer to the following procedure:
 - Setup the [development environment](#development-environment) explained above.
 - Format the code by following the
   [code style guidelines](#code-style-guidelines) below.
-- Auto-format any JS code changes by running `npm run prettier-src`.
 - Commit and push the changes to your fork of
   [dvc.org](https://github.com/iterative/dvc.org.git).
 - Please follow the [commit style guidelines](#commit-style-guidelines)


### PR DESCRIPTION
Add instructions to setup pre-commit hook as added in [this](https://github.com/iterative/dvc.org/pull/324) pull request.