### PR TITLE
Fix #469: Recommend --local for remote modify connection_string

### DIFF
--- a/static/docs/commands-reference/remote_modify.md
+++ b/static/docs/commands-reference/remote_modify.md
@@ -158,12 +158,9 @@ $ dvc remote modify myremote url "azure://ContainerName=remote;"
 - `connection_string` - connection string.
 
 ```dvc
-$ dvc remote modify myremote connection_string my-connection-string
-```
-Note: The connection string is inserted into the .dvc/config file and exposed to Git. Therefore, it is safer to add the connection string with the `--local` option, enforcing it to be written to an unstaged config file.
-```dvc
 $ dvc remote modify myremote connection_string my-connection-string --local
 ```
+Note: The connection string contains access to data and is inserted into the .dvc/config file. Therefore, it is safer to add the connection string with the `--local` option, enforcing it to be written to a Git-ignored config file.
 
 </details>
 

--- a/static/docs/commands-reference/remote_modify.md
+++ b/static/docs/commands-reference/remote_modify.md
@@ -160,7 +160,9 @@ $ dvc remote modify myremote url "azure://ContainerName=remote;"
 ```dvc
 $ dvc remote modify myremote connection_string my-connection-string --local
 ```
-Note: The connection string contains access to data and is inserted into the .dvc/config file. Therefore, it is safer to add the connection string with the `--local` option, enforcing it to be written to a Git-ignored config file.
+> The connection string contains access to data and is inserted into the
+> `.dvc/config file.` Therefore, it is safer to add the connection string with
+> the `--local` option, enforcing it to be written to a Git-ignored config file.
 
 </details>
 

--- a/static/docs/commands-reference/remote_modify.md
+++ b/static/docs/commands-reference/remote_modify.md
@@ -160,6 +160,10 @@ $ dvc remote modify myremote url "azure://ContainerName=remote;"
 ```dvc
 $ dvc remote modify myremote connection_string my-connection-string
 ```
+Note: The connection string is inserted into the .dvc/config file and exposed to Git. Therefore, it is safer to add the connection string with the `--local` option, enforcing it to be written to an unstaged config file.
+```dvc
+$ dvc remote modify myremote connection_string my-connection-string --local
+```
 
 </details>
 


### PR DESCRIPTION
Fix #469 Recommend --local for remote modify connection_string

- Modified code example to include `--local` for recommended behaviour
- Added a note explaining why `--local` is safer to use