### PR TITLE
Creating a bucket is necessary before adding it to remote storage

### DIFF
--- a/static/docs/commands-reference/config.md
+++ b/static/docs/commands-reference/config.md
@@ -181,9 +181,10 @@ $ dvc config core.loglevel debug
 
 Add an S3 remote and set it as the project default:
 
-Before,adding a new remote be sure to login into AWS services and follow
-instructions at [Create a Bucket](https://docs.aws.amazon.com/AmazonS3/latest/gsg/CreatingABucket.html)
-to create your bucket. 
+> **Note!** Before,adding a new remote be sure to login into AWS services and
+> follow instructions at
+> [Create a Bucket](https://docs.aws.amazon.com/AmazonS3/latest/gsg/CreatingABucket.html)
+> to create your bucket.
 
 ```dvc
 $ dvc remote add myremote s3://bucket/path

--- a/static/docs/commands-reference/config.md
+++ b/static/docs/commands-reference/config.md
@@ -181,7 +181,7 @@ $ dvc config core.loglevel debug
 
 Add an S3 remote and set it as the project default:
 
-> **Note!** Before,adding a new remote be sure to login into AWS services and
+> **Note!** Before adding a new remote be sure to login into AWS services and
 > follow instructions at
 > [Create a Bucket](https://docs.aws.amazon.com/AmazonS3/latest/gsg/CreatingABucket.html)
 > to create your bucket.

--- a/static/docs/commands-reference/config.md
+++ b/static/docs/commands-reference/config.md
@@ -181,6 +181,10 @@ $ dvc config core.loglevel debug
 
 Add an S3 remote and set it as the project default:
 
+Before,adding a new remote be sure to login into AWS services and follow
+instructions at [Create a Bucket](https://docs.aws.amazon.com/AmazonS3/latest/gsg/CreatingABucket.html)
+to create your bucket. 
+
 ```dvc
 $ dvc remote add myremote s3://bucket/path
 $ dvc config core.remote myremote

--- a/static/docs/commands-reference/remote.md
+++ b/static/docs/commands-reference/remote.md
@@ -96,9 +96,10 @@ remote = myremote
 
 2. Add AWS S3 remote and modify its region:
 
-Before,adding a new remote be sure to login into AWS services and follow
-instructions at [Create a Bucket](https://docs.aws.amazon.com/AmazonS3/latest/gsg/CreatingABucket.html)
-to create your bucket. 
+> **Note!** Before,adding a new remote be sure to login into AWS services and
+> follow instructions at
+> [Create a Bucket](https://docs.aws.amazon.com/AmazonS3/latest/gsg/CreatingABucket.html)
+> to create your bucket.
 
 ```dvc
 $ dvc remote add mynewremote s3://mybucket/myproject

--- a/static/docs/commands-reference/remote.md
+++ b/static/docs/commands-reference/remote.md
@@ -96,7 +96,7 @@ remote = myremote
 
 2. Add AWS S3 remote and modify its region:
 
-> **Note!** Before,adding a new remote be sure to login into AWS services and
+> **Note!** Before adding a new remote be sure to login into AWS services and
 > follow instructions at
 > [Create a Bucket](https://docs.aws.amazon.com/AmazonS3/latest/gsg/CreatingABucket.html)
 > to create your bucket.

--- a/static/docs/commands-reference/remote.md
+++ b/static/docs/commands-reference/remote.md
@@ -96,6 +96,10 @@ remote = myremote
 
 2. Add AWS S3 remote and modify its region:
 
+Before,adding a new remote be sure to login into AWS services and follow
+instructions at [Create a Bucket](https://docs.aws.amazon.com/AmazonS3/latest/gsg/CreatingABucket.html)
+to create your bucket. 
+
 ```dvc
 $ dvc remote add mynewremote s3://mybucket/myproject
 $ dvc remote modify mynewremote region us-east-2


### PR DESCRIPTION
Fix #415 
I just added the information to create a bucket with the links to it in commands-reference/config and commands-reference/remote .