### PR TITLE
Prevent restaging after pre commit formatting

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
   },
   "husky": {
     "hooks": {
-      "pre-commit": "pretty-quick --staged --bail"
+      "pre-commit": "pretty-quick --staged --no-restage --bail"
     }
   }
 }


### PR DESCRIPTION
Add [`--no-restage`](https://github.com/azz/pretty-quick#--no-restage-only-git) flag to prevent restaging.

Fixes #372 

