### PR TITLE
Fix Katacoda button line-break

### DIFF
--- a/src/Documentation/Tutorials.js
+++ b/src/Documentation/Tutorials.js
@@ -61,6 +61,8 @@ const ExternalButton = styled(LightButton)`
 `
 
 const KatacodaButton = styled(ExternalButton)`
+  white-space: nowrap;
+
   i {
     background-image: url(/static/img/katacoda_grey_small.png);
     width: 24px;


### PR DESCRIPTION
Katacoda button text is wrapped to the second line in FF and Edge. This PR fixes it.