### PR TITLE
Fix scrolling behaviour for anchored headers

### DIFF
--- a/pages/doc.js
+++ b/pages/doc.js
@@ -153,7 +153,11 @@ export default class Documentation extends Component {
     const element = document.getElementById(hash.replace(/^#/, ''))
 
     if (element) {
-      element.scrollIntoView()
+      const headerHeight = document.getElementsByClassName('header')[0]
+        .offsetHeight
+      const elementBoundary = element.getBoundingClientRect()
+      const rootElement = document.getElementById(ROOT_ELEMENT)
+      rootElement.scroll({ top: elementBoundary.top - headerHeight })
     }
   }
 


### PR DESCRIPTION
Fixes #681 

So I couldn't debug why `element.scrollIntoView()` wasn't working so I came up with an alternate solution.

### Explaination

1. It finds the location of the anchored header using `element.getBoundingClientRect().top` which is with respect to the topmost point in the window.
2. Now we scroll to this position but subtract the `headerHeight` because it is scrolling with respect to the `bodybag` container (it starts below the header) since it has the `overflow-y` property set.