### PR TITLE
Fix #2327: add gss_auth option for ssh

### DIFF
--- a/static/docs/commands-reference/remote/modify.md
+++ b/static/docs/commands-reference/remote/modify.md
@@ -263,6 +263,13 @@ For more information on configuring Azure Storage connection strings, visit
   ```dvc
   $ dvc remote modify myremote ask_password true
   ```
+  
+- `gss_auth` - use Generic Security Services authentication if available on
+  host (for example, [with kerberos](https://en.wikipedia.org/wiki/Generic_Security_Services_Application_Program_Interface#Relationship_to_Kerberos)). 
+
+  ```dvc
+  $ dvc remote modify myremote gss_auth true
+  ```
 
 </details>
 


### PR DESCRIPTION
Fix [#2327](https://github.com/iterative/dvc/issues/2327).  Add documentation of the `gss_auth` option for ssh remotes.

I am having difficulty with...
> Content must be properly formatted at 80 symbols width

...since the Wikipedia link I included has a long uninterrupted portion.  Feel free to remove or change this link, however, I recommend keeping the mention of kerberos in this section (sense the majority of GSS authentication is through kerberos). 
