### PR TITLE
Darken the color in tooltips

### DIFF
--- a/src/Tooltip/desktop-view.js
+++ b/src/Tooltip/desktop-view.js
@@ -168,6 +168,7 @@ const TooltipContainer = styled.div`
 `
 
 const TooltipText = styled.div`
+  color: black;
   padding: 8px 10px;
   border: 1px solid #d1d5da;
   border-radius: 3px;


### PR DESCRIPTION
![Screenshot from 2019-10-17 23-32-24](https://user-images.githubusercontent.com/35191225/67035368-2bb09980-f137-11e9-801d-8df1aef05b74.png)

Hovering over keywords inside blockquotes took their text colour. These changes are introduced to fix that.