### PR TITLE
Fix #729: Open external domain links in a new tab

### DIFF
--- a/src/Documentation/Markdown/Markdown.js
+++ b/src/Documentation/Markdown/Markdown.js
@@ -390,16 +390,14 @@ export const GithubLink = styled(LightButton)`
 `
 
 const ExternalLink = styled.a`
-  position: relative;
-  padding-right: 21px;
-
   &:after {
-    position: absolute;
-    top: 2px;
+    position: relative;
+    top: 1px;
     right: 0;
-    width: 16px;
-    height: 16px;
-    /* Icon source https://www.iconfinder.com/icons/2561428/external_link_icon */
+    width: 12px;
+    height: 12px;
+    margin-left: 1px;
+    /* Icon source https://en.wikipedia.org/w/skins/Vector/images/external-link-ltr-icon.svg */
     content: url(/static/img/external-link.svg);
   }
 `

--- a/src/Documentation/Markdown/Markdown.js
+++ b/src/Documentation/Markdown/Markdown.js
@@ -104,6 +104,27 @@ CodeBlock.propTypes = {
   value: PropTypes.node.isRequired
 }
 
+const Link = ({ children, ...props }) => {
+  const externalLink = props.href.match(/^(\/\/|http(s)?:\/\/)/)
+  const showIcon =
+    externalLink && children && typeof children[0].props.children === 'string'
+
+  const modifiedProps = externalLink
+    ? { ...props, target: '_blank', rel: 'noopener nofollow' }
+    : props
+
+  if (showIcon) {
+    return <ExternalLink {...modifiedProps}>{children}</ExternalLink>
+  }
+
+  return <a {...modifiedProps}>{children}</a>
+}
+
+Link.propTypes = {
+  children: PropTypes.node.isRequired,
+  href: PropTypes.string.isRequired
+}
+
 export default class Markdown extends React.PureComponent {
   constructor() {
     super()
@@ -167,6 +188,7 @@ export default class Markdown extends React.PureComponent {
           escapeHtml={false}
           source={markdown}
           renderers={{
+            link: Link,
             code: CodeBlock,
             heading: HeadingRenderer,
             virtualHtml: HtmlRenderer
@@ -364,5 +386,20 @@ export const GithubLink = styled(LightButton)`
 
   i {
     background-image: url(/static/img/github_icon.svg);
+  }
+`
+
+const ExternalLink = styled.a`
+  position: relative;
+  padding-right: 21px;
+
+  &:after {
+    position: absolute;
+    top: 2px;
+    right: 0;
+    width: 16px;
+    height: 16px;
+    /* Icon source https://www.iconfinder.com/icons/2561428/external_link_icon */
+    content: url(/static/img/external-link.svg);
   }
 `

--- a/static/img/external-link.svg
+++ b/static/img/external-link.svg
@@ -1,1 +1,6 @@
-<?xml version="1.0" ?><svg fill="none" height="16" stroke="#0366d6" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewBox="0 0 24 24" width="16" xmlns="http://www.w3.org/2000/svg"><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/><polyline points="15 3 21 3 21 9"/><line x1="10" x2="21" y1="14" y2="3"/></svg>
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12">
+	<path fill="#fff" stroke="#36c" d="M1.5 4.518h5.982V10.5H1.5z"/>
+	<path fill="#0366d6" d="M5.765 1H11v5.39L9.427 7.937l-1.31-1.31L5.393 9.35l-2.69-2.688 2.81-2.808L4.2 2.544z"/>
+	<path fill="#fff" d="M9.995 2.004l.022 4.885L8.2 5.07 5.32 7.95 4.09 6.723l2.882-2.88-1.85-1.852z"/>
+</svg>

--- a/static/img/external-link.svg
+++ b/static/img/external-link.svg
@@ -1,0 +1,1 @@
+<?xml version="1.0" ?><svg fill="none" height="16" stroke="#0366d6" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewBox="0 0 24 24" width="16" xmlns="http://www.w3.org/2000/svg"><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/><polyline points="15 3 21 3 21 9"/><line x1="10" x2="21" y1="14" y2="3"/></svg>


### PR DESCRIPTION
Added custom renderer for links that will add target="_blank" to external links and show icon after them