### PR TITLE
Fix client navigation for links with hashes

### DIFF
--- a/pages/doc.js
+++ b/pages/doc.js
@@ -130,7 +130,7 @@ export default function Documentation({ item, headings, markdown, errorCode }) {
 }
 
 Documentation.getInitialProps = async ({ asPath, req }) => {
-  const item = getItemByPath(asPath)
+  const item = getItemByPath(asPath.split('#')[0])
 
   if (!item) {
     return {

--- a/src/Documentation/Markdown/Markdown.js
+++ b/src/Documentation/Markdown/Markdown.js
@@ -126,14 +126,10 @@ const Link = ({ children, href, ...props }) => {
     )
   }
 
-  const nextProps = href.match(/^\/doc/)
-    ? { href: PAGE_DOC, as: href }
-    : { href }
-
   return (
-    <NextLink {...nextProps}>
-      <a {...modifiedProps}>{children}</a>
-    </NextLink>
+    <a {...modifiedProps} href={href}>
+      {children}
+    </a>
   )
 }
 

--- a/src/Documentation/Markdown/Markdown.js
+++ b/src/Documentation/Markdown/Markdown.js
@@ -126,10 +126,14 @@ const Link = ({ children, href, ...props }) => {
     )
   }
 
+  const nextProps = href.match(/^\/doc/)
+    ? { href: PAGE_DOC, as: href }
+    : { href }
+
   return (
-    <a {...modifiedProps} href={href}>
-      {children}
-    </a>
+    <NextLink {...nextProps}>
+      <a {...modifiedProps}>{children}</a>
+    </NextLink>
   )
 }
 


### PR DESCRIPTION
Fix for 404 errors in #849. Error was with our custom 404 page logic - we was checking if the page exists by matching it's url with the sidebar.json content without removing the hash.