### PR TITLE
link to dvc version

### DIFF
--- a/static/docs/user-guide/development.md
+++ b/static/docs/user-guide/development.md
@@ -6,7 +6,8 @@ following.
 > **Note**! `gitpython` should be installed first to allow `setup.py` to
 > dynamically generate dvc version from the current git commit SHA. It allows us
 > to distinguish official dvc release (e.g. `0.24.3`) from a development version
-> (e.g. `0.24.3-9c7381`).
+> (e.g. `0.24.3-9c7381`). For more information on naming convention, refer to
+> [dvc version](/doc/commands-reference/version).
 
 ```dvc
 $ pip install gitpython


### PR DESCRIPTION
For naming convention, a link is added to `dvc version` command.