### PR TITLE
Add styles to render captions for images

### DIFF
--- a/src/styles.js
+++ b/src/styles.js
@@ -30,6 +30,14 @@ export const global = `
 	*:focus {
     outline: 0;
   }
+
+  img + em {
+    color: #6a737d;
+    font-size: 0.9em;
+    display: block;
+    margin-top: -6px;
+    text-align: center;
+  }
 `
 
 const maxWidth = 1005

--- a/static/docs/tutorials/versioning.md
+++ b/static/docs/tutorials/versioning.md
@@ -13,7 +13,7 @@ to build a powerful image classifier, using only a small dataset. The goal of
 this example is to give you some hands-on experience with a very basic scenario
 – working with multiple versions of datasets and ML models using DVC commands.
 
-![](/static/img/cats-and-dogs.jpg)
+![](/static/img/cats-and-dogs.jpg) _Dataset to classify cats and dogs_
 
 We first train a classifier model using 1000 labeled images, then we double the
 number and retrain our model. We capture both datasets and both results and show


### PR DESCRIPTION
Fixes #685 

## Caption preview
![Screenshot from 2019-10-10 00-46-48](https://user-images.githubusercontent.com/35191225/66513012-d1d91f80-eaf7-11e9-8200-dd35b2ca84f5.png)

## How to put one?
```
![](/static/img/cats-and-dogs.jpg) _Dataset to classify cats and dogs_
```
This generates:
```
<p>
  <img src="/static/img/cats-and-dogs.jpg" />
  <em>Dataset to classify cats and dogs</em>
</p>
```

Now I styled the element using `img + em` selector.

## Styles

- `margin-top` is given as `-6px` so that there is `2px` space between the image and the caption. It is not noticeable here since the background colour of image is white.

- The colour is the same as the one used in quotes.
![Screenshot from 2019-10-10 00-54-12](https://user-images.githubusercontent.com/35191225/66513353-85421400-eaf8-11e9-863d-06896a1beb0f.png)