### PR TITLE
Remove confusing deletion instruction on get-started

### DIFF
--- a/static/docs/get-started/retrieve-data.md
+++ b/static/docs/get-started/retrieve-data.md
@@ -12,11 +12,6 @@ $ rm -f data/data.xml
 $ dvc pull
 ```
 
-> If you've followed previous chapters of this section, try deleting
-> `data/data.xml` before running the command above, otherwise DVC won't find a
-> need to [checkout](/doc/command-reference/checkout) the file, since it's
-> already in your workspace.
-
 This command downloads data files that are referenced in all
 [DVC-files](/doc/user-guide/dvc-file-format) in the <abbr>project</abbr>. So,
 you usually run it after `git clone`, `git pull`, or `git checkout`.


### PR DESCRIPTION
The `Retrieve Data` section already has a code snippet to delete `data/data.xml`, but the notice seems to have remained from the old days when there didn't use to be deletion code snippet. I found this very confusing, and maybe others did as well. Again, this is redundant, anyway.