### PR TITLE
fix: pipeline not showed as link in related tech

### DIFF
--- a/static/docs/understanding-dvc/related-technologies.md
+++ b/static/docs/understanding-dvc/related-technologies.md
@@ -13,7 +13,7 @@ process.
   should NOT be stored in a Git repository but still need to be tracked and
   versioned.
 
-2. **Workflow management tools** ([pipelines]](/doc/commands-reference/pipeline)
+2. **Workflow management tools** ([pipelines](/doc/commands-reference/pipeline)
    and dependency graphs
    ([DAG](https://en.wikipedia.org/wiki/Directed_acyclic_graph))): Airflow,
    Luigi, etc. The differences are:


### PR DESCRIPTION
Currently pipeline isn't rendered as a link..because a typo: an extra ]

- Have you followed the guidelines in our
  Yes, it's a small change
