### PR TITLE
Fix #707: remove all loading bars in the readme docs

### DIFF
--- a/static/docs/command-reference/add.md
+++ b/static/docs/command-reference/add.md
@@ -187,12 +187,9 @@ Taking a directory under DVC control as simple as taking a single file:
 $ dvc add pics
 
 Computing md5 for a large directory pics/train/cats. This is only done once.
-[##############################] 100% pics/train/cats
-
 ...
 
 Linking directory 'pics'.
-[##############################] 100% pics
 
 Saving information to 'pics.dvc'.
 ...

--- a/static/docs/command-reference/checkout.md
+++ b/static/docs/command-reference/checkout.md
@@ -158,7 +158,6 @@ files that are under DVC control. The model file checksum
 ```dvc
 $ dvc pull
 ...
-(1/6): [#######################] 100% model.pkl
 Checking out model.pkl with cache '3863d0e317dee0a55c4e59d2ec0eef33'
 ...
 

--- a/static/docs/command-reference/fetch.md
+++ b/static/docs/command-reference/fetch.md
@@ -175,10 +175,6 @@ $ dvc status --cloud
 
 $ dvc fetch
 ...
-(2/6): [##############################] 100% data/features/test.pkl
-(3/6): [##############################] 100% model.pkl
-(4/6): [##############################] 100% data/features/train.pkl
-...
 
 $ tree .dvc
 .dvc
@@ -218,9 +214,6 @@ corresponding DVC-file (command target) is specified:
 
 ```dvc
 $ dvc fetch prepare.dvc
-...
-(1/2): [##############################] 100% data/prepared/test.tsv
-(2/2): [##############################] 100% data/prepared/train.tsv
 
 $ tree .dvc/cache
 .dvc/cache
@@ -261,12 +254,6 @@ to retrieve the data up to our third stage, `train.dvc`? We can use the
 
 ```dvc
 $ dvc fetch --with-deps train.dvc
-...
-(1/4): [##############################] 100% model.pkl
-(2/4): [######                        ] 21% data/data.xml
-(2/4): [##############################] 100% data/features/train.pkl
-(3/4): [##############################] 100% data/features/test.pkl
-(4/4): [##############################] 100% data/data.xml
 
 $ tree .dvc/cache
 .dvc/cache

--- a/static/docs/command-reference/import-url.md
+++ b/static/docs/command-reference/import-url.md
@@ -155,9 +155,6 @@ _Get Started_ section is to use `dvc import-url`:
 $ dvc import-url https://data.dvc.org/get-started/data.xml \
                  data/data.xml
 Importing 'https://data.dvc.org/get-started/data.xml' -> 'data/data.xml'
-[##############################] 100% data.xml
-[##############################] 100% data.xml
-
 
 Saving information to 'data.xml.dvc'.
 
@@ -223,7 +220,6 @@ edit the data file.
 ```dvc
 $ dvc import-url /tmp/dvc-import-url-example/data.xml data/data.xml
 Importing '../../../tmp/dvc-import-url-example/data.xml' -> 'data/data.xml'
-[##############################] 100% data.xml
 ...
 ```
 
@@ -318,7 +314,6 @@ do so, we can run `dvc update` to make sure the import stage is up to date:
 $ dvc update data.xml.dvc
 ...
 Importing '.../tmp/dvc-import-url-example/data.xml' -> 'data/data.xml'
-[##############################] 100% data.xml
 ...
 Saving information to 'data.xml.dvc'.
 ```

--- a/static/docs/command-reference/install.md
+++ b/static/docs/command-reference/install.md
@@ -164,8 +164,6 @@ featurize.dvc:
 
 $ dvc checkout
 
-[##############################] 100% Checkout finished!
-
 $ dvc status
 
 Data and pipelines are up to date.
@@ -190,7 +188,6 @@ Switched to branch 'master'
 Your branch is up to date with 'origin/master'.
 
 $ dvc checkout
-[##############################] 100% Checkout finished!
 ```
 
 We've seen the default behavior with there being no Git hooks installed. We want
@@ -221,7 +218,6 @@ Note: checking out '6-featurization'.
 You are in 'detached HEAD' state. ...
 
 HEAD is now at d13ba9a add featurization stage
-[##############################] 100% Checkout finished!
 
 $ dvc status
 

--- a/static/docs/command-reference/pull.md
+++ b/static/docs/command-reference/pull.md
@@ -122,12 +122,6 @@ files from the current Git branch:
 
 ```dvc
 $ dvc pull --remote r1
-
-(1/8): [####################] 100% images/0001.jpg
-(2/8): [####################] 100% images/0002.jpg
-...
-(7/8): [####################] 100% images/0007.jpg
-(8/8): [####################] 100% model.pkl
 ```
 
 We can download specific files that are <abbr>outputs</abbr> of a specific
@@ -135,7 +129,6 @@ DVC-file:
 
 ```dvc
 $ dvc pull data.zip.dvc
-[####################] 100% data.zip
 ```
 
 In this case we left off the `--remote` option, so it will have pulled from the
@@ -177,14 +170,9 @@ to retrieve part of the data?
 ```dvc
 $ dvc pull --remote r1 --with-deps matrix-train.p.dvc
 
-(1/2): [####################] 100% data/matrix-test.p data/matrix-test.p
-(2/2): [####################] 100% data/matrix-train.p data/matrix-train.p
-
 ... Do some work based on the partial update
 
 $ dvc pull --remote r1 --with-deps model.p.dvc
-
-(1/1): [####################] 100% data/model.p data/model.p
 
 ... Pull the rest of the data
 

--- a/static/docs/command-reference/push.md
+++ b/static/docs/command-reference/push.md
@@ -124,20 +124,12 @@ Push all data file caches from the current Git branch to the default remote:
 
 ```dvc
 $ dvc push
-
-(1/8): [######################] 100% images/0001.jpg
-(2/8): [######################] 100% images/0002.jpg
-...
-(7/8): [######################] 100% images/0007.jpg
-(8/8): [###########           ] 57% model.pkl
 ```
 
 Push <abbr>outputs</abbr> of a specific DVC-file:
 
 ```dvc
 $ dvc push data.zip.dvc
-
-[######################] 100% data.zip
 ```
 
 ## Example: With dependencies
@@ -175,14 +167,9 @@ want to upload part of the data?
 ```dvc
 $ dvc push --remote r1 --with-deps matrix-train.p.dvc
 
-(1/2): [####################] 100% data/matrix-test.p data/matrix-test.p
-(2/2): [####################] 100% data/matrix-train.p data/matrix-train.p
-
 ... Do some work based on the partial update
 
 $ dvc push --remote r1 --with-deps model.p.dvc
-
-(1/1): [####################] 100% data/model.p data/model.p
 
 ... Push the rest of the data
 

--- a/static/docs/command-reference/status.md
+++ b/static/docs/command-reference/status.md
@@ -194,7 +194,6 @@ remote yet:
 ```dvc
 $ dvc status --remote storage
 Preparing to collect status from s3://dvc-remote
-[##############################] 100% Collecting information
     new:      data/model.p
     new:      data/eval.txt
     new:      data/matrix-train.p

--- a/static/docs/command-reference/unprotect.md
+++ b/static/docs/command-reference/unprotect.md
@@ -79,7 +79,6 @@ Unprotect the file:
 
 ```dvc
 $ dvc unprotect Posts.xml.zip
-[##############################] 100% Posts.xml.zip
 ```
 
 Check that the file is writable now, the cached version is intact, and they are

--- a/static/docs/tutorials/deep/sharing-data.md
+++ b/static/docs/tutorials/deep/sharing-data.md
@@ -35,8 +35,6 @@ Then, a simple command pushes files from your cache to the cloud:
 
 ```dvc
 $ dvc push
-(1/9): [#########################] 100% 23/404ed8212fc1ee6f5a81ff6f6df2ef
-(2/9): [##########               ] 34% 5f/42ecd9a121b4382cd6510534533ec3
 ```
 
 The command does not push all cached files, but only the ones that belong to the

--- a/static/docs/use-cases/share-data-and-model-files.md
+++ b/static/docs/use-cases/share-data-and-model-files.md
@@ -67,11 +67,6 @@ storage with the `dvc push` command:
 
 ```dvc
 $ dvc push
-(1/5): [##############################] 100% images/0001.jpg
-(2/5): [##############################] 100% images/0002.jpg
-(3/5): [##############################] 100% images/0001.jpg
-(4/5): [##############################] 100% images
-(5/5): [##############################] 100% model.pkl
 ```
 
 Code and [DVC-files](/doc/user-guide/dvc-file-format) should be committed and
@@ -99,11 +94,6 @@ To download data files for your <abbr>project</abbr>, run:
 
 ```dvc
 $ dvc pull
-(1/5): [##############################] 100% images/0001.jpg
-(2/5): [##############################] 100% images/0002.jpg
-(3/5): [##############################] 100% images/0003.jpg
-(4/5): [##############################] 100% images
-(5/5): [##############################] 100% model.pkl
 ```
 
 `dvc pull` will download the missing data files from the default remote storage

--- a/static/docs/user-guide/external-dependencies.md
+++ b/static/docs/user-guide/external-dependencies.md
@@ -119,7 +119,6 @@ external path or URL types.
 ```dvc
 $ dvc import-url https://data.dvc.org/get-started/data.xml
 Importing 'https://data.dvc.org/get-started/data.xml' -> 'data.xml'
-[##############################] 100% data.xml
 ...
 ```
 


### PR DESCRIPTION
This removes the loading bar from the READMEs described in

Fix #707