### PR TITLE
Fixes #559: Child order in prev/next

### DIFF
--- a/src/Documentation/SidebarMenu/helper.js
+++ b/src/Documentation/SidebarMenu/helper.js
@@ -118,15 +118,17 @@ function normalizeSidebar({
       prevRef.next = normalizedItem.path
     }
 
-    prevRef = normalizedItem // Set it before children to preserve order
-
     if (item.children) {
       normalizedItem.children = normalizeSidebar({
         data: item.children,
         parentPath: `${parentPath}${item.slug}/`,
         parentResultRef: resultRef,
-        startingPrevRef: prevRef
+        startingPrevRef: normalizedItem
       })
+
+      prevRef = normalizedItem.children[normalizedItem.children.length - 1]
+    } else {
+      prevRef = normalizedItem
     }
 
     currentResult.push(normalizedItem)


### PR DESCRIPTION
If item has children – last child should be next prevRef value.