### PR TITLE
Fix: #739 : update get-started index page

### DIFF
--- a/static/docs/get-started/index.md
+++ b/static/docs/get-started/index.md
@@ -17,6 +17,6 @@ us a ⭐ if you like the project!
 ✅ Contribute either [on GitHub](https://github.com/iterative/dvc) or
 [on Patreon](https://www.patreon.com/DVCorg/overview) to support the project.
 
-Separate to this section, the longer [Tutorial](/doc/tutorials/deep) also
+Separate to this section, the longer [Tutorial](/doc/tutorials) also
 introduces DVC step-by-step, while additionally explaining in great detail the
 motivation and what's happening internally.


### PR DESCRIPTION
Fixed the link for " Tutorial " to link to the base tutorials directory.
Fix #739