### PR TITLE
Fix configuration in ci tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,12 +26,9 @@ jobs:
             # fallback to using the latest cache if no exact match is found
             - v1-dependencies-
 
-      - run: yarn install
+      - run: npm install
 
       - save_cache:
           paths:
             - node_modules
           key: v1-dependencies-{{ checksum "package.json" }}
-
-      # run tests!
-      - run: yarn test


### PR DESCRIPTION
- There is no `yarn.lock` file since we don't use yarn so `yarn install` will fail. `npm install` will work.
- Since there are no tests, `npm run test`/`yarn test` would fail.