### PR TITLE
Add configuration for husky pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,0 @@
-repos:
-  - repo: https://github.com/prettier/prettier
-    rev: 1.17.0
-    hooks:
-      - id: prettier
-        args: ['trailing-comma=true', 'tab-width=2', '--prose-wrap=always']

--- a/package.json
+++ b/package.json
@@ -59,6 +59,13 @@
   "devDependencies": {
     "babel-plugin-styled-components": "^1.5.1",
     "babel-plugin-transform-object-assign": "^6.22.0",
-    "prettier": "~1.17.0"
+    "husky": "^2.3.0",
+    "prettier": "~1.17.0",
+    "pretty-quick": "^1.11.0"
+  },
+  "husky": {
+    "hooks": {
+      "pre-commit": "pretty-quick --staged --bail"
+    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "babel-plugin-styled-components": "^1.5.1",
     "babel-plugin-transform-object-assign": "^6.22.0",
     "husky": "^2.3.0",
-    "prettier": "~1.17.0",
+    "prettier": "^1.17.0",
     "pretty-quick": "^1.11.0"
   },
   "husky": {

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,0 @@
-pre-commit
-

--- a/static/docs/user-guide/contributing-documentation.md
+++ b/static/docs/user-guide/contributing-documentation.md
@@ -61,8 +61,9 @@ $ git clone git@github.com:<username>/dvc.org.git
 
 It's highly recommended to run the Node.js docs app locally to test significant
 changes to the docs before submitting them, and its very much needed in order to
-make changes to the docs JavaScript engine itself (rare). To do so, please
-follow the steps below:
+make changes to the docs JavaScript engine itself (rare). These changes need to
+be properly formatted as well. This is also ensured in the following steps for
+setting up.
 
 - Make sure you have the latest version of [Node.js](https://nodejs.org/en/)
   installed. Install and keep the dependencies up to date by running
@@ -81,12 +82,12 @@ follow the steps below:
   width. We recommend using Visual Studio Code and the
   [Rewrap](https://marketplace.visualstudio.com/items?itemName=stkb.rewrap)
   plugin to format the content of Markdown files or it will be done by a
-  pre-commit hook integrated.
+  pre-commit hook which was automatically integrated when we ran `npm install`.
 
 - **Markdown and JS files:** we use `prettier` default conventions to format our
   files. The formatting of staged files will be automatically done by the
-  pre-commit we have configured or run `prettier` manually before submitting the
-  pull request.
+  pre-commit hook we have configured or run `prettier` manually before
+  submitting the pull request.
 
 - Using `dvc <command>` in the documentation will create a link to that command
   automatically. No need to use `[]()` explicitly to create them.

--- a/static/docs/user-guide/contributing-documentation.md
+++ b/static/docs/user-guide/contributing-documentation.md
@@ -51,9 +51,6 @@ We will review your PR as soon as possible. Thank you for contributing!
 
 ## Development environment
 
-It's highly recommended to install the pre-commit hook that prettifies the files
-for you automatically before you push them:
-
 - Get the latest development version by
   [forking](https://help.github.com/en/articles/fork-a-repo) and cloning the
   repository from GitHub:
@@ -61,28 +58,6 @@ for you automatically before you push them:
 ```dvc
 $ git clone git@github.com:<username>/dvc.org.git
 ```
-
-- Make sure you have Python 3.6 or higher installed. It will be required to run
-  style checkers on pre-commit. On Mac OS, use `brew` to install the latest
-  version of Python.
-
-- We **strongly** recommend initializing a
-  [virtual environment](https://virtualenv.pypa.io/en/latest/userguide/) before
-  installing the required libraries for style checkers. Follow the instructions
-  to create one:
-
-```dvc
-$ cd dvc.org
-$ virtualenv --python python3 .env
-$ source .env/bin/activate
-```
-
-- Install the style checker's requirements using
-  `pip install -r requirements.txt`.
-
-- Install coding style pre-commit hook with `pre-commit install`.
-- Once the `pre-commit` hook is installed, you may deactivate the virtual
-  environment by running `deactivate`.
 
 It's highly recommended to run the Node.js docs app locally to test significant
 changes to the docs before submitting them, and its very much needed in order to
@@ -105,12 +80,13 @@ follow the steps below:
 - **Markdown and JS files:** content must be properly formatted at 80 symbols
   width. We recommend using Visual Studio Code and the
   [Rewrap](https://marketplace.visualstudio.com/items?itemName=stkb.rewrap)
-  plugin to format the content of Markdown files or install the pre-commit hook
-  described above.
+  plugin to format the content of Markdown files or it will be done by a
+  pre-commit hook integrated.
 
 - **Markdown and JS files:** we use `prettier` default conventions to format our
-  files. It's highly recommended to install the hook or run `prettier` manually
-  before submitting the pull request.
+  files. The formatting of staged files will be automatically done by the
+  pre-commit we have configured or run `prettier` manually before submitting the
+  pull request.
 
 - Using `dvc <command>` in the documentation will create a link to that command
   automatically. No need to use `[]()` explicitly to create them.

--- a/static/docs/user-guide/contributing-documentation.md
+++ b/static/docs/user-guide/contributing-documentation.md
@@ -81,13 +81,13 @@ setting up.
 - **Markdown and JS files:** content must be properly formatted at 80 symbols
   width. We recommend using Visual Studio Code and the
   [Rewrap](https://marketplace.visualstudio.com/items?itemName=stkb.rewrap)
-  plugin to format the content of Markdown files or it will be done by a
-  pre-commit hook which was automatically integrated when we ran `npm install`.
+  plugin. Correct formatting will be done automatically by a Git pre-commit hook
+  which is integrated when `npm install` runs in the instructions above.
 
 - **Markdown and JS files:** we use `prettier` default conventions to format our
-  files. The formatting of staged files will be automatically done by the
-  pre-commit hook we have configured or run `prettier` manually before
-  submitting the pull request.
+  files. The formatting of staged files will automatically be done by the Git
+  pre-commit hook we have configured. You may also run
+  `npx prettier --write <file path(s)>` manually before committing changes.
 
 - Using `dvc <command>` in the documentation will create a link to that command
   automatically. No need to use `[]()` explicitly to create them.


### PR DESCRIPTION
Husky and pretty quick is used as a pre-commit hook.
- `--staged` flag ensures that `pretty-quick` runs `prettier` only on staged files.
- `--bail` flag ensures that committing is prevented even if the files are fixed.

Fixes #372 