### PR TITLE
Trim newline characters in tooltip texts

### DIFF
--- a/src/Tooltip/index.js
+++ b/src/Tooltip/index.js
@@ -32,7 +32,7 @@ class Tooltip extends Component {
           glossaryItem.match.map(word => word.toLowerCase()),
           // In v4 text field in a React.Node,
           // so to get string we need to use it's children
-          this.props.text.props.children.toLowerCase()
+          this.props.text.props.children.replace(/\n/g, ' ').toLowerCase()
         )
       ) {
         this.setState({


### PR DESCRIPTION
Fixes #518 

To test these changes, please edit the `add.md` file as follows
![Screenshot from 2019-09-02 17-23-04](https://user-images.githubusercontent.com/35191225/64112961-8d46bf80-cda6-11e9-8c25-a25daacb43ce.png)
