### PR TITLE
Fix #609: Add github-style anchor links

### DIFF
--- a/src/Documentation/HeadInjector.js
+++ b/src/Documentation/HeadInjector.js
@@ -5,7 +5,7 @@ export const HeadInjector = ({ sectionName = 'Documentation' }) => (
     <link
       rel="stylesheet"
       type="text/css"
-      href="https://cdnjs.cloudflare.com/ajax/libs/github-markdown-css/2.10.0/github-markdown.min.css"
+      href="https://cdnjs.cloudflare.com/ajax/libs/github-markdown-css/3.0.1/github-markdown.min.css"
     />
     <link
       rel="stylesheet"

--- a/src/Documentation/Markdown/Markdown.js
+++ b/src/Documentation/Markdown/Markdown.js
@@ -41,7 +41,25 @@ const HeadingRenderer = ({ level, children }) => {
   const content = React.Children.toArray(children)
   const text = children.reduce(flatten, '')
   const slug = kebabCase(text)
-  return React.createElement('h' + level, { id: slug }, content)
+  const anchor =
+    level !== 1 ? (
+      <a class="anchor" aria-hidden="true" href={`#${slug}`}>
+        <svg
+          class="octicon octicon-link"
+          viewBox="0 0 16 16"
+          version="1.1"
+          width="16"
+          height="16"
+          aria-hidden="true"
+        >
+          <path
+            fill-rule="evenodd"
+            d="M4 9h1v1H4c-1.5 0-3-1.69-3-3.5S2.55 3 4 3h4c1.45 0 3 1.69 3 3.5 0 1.41-.91 2.72-2 3.25V8.59c.58-.45 1-1.27 1-2.09C10 5.22 8.98 4 8 4H4c-.98 0-2 1.22-2 2.5S3 9 4 9zm9-3h-1v1h1c1 0 2 1.22 2 2.5S13.98 12 13 12H9c-.98 0-2-1.22-2-2.5 0-.83.42-1.64 1-2.09V6.25c-1.09.53-2 1.84-2 3.25C6 11.31 7.55 13 9 13h4c1.45 0 3-1.69 3-3.5S14.5 6 13 6z"
+          ></path>
+        </svg>
+      </a>
+    ) : null
+  return React.createElement('h' + level, { id: slug }, anchor, content)
 }
 
 const HtmlRenderer = props => {


### PR DESCRIPTION
We already use github-markdown-css, which has all nescessary styles but to make it work I had to copy svg icon itself from github site.

Not sure about possible copyright issues with that (consideren that we already using buch of github css styles).