### PR TITLE
Fix #627: clarify which option is used by default for 'dvc config'

### DIFF
--- a/static/docs/commands-reference/config.md
+++ b/static/docs/commands-reference/config.md
@@ -21,7 +21,8 @@ takes a config option `name` (a section and a key, separated by a dot) and its
 
 This command reads and overwrites the DVC configuration file `.dvc/config`. If
 `--local` option is specified, `.dvc/config.local` is modified instead. If None
-of `--local`, `--global`, or `--system` is provided, `--local` is set by default.
+of `--local`, `--global`, or `--system` is provided, `--local` is set by
+default.
 
 If the config option `value` is not provided and `--unset` option is not used,
 this command returns the current value of the config option, if found in the

--- a/static/docs/commands-reference/config.md
+++ b/static/docs/commands-reference/config.md
@@ -20,7 +20,8 @@ takes a config option `name` (a section and a key, separated by a dot) and its
 `value` (any valid alpha-numeric string generally).
 
 This command reads and overwrites the DVC configuration file `.dvc/config`. If
-`--local` option is specified, `.dvc/config.local` is modified instead.
+`--local` option is specified, `.dvc/config.local` is modified instead. If None
+of `--local`, `--global`, or `--system` is provided, `--local` is set by default.
 
 If the config option `value` is not provided and `--unset` option is not used,
 this command returns the current value of the config option, if found in the


### PR DESCRIPTION
Fixes #627