### PR TITLE
Update get-started index page

### DIFF
--- a/static/docs/get-started/index.md
+++ b/static/docs/get-started/index.md
@@ -17,6 +17,6 @@ us a ⭐ if you like the project!
 ✅ Contribute either [on GitHub](https://github.com/iterative/dvc) or
 [on Patreon](https://www.patreon.com/DVCorg/overview) to support the project.
 
-The longer [Tutorials](/doc/tutorials) section contains a step-by-step introduction to DVC. 
-In addition section explains, in great detail the motivation behind the project and its 
+The longer [Tutorials](/doc/tutorials) section contains a step-by-step introduction to DVC.
+In addition the section explains, in great detail, the motivation behind the project and its
 internal mechanism.

--- a/static/docs/get-started/index.md
+++ b/static/docs/get-started/index.md
@@ -17,6 +17,6 @@ us a ⭐ if you like the project!
 ✅ Contribute either [on GitHub](https://github.com/iterative/dvc) or
 [on Patreon](https://www.patreon.com/DVCorg/overview) to support the project.
 
-The longer [Tutorials](/doc/tutorials) section contains a step-by-step introduction to DVC.
-In addition the section explains, in great detail, the motivation behind the project and its
-internal mechanism.
+The longer [Tutorials](/doc/tutorials) section contains a step-by-step
+introduction to DVC. In addition the section explains, in great detail, the
+motivation behind the project and its internal mechanism.

--- a/static/docs/get-started/index.md
+++ b/static/docs/get-started/index.md
@@ -17,6 +17,6 @@ us a ⭐ if you like the project!
 ✅ Contribute either [on GitHub](https://github.com/iterative/dvc) or
 [on Patreon](https://www.patreon.com/DVCorg/overview) to support the project.
 
-Separate to this section, the longer [Tutorial](/doc/tutorials/deep) also
-introduces DVC step-by-step, while additionally explaining in great detail the
-motivation and what's happening internally.
+The longer [Tutorials](/doc/tutorials) section contains a step-by-step introduction to DVC. 
+In addition section explains, in great detail the motivation behind the project and its 
+internal mechanism.


### PR DESCRIPTION
Fixed the link for " Tutorial " to link to the base tutorials directory and changed the surrounding text to a more readable and flowing paragraph.
