### PR TITLE
Fix#146:add issues and PR template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,5 @@
+---
+name: Bug report
+about: Create a report to help us improve
+
+---

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,5 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+
+---

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,11 @@
+IMPORTANT NOTES (please read, then delete):
+
+* Have you followed the guidelines in our [Contributing Documentation](https://dvc.org/doc/user-guide/contributing-documentation)?
+
+* The PR title should start with "Fix #bugnum: " (if applicable), followed by a
+ clear one-line present-tense summary of the changes introduced in the PR. For
+ example: "Fix #bugnum: Introduce the first version of the collection editor.".
+
+* Please make sure to mention "#bugnum" somewhere in the description of the PR.
+ This enables Github to link the PR to the corresponding bug.
+

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,11 +1,11 @@
 IMPORTANT NOTES (please read, then delete):
 
-* Have you followed the guidelines in our [Contributing Documentation](https://dvc.org/doc/user-guide/contributing-documentation)?
+- Have you followed the guidelines in our [Contributing Documentation](https://dvc.org/doc/user-guide/contributing-documentation)?
 
-* The PR title should start with "Fix #bugnum: " (if applicable), followed by a
+- The PR title should start with "Fix #bugnum: " (if applicable), followed by a
  clear one-line present-tense summary of the changes introduced in the PR. For
  example: "Fix #bugnum: Introduce the first version of the collection editor.".
 
-* Please make sure to mention "#bugnum" somewhere in the description of the PR.
+- Please make sure to mention "#bugnum" somewhere in the description of the PR.
  This enables Github to link the PR to the corresponding bug.
 


### PR DESCRIPTION
Fix #146 

@shcheklein you must need to activate ISSUE Templates in the repository as mentioned [here](https://help.github.com/en/articles/about-issue-and-pull-request-templates)

Do check this also: https://help.github.com/en/articles/creating-issue-templates-for-your-repository