### PR TITLE
connect-code-and-data - Adding link reference to virtualenv

### DIFF
--- a/static/docs/get-started/connect-code-and-data.md
+++ b/static/docs/get-started/connect-code-and-data.md
@@ -40,8 +40,9 @@ $ tree
     └── train.py
 ```
 
-We **strongly** recommend using [`virtualenv`](https://virtualenv.pypa.io/en/stable/) or a similar tool to isolate your
-environment:
+We **strongly** recommend using
+[`virtualenv`](https://virtualenv.pypa.io/en/stable/) or a similar tool to
+isolate your environment:
 
 ```dvc
 $ virtualenv .env

--- a/static/docs/get-started/connect-code-and-data.md
+++ b/static/docs/get-started/connect-code-and-data.md
@@ -40,7 +40,7 @@ $ tree
     └── train.py
 ```
 
-We **strongly** recommend using `virtualenv` or a similar tool to isolate your
+We **strongly** recommend using [`virtualenv`](https://virtualenv.pypa.io/en/stable/) or a similar tool to isolate your
 environment:
 
 ```dvc


### PR DESCRIPTION
As I'm not a Python expert but I'm digging into the Data/ML space, I spent a few minutes trying to understand what was `virtualenv` and how could I get it. 

Of course, doing a quick search on the internet solved my problem, but why not adding a link reference directly to the docs to accelerate people like that are going through the tutorials? :) 