### PR TITLE
Use a unique `id` to access the app header and content body instead of a `className`

### DIFF
--- a/consts/index.js
+++ b/consts/index.js
@@ -1,0 +1,1 @@
+export const HEADER = 'header'

--- a/pages/doc.js
+++ b/pages/doc.js
@@ -20,6 +20,8 @@ import styled from 'styled-components'
 import { media } from '../src/styles'
 // sidebar data and helpers
 import sidebar, { getItemByPath } from '../src/Documentation/SidebarMenu/helper'
+// constants
+import { HEADER } from '../consts'
 
 const ROOT_ELEMENT = 'bodybag'
 const SIDEBAR_MENU = 'sidebar-menu'
@@ -153,7 +155,7 @@ export default class Documentation extends Component {
     const element = document.getElementById(hash.replace(/^#/, ''))
 
     if (element) {
-      const headerHeight = document.getElementsByClassName('header')[0]
+      const headerHeight = document.getElementsByClassName(HEADER)[0]
         .offsetHeight
       const elementBoundary = element.getBoundingClientRect()
       const rootElement = document.getElementById(ROOT_ELEMENT)

--- a/pages/doc.js
+++ b/pages/doc.js
@@ -155,8 +155,7 @@ export default class Documentation extends Component {
     const element = document.getElementById(hash.replace(/^#/, ''))
 
     if (element) {
-      const headerHeight = document.getElementsByClassName(HEADER)[0]
-        .offsetHeight
+      const headerHeight = document.getElementById(HEADER).offsetHeight
       const elementBoundary = element.getBoundingClientRect()
       const rootElement = document.getElementById(ROOT_ELEMENT)
       rootElement.scroll({ top: elementBoundary.top - headerHeight })

--- a/src/Documentation/Markdown/Markdown.js
+++ b/src/Documentation/Markdown/Markdown.js
@@ -156,7 +156,7 @@ export default class Markdown extends React.PureComponent {
     const { markdown, githubLink, prev, next, onNavigate } = this.props
 
     return (
-      <Content>
+      <Content id="markdown-root">
         <GithubLink href={githubLink} target="_blank">
           <i /> Edit on GitHub
         </GithubLink>

--- a/src/Documentation/RightPanel/RightPanel.js
+++ b/src/Documentation/RightPanel/RightPanel.js
@@ -6,7 +6,7 @@ import { LightButton } from '../LightButton'
 import throttle from 'lodash.throttle'
 
 const ROOT_ELEMENT = 'bodybag'
-const MARKDOWN_ROOT = '.markdown-body'
+const MARKDOWN_ROOT = '#markdown-root'
 
 const imageChecker = (images, callback) => {
   // IE can't use forEach on array-likes

--- a/src/Tooltip/desktop-view.js
+++ b/src/Tooltip/desktop-view.js
@@ -20,7 +20,7 @@ class DesktopView extends Component {
   }
 
   tooltipPositionEval = () => {
-    const headerHeight = document.getElementsByClassName(HEADER)[0].offsetHeight
+    const headerHeight = document.getElementById(HEADER).offsetHeight
     const markdownBody = document.getElementsByClassName('markdown-body')[0]
     const tooltipBoundary = document
       .getElementById(`tooltip-text-${this.props.id}`)

--- a/src/Tooltip/desktop-view.js
+++ b/src/Tooltip/desktop-view.js
@@ -3,6 +3,8 @@ import PropTypes from 'prop-types'
 import ReactMarkdown from 'react-markdown'
 import styled from 'styled-components'
 
+import { HEADER } from '../../consts'
+
 class DesktopView extends Component {
   state = {
     hover: false,
@@ -18,8 +20,7 @@ class DesktopView extends Component {
   }
 
   tooltipPositionEval = () => {
-    const headerHeight = document.getElementsByClassName('header')[0]
-      .offsetHeight
+    const headerHeight = document.getElementsByClassName(HEADER)[0].offsetHeight
     const markdownBody = document.getElementsByClassName('markdown-body')[0]
     const tooltipBoundary = document
       .getElementById(`tooltip-text-${this.props.id}`)

--- a/src/Tooltip/desktop-view.js
+++ b/src/Tooltip/desktop-view.js
@@ -21,7 +21,7 @@ class DesktopView extends Component {
 
   tooltipPositionEval = () => {
     const headerHeight = document.getElementById(HEADER).offsetHeight
-    const markdownBody = document.getElementsByClassName('markdown-body')[0]
+    const markdownBody = document.getElementById('markdown-root')
     const tooltipBoundary = document
       .getElementById(`tooltip-text-${this.props.id}`)
       .getBoundingClientRect()

--- a/src/TopMenu/index.js
+++ b/src/TopMenu/index.js
@@ -52,7 +52,7 @@ class TopMenu extends Component {
     return (
       <Wrapper>
         <Container
-          className={HEADER}
+          id={HEADER}
           scrolled={isDocPage || scrolled}
           wide={isDocPage}
         >

--- a/src/TopMenu/index.js
+++ b/src/TopMenu/index.js
@@ -7,6 +7,8 @@ import throttle from 'lodash.throttle'
 // styles
 import styled from 'styled-components'
 import { media } from '../styles'
+// constants
+import { HEADER } from '../../consts'
 
 const MIN_HEIGHT = 78
 
@@ -50,7 +52,7 @@ class TopMenu extends Component {
     return (
       <Wrapper>
         <Container
-          className="header"
+          className={HEADER}
           scrolled={isDocPage || scrolled}
           wide={isDocPage}
         >


### PR DESCRIPTION
Fixes #681 
Partially addresses #714 