### PR TITLE
Explictly add prop-types and @babel/core to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "lodash.throttle": "^4.1.1",
     "next": "^7.0.3",
     "perfect-scrollbar": "^1.4.0",
+    "prop-types": "^15.7.2",
     "react": "^16.9.0",
     "react-collapse": "^4.0.3",
     "react-collapsible": "^2.6.0",
@@ -49,6 +50,7 @@
     "unist-util-visit": "latest"
   },
   "devDependencies": {
+    "@babel/core": "^7.5.5",
     "babel-jest": "^24.9.0",
     "babel-plugin-transform-define": "^1.3.1",
     "babel-plugin-transform-object-assign": "^6.22.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -29,7 +29,7 @@
     semver "^5.4.1"
     source-map "^0.5.0"
 
-"@babel/core@^7.1.0":
+"@babel/core@^7.1.0", "@babel/core@^7.5.5":
   version "7.5.5"
   resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.5.5.tgz#17b2686ef0d6bc58f963dddd68ab669755582c30"
   integrity sha512-i4qoSr2KTtce0DmkuuQBV4AuQgGPUcPXMr9L5MyYAtk06z068lQ10a4O009fe5OB/DfNV+h+qqT7ddNV8UnRjg==


### PR DESCRIPTION
They are already installed via submodules of other dependencies so there is no practical problems, but to prevent bugs in the future it is better to add them explicitly.