### PR TITLE
documentation example gives error

### DIFF
--- a/static/docs/commands-reference/metrics/index.md
+++ b/static/docs/commands-reference/metrics/index.md
@@ -60,7 +60,7 @@ $ dvc run -d code/evaluate.py -M data/eval.json \
 Now let's print metric values that we are tracking in this <abbr>project</abbr>:
 
 ```dvc
-$ dvc metrics show -a
+$ dvc metrics show --all-branches
 
   master:
       data/eval.json: {"AUC": "0.624652"}


### PR DESCRIPTION
dvc version v0.6 currently gives error message
'ERROR: ambiguous option: --a could match --all-branches, --all-tags'
This fix clears that error.