### PR TITLE
Write command for running a single test function

### DIFF
--- a/static/docs/user-guide/contributing/core.md
+++ b/static/docs/user-guide/contributing/core.md
@@ -120,6 +120,12 @@ To run a single test case:
 $ python -m tests tests/func/test_metrics.py::TestCachedMetrics
 ```
 
+To run a single test function:
+
+```dvc
+$ python -m tests tests/unit/utils/test_fs.py::test_get_inode
+```
+
 To pass additional arguments:
 
 ```dvc


### PR DESCRIPTION
The command which was already written
```
$ python -m tests tests/func/test_metrics.py::TestCachedMetrics
```
ran a test case of one or more functions.

These changes instruct to run a single test function.

Should I also add running a single test function inside a single test case? It will be something like this.
```
$ python -m tests tests/unit/utils/test_fs.py::TestContainsLink::test_should_return_true_on_symlink_in_path
```