### PR TITLE
Get rid of links to external dependencies in import command

### DIFF
--- a/static/docs/command-reference/import.md
+++ b/static/docs/command-reference/import.md
@@ -3,8 +3,8 @@
 Download or copy an <abbr>output</abbr> file or directory from any <abbr>DVC
 repository</abbr> (e.g. hosted on GitHub) into the <abbr>workspace</abbr>. DVC
 creates a [DVC-file](/doc/user-guide/dvc-file-format) with information about the
-data source, which can later be used for
-[updating](/doc/command-reference/update) the import.
+data source, which can later be used to [update](/doc/command-reference/update)
+the import.
 
 > See also `dvc get`, that corresponds to the first step this command performs
 > (just download the data).
@@ -100,9 +100,9 @@ Importing 'data/data.xml (git@github.com:iterative/example-get-started)'
 
 In contrast with `dvc get`, this command doesn't just download the data file,
 but it also creates an import stage
-([DVC-file](/doc/user-guide/dvc-file-format)) with a link to this data source.
-This DVC-file with the link is used during imported file
-[update](/doc/user-guide/external-dependencies). Check `data.xml.dvc`:
+([DVC-file](/doc/user-guide/dvc-file-format)) with a link to the data source (as
+explained in the description above). (This import stage can later be used to
+[update](/doc/command-reference/update) the import.) Check `data.xml.dvc`:
 
 ```yaml
 md5: 7de90e7de7b432ad972095bc1f2ec0f8

--- a/static/docs/command-reference/import.md
+++ b/static/docs/command-reference/import.md
@@ -1,9 +1,11 @@
 # import
 
-Download or copy file or directory from any <abbr>DVC project</abbr> in a Git
-repository (e.g. hosted on GitHub) into the <abbr>workspace</abbr>, and track
-changes in this [external dependency](/doc/user-guide/external-dependencies).
-Creates [DVC-files](/doc/user-guide/dvc-file-format).
+Import file or directory from any <abbr>DVC project</abbr> in a Git
+repository (e.g. hosted on GitHub). The imported files will be copied
+or downloaded into the <abbr>workspace</abbr> while DVC keeps information
+about the source in a created [DVC-files](/doc/user-guide/dvc-file-format).
+Information about the source is a link to a imported repository and it is
+used during imported file [update](/doc/user-guide/external-dependencies).
 
 > See also `dvc get`, that corresponds to the first step this command performs
 > (just download the data).
@@ -100,9 +102,10 @@ Importing 'data/data.xml (git@github.com:iterative/example-get-started)'
 
 In contrast with `dvc get`, this command doesn't just download the data file,
 but it also creates an import stage
-([DVC-file](/doc/user-guide/dvc-file-format)) to register this data as an
-[external dependency](/doc/user-guide/external-dependencies) (using the `repo`
-field). Check `data.xml.dvc`:
+([DVC-file](/doc/user-guide/dvc-file-format)) with a link to this data source.
+This DVC-file with the link is used during imported
+file [update](/doc/user-guide/external-dependencies).
+Check `data.xml.dvc`:
 
 ```yaml
 md5: 7de90e7de7b432ad972095bc1f2ec0f8

--- a/static/docs/command-reference/import.md
+++ b/static/docs/command-reference/import.md
@@ -1,11 +1,10 @@
 # import
 
-Import file or directory from any <abbr>DVC project</abbr> in a Git
-repository (e.g. hosted on GitHub). The imported files will be copied
-or downloaded into the <abbr>workspace</abbr> while DVC keeps information
-about the source in a created [DVC-files](/doc/user-guide/dvc-file-format).
-Information about the source is a link to a imported repository and it is
-used during imported file [update](/doc/user-guide/external-dependencies).
+Download or copy an <abbr>output</abbr> file or directory from any <abbr>DVC
+repository</abbr> (e.g. hosted on GitHub) into the <abbr>workspace</abbr>. DVC
+creates a [DVC-file](/doc/user-guide/dvc-file-format) with information about the
+data source, which can later be used for
+[updating](/doc/command-reference/update) the import.
 
 > See also `dvc get`, that corresponds to the first step this command performs
 > (just download the data).
@@ -49,12 +48,11 @@ _import stage_ (DVC-file) is then created, extending the full file or directory
 name of the imported data e.g. `data.txt.dvc` – similar to having used `dvc run`
 to generate the same output.
 
-DVC supports DVC-files that refer to data in an external DVC repository (hosted
-on a Git server) a.k.a _import stages_. In such a DVC-file, the `deps` section
-specifies the `repo` URL and data `path`, and the `outs` section contains the
-corresponding local path in the workspace. It records enough data from the
-imported data to enable DVC to efficiently check it to determine whether the
-local copy is out of date.
+DVC-files support references to data in an external DVC repository (hosted on a
+Git server). In such a DVC-file, the `deps` section specifies the `repo`-`url`
+and data `path` fields, and the `outs` section contains the corresponding local
+workspace `path` field. This is enough data about the imported data, to enable
+DVC efficiently determining whether the local copy is out of date.
 
 To actually [track the data](https://dvc.org/doc/get-started/add-files),
 `git add` (and `git commit`) the import stage.
@@ -103,9 +101,8 @@ Importing 'data/data.xml (git@github.com:iterative/example-get-started)'
 In contrast with `dvc get`, this command doesn't just download the data file,
 but it also creates an import stage
 ([DVC-file](/doc/user-guide/dvc-file-format)) with a link to this data source.
-This DVC-file with the link is used during imported
-file [update](/doc/user-guide/external-dependencies).
-Check `data.xml.dvc`:
+This DVC-file with the link is used during imported file
+[update](/doc/user-guide/external-dependencies). Check `data.xml.dvc`:
 
 ```yaml
 md5: 7de90e7de7b432ad972095bc1f2ec0f8

--- a/static/docs/get-started/initialize.md
+++ b/static/docs/get-started/initialize.md
@@ -1,8 +1,8 @@
 # Initialize
 
 There are a few recommended ways to install DVC: OS-specific package/installer,
-`pip`, `conda`, and Homebrew. See the [**Installation**](/doc/install) page for
-all the options and details.
+`pip`, `conda`, and Homebrew. See [Installation](/doc/install) for all the
+options and details.
 
 Let's start by creating a <abbr>workspace</abbr> we can version with Git. Then
 run `dvc init` inside to create the DVC <abbr>project</abbr>:


### PR DESCRIPTION
External-dependencies is quite advanced concept that is necessary only in rear optimization cases. It is better not to use and reference to external-dependencies if there is no real need.