### PR TITLE
Fix: typo dvc run -R to -M

### DIFF
--- a/static/docs/get-started/metrics.md
+++ b/static/docs/get-started/metrics.md
@@ -19,7 +19,7 @@ $ dvc run -f evaluate.dvc \
 from the `features/test.pkl` file and produces a
 [metric](/doc/commands-reference/metrics) file (`auc.metric`). Any
 <abbr>output</abbr> (in this case just a plain text file containing a single
-numeric value) can be marked as a metric, for example by using the `-R` option
+numeric value) can be marked as a metric, for example by using the `-M` option
 of `dvc run`.
 
 > Please, refer to the `dvc metrics` command documentation to see more available


### PR DESCRIPTION
In get started > metrics.
Says:
using the `-R` option of `dvc run`.
when there isn't any -R option. So maybe ir refers to the -M option.

- Have you followed the guidelines in our
  [Contributing Documentation](https://dvc.org/doc/user-guide/contributing-documentation)?
Yes, it's a small one