### PR TITLE
Add-file - adjusting help title to get the data.xml file from a browser

### DIFF
--- a/static/docs/get-started/add-files.md
+++ b/static/docs/get-started/add-files.md
@@ -6,13 +6,13 @@ Let's get a sample data set to play with:
 
 <details>
 
-### Expand if you're having problems downloading from command line
+### Expand if you're on Windows or having problems downloading from command line
 
-If you experienced problems using `wget` or you're on Windows
-and you don't want to install it, you'll need to use a browser to download
-`data.xml` and save it into `data` subdirectory. To download, right-click
-[this link](https://dvc.org/s3/get-started/data.xml) and click
-`Save link as`(Chrome) or `Save object as`(Firefox).
+If you experienced problems using `wget` or you're on Windows and you don't want
+to install it, you'll need to use a browser to download `data.xml` and save it
+into `data` subdirectory. To download, right-click
+[this link](https://dvc.org/s3/get-started/data.xml) and click `Save link as`
+(Chrome) or `Save object as` (Firefox).
 
 </details>
 

--- a/static/docs/get-started/add-files.md
+++ b/static/docs/get-started/add-files.md
@@ -6,11 +6,12 @@ Let's get a sample data set to play with:
 
 <details>
 
-### Expand to learn how to download on Windows
+### Expand if you're having problems downloading from command line
 
-Windows does not ship `wget` utility by default, so you'll need to use a browser
-to download `data.xml` and save it into `data` subdirectory. To download,
-right-click [this link](https://dvc.org/s3/get-started/data.xml) and click
+If you experienced problems using `wget` or you're on Windows
+and you don't want to install it, you'll need to use a browser to download
+`data.xml` and save it into `data` subdirectory. To download, right-click
+[this link](https://dvc.org/s3/get-started/data.xml) and click
 `Save link as`(Chrome) or `Save object as`(Firefox).
 
 </details>


### PR DESCRIPTION
According to a [conversation](https://discordapp.com/channels/485586884165107732/485596304961962003/583712131619487744) I had with Ruslan on Discord, we agreed to change the title and description of this collapsed help text to make it more visible for people on Windows who are already using Terminals like `Cmder`, `WSL` or even the new `Windows Terminal` but are still facing issues using wget.

The issue seems to be related to SSL certificates.

- https://github.com/ContinuumIO/anaconda-issues/issues/10709

But I don't think that fixing this certificate issue is on the scope of this repo, so it makes more sense to generalize the docs.