### PR TITLE
Reorder command options (flags) in the command reference guide

### DIFF
--- a/static/docs/commands-reference/checkout.md
+++ b/static/docs/commands-reference/checkout.md
@@ -79,13 +79,13 @@ command. In other cases the cache can be pulled from a remote cache using the
   are associated with the named stage, and the stages which execute earlier in
   the pipeline.
 
+- `-R`, `--recursive` - performs recursive checkout for target directory.
+
 - `-f`, `--force` - does not prompt when removing workspace files. Changing the
   current set of DVC files with SCM commands like `git checkout` can result in
   the need for DVC to remove files which should not exist in the current state
   and are missing in the local cache (they are not committed in DVC terms). This
   option controls whether the user will be asked to confirm these files removal.
-
-- `-R`, `--recursive` - performs recursive checkout for target directory.
 
 - `-h`, `--help` - shows the help message and exit.
 

--- a/static/docs/commands-reference/pull.md
+++ b/static/docs/commands-reference/pull.md
@@ -79,16 +79,16 @@ reflinks or hardlinks to put it in the workspace without copying. See
   considered are associated with the named stage, and the stages which execute
   earlier in the pipeline.
 
-- `-f`, `--force` - does not prompt when removing working directory files, which
-  occurs during the process of updating the workspace. This option surfaces
-  behavior from the `dvc checkout` command because `dvc pull` in effect performs
-  a _checkout_ after downloading files.
-
 - `-R`, `--recursive` - `targets` values is expected to be a directory path.
   Determines the files to download by searching the named directory and its
   subdirectories for DVC files to download data for. Along with providing a
   `target`, or `target` along with `--with-deps` it is yet another way to cut
   the scope of DVC files to download.
+
+- `-f`, `--force` - does not prompt when removing working directory files, which
+  occurs during the process of updating the workspace. This option surfaces
+  behavior from the `dvc checkout` command because `dvc pull` in effect performs
+  a _checkout_ after downloading files.
 
 - `-j JOBS`, `--jobs JOBS` - specifies number of jobs to run simultaneously
   while downloading files from the remote cache. The effect is to control the


### PR DESCRIPTION
This PR reorders command flags to make similar flags `-d` and `-R` together. 