### PR TITLE
remote: use `-d` in s3 example

### DIFF
--- a/public/static/docs/command-reference/remote/index.md
+++ b/public/static/docs/command-reference/remote/index.md
@@ -101,7 +101,7 @@ remote = myremote
 > [Create a Bucket](https://docs.aws.amazon.com/AmazonS3/latest/gsg/CreatingABucket.html).
 
 ```dvc
-$ dvc remote add mynewremote s3://mybucket/myproject
+$ dvc remote add -d mynewremote s3://mybucket/myproject
 $ dvc remote modify mynewremote region us-east-2
 ```
 

--- a/public/static/docs/command-reference/remote/index.md
+++ b/public/static/docs/command-reference/remote/index.md
@@ -95,7 +95,7 @@ url = /path/to/remote
 remote = myremote
 ```
 
-## Example: Add Amazon S3 remote and modify its region
+## Example: Add a default Amazon S3 remote and modify its region
 
 > 💡 Before adding an S3 remote, be sure to
 > [Create a Bucket](https://docs.aws.amazon.com/AmazonS3/latest/gsg/CreatingABucket.html).


### PR DESCRIPTION
User complained that local one has `-d` but s3 doesn't.

Disregard the recommendations below if you use **Edit on GitHub** button to improve the docs in place.

❗ Please read the guidelines in the [Contributing to the Documentation](https://dvc.org/doc/user-guide/contributing/docs) list if you make any substantial changes to the documentation or JS engine.

🐛 Please make sure to mention `Fix #issue` (if applicable) in the description of the PR. This enables GitHub to link the PR to the corresponding bug and close it automatically when PR is merged.

Thank you for the contribution - we'll try to review and merge it as soon as possible. 🙏
