### PR TITLE
Updated the last stage

### DIFF
--- a/static/docs/get-started/visualize.md
+++ b/static/docs/get-started/visualize.md
@@ -30,9 +30,9 @@ $ dvc pipeline show --ascii train.dvc
                *
                *
                *
-       .---------------.
-       | model.pkl.dvc |
-       `---------------'
+         +-----------+
+         | train.dvc |
+         +-----------+
 ```
 
 ## Commands


### PR DESCRIPTION
The last stage value was showing "model.pkl.dvc" instead of "train.dvc"
https://dvc.org/doc/get-started/visualize

Stages > dvc pipeline show --ascii train.dvc