### PR TITLE
Fix broken link "show" and "list"

### DIFF
--- a/static/docs/commands-reference/pipeline/index.md
+++ b/static/docs/commands-reference/pipeline/index.md
@@ -1,8 +1,8 @@
 # pipeline
 
 A set of commands to manage [pipelines](/doc/get-started/pipeline):
-[show](/doc/commands-reference/pipeline-show) and
-[list](/doc/commands-reference/pipeline-list).
+[show](/doc/commands-reference/pipeline/show) and
+[list](/doc/commands-reference/pipeline/list).
 
 ## Synopsis
 


### PR DESCRIPTION
"show" and "list" links are directing to a non existent page (404 not found error is returned). 
I fix the link with the appropriate url.
This is a minor change.