### PR TITLE
add: update output samples per decreased verbosity

### DIFF
--- a/static/docs/command-reference/add.md
+++ b/static/docs/command-reference/add.md
@@ -120,7 +120,6 @@ Take a file under DVC control:
 ```dvc
 $ dvc add data.xml
 
-Saving 'data.xml' to cache '.dvc/cache'.
 Saving information to 'data.xml.dvc'.
 
 To track the changes with git run:
@@ -192,8 +191,6 @@ Computing md5 for a large directory pics/train/cats. This is only done once.
 
 ...
 
-Saving 'pics' to cache '.dvc/cache'.
-
 Linking directory 'pics'.
 [##############################] 100% pics
 
@@ -227,10 +224,10 @@ If instead you use the `--recursive` option, the output looks as so:
 ```dvc
 $ dvc add --recursive pics
 
-Saving 'pics/train/cats/cat.150.jpg' to cache '.dvc/cache'.
-Saving 'pics/train/cats/cat.130.jpg' to cache '.dvc/cache'.
-Saving 'pics/train/cats/cat.111.jpg' to cache '.dvc/cache'.
-Saving 'pics/train/cats/cat.438.jpg' to cache '.dvc/cache'.
+Saving information to 'pics/cat1.jpg.dvc'.
+Saving information to 'pics/cat3.jpg.dvc'.
+Saving information to 'pics/cat2.jpg.dvc'.
+Saving information to 'pics/cat4.jpg.dvc'.
 ...
 ```
 

--- a/static/docs/command-reference/lock.md
+++ b/static/docs/command-reference/lock.md
@@ -44,7 +44,7 @@ First, let's create a simple DVC-file:
 ```dvc
 $ echo foo > foo
 $ dvc add foo
-Saving 'foo'...
+Saving information ...
 
 $ dvc run -d foo -o bar cp foo bar
 Running command:

--- a/static/docs/command-reference/run.md
+++ b/static/docs/command-reference/run.md
@@ -166,8 +166,7 @@ $ mkdir data
 $ dvc run -d data -o metric -f metric.dvc "echo '1' >> metric"
 
 Running command:
-  echo 'a' >> metric
-Saving 'metric' to cache '.dvc/cache'.
+  echo '1' >> metric
 Saving information to 'metric.dvc'.
 
 To track the changes with git run:

--- a/static/docs/command-reference/unlock.md
+++ b/static/docs/command-reference/unlock.md
@@ -40,7 +40,7 @@ First, let's create a simple DVC-file:
 ```dvc
 $ echo foo > foo
 $ dvc add foo
-Saving 'foo'...
+Saving information ...
 
 $ dvc run -d foo -o bar cp foo bar
 Running command:

--- a/static/docs/command-reference/unprotect.md
+++ b/static/docs/command-reference/unprotect.md
@@ -60,7 +60,6 @@ $ ls -lh
 -rw-r--r--  1 10576022 Nov 27 13:30 Posts.xml.zip
 
 $ dvc add Posts.xml.zip
-Saving 'Posts.xml.zip' to cache '.dvc/cache'.
 Saving information to 'Posts.xml.zip.dvc'.
 
 To track the changes with git run:

--- a/static/docs/tutorials/deep/define-ml-pipeline.md
+++ b/static/docs/tutorials/deep/define-ml-pipeline.md
@@ -169,7 +169,6 @@ Running command:
   unzip data/Posts.xml.zip -d data/
 Archive:  data/Posts.xml.zip
     inflating: data/Posts.xml
-Saving 'data/Posts.xml' to cache '.dvc/cache'.
 Saving information to 'Posts.xml.dvc'.
 
 To track the changes with git run:


### PR DESCRIPTION
With reference to iterative/dvc#2607

In static/docs/command-reference/run.md,
I changed `'a'` to `'1'` because it was a typographical error.

In static/docs/tutorials/deep/define-ml-pipeline.md,
I experimented with add zip files which showed that it also creates a directory where extracted files are put.