### PR TITLE
Update the linebreak symbol

### DIFF
--- a/static/docs/get-started/add-files.md
+++ b/static/docs/get-started/add-files.md
@@ -6,8 +6,7 @@ Let's get a dataset example to play with:
 
 ```dvc
 $ mkdir data
-$ dvc get https://github.com/iterative/dataset-registry \
-        get-started/data.xml -o data/data.xml
+$ dvc get https://github.com/iterative/dataset-registry get-started/data.xml -o data/data.xml
 ```
 
 > `dvc get` can use any <abbr>DVC project</abbr> hosted on a Git repository to


### PR DESCRIPTION
The original doc comment of this is confusing for Python users:
```dvc
$ mkdir data
$ dvc get https://github.com/iterative/dataset-registry \ 
get-started/data.xml -o data/data.xml
```
So changed this into one single command line for clarity after conversation with Ivan on Discord. 
```dvc
$ mkdir data
$ dvc get https://github.com/iterative/dataset-registry get-started/data.xml -o data/data.xml
```

**IMPORTANT NOTES** (please read, then delete):

- Have you followed the guidelines in
  [Contributing Documentation](https://dvc.org/doc/user-guide/contributing/docs)?

- Please use the title to provide a clear one-line present-tense summary of the
  changes introduced in the PR. For example: "Introduce the first version of the
  collection editor.".

- Please make sure to mention "Fix #bugnum" (if applicable) in the description
  of the PR. This enables GitHub to link the PR to the corresponding bug.
