### PR TITLE
hotfix: wrong links in get-started/example-pipeline

### DIFF
--- a/static/docs/get-started/agenda.md
+++ b/static/docs/get-started/agenda.md
@@ -13,8 +13,8 @@ $ git clone https://github.com/iterative/example-get-started
 Otherwise, bear with us and we will introduce the basic DVC concepts and get to
 the same result together!
 
-The idea of this project is a simplified version of the
-[tutorial](/doc/tutorial). It explores the NLP problem of predicting tags for a
+The idea of the project is a simplified version of the
+[Tutorial](/doc/tutorial). It explores the NLP problem of predicting tags for a
 given StackOverflow question. For example, we want one classifier which can
 predict a post that is about the Python language by tagging it `python`.
 

--- a/static/docs/get-started/example-pipeline.md
+++ b/static/docs/get-started/example-pipeline.md
@@ -31,7 +31,7 @@ nothing to do with DVC so far, it's just a simple preparation:
 ### Expand to learn how to download on Windows
 
 Windows doesn't ship `wget` utility by default, so you'll need to use just use
-your browser to download `code.zip`.
+your browser to download `pipeline.zip`.
 
 </details>
 
@@ -39,8 +39,8 @@ your browser to download `code.zip`.
 $ mkdir example && cd example
 $ git init
 $ wget https://code.dvc.org/tutorial/nlp/pipeline.zip
-$ unzip code.zip
-$ rm -f code.zip
+$ unzip pipeline.zip
+$ rm -f pipeline.zip
 $ git add code/
 $ git commit -m "download and initialize code"
 ```


### PR DESCRIPTION
After checking #561