### PR TITLE
tooltip: do not use a div container for tooltips

### DIFF
--- a/src/Tooltip/index.js
+++ b/src/Tooltip/index.js
@@ -1,4 +1,4 @@
-import { OnlyDesktop, OnlyMobile } from '../styles'
+import { OnlyDesktopInline, OnlyMobileInline } from '../styles'
 import React, { Component } from 'react'
 
 import DesktopView from './desktop-view'
@@ -37,21 +37,21 @@ class Tooltip extends Component {
     if (this.state.match) {
       return (
         <>
-          <OnlyDesktop>
+          <OnlyDesktopInline>
             <DesktopView
               description={this.state.description}
               header={this.state.header}
               id={this.props.id}
               text={this.props.text}
             />
-          </OnlyDesktop>
-          <OnlyMobile>
+          </OnlyDesktopInline>
+          <OnlyMobileInline>
             <MobileView
               description={this.state.description}
               header={this.state.header}
               text={this.props.text}
             />
-          </OnlyMobile>
+          </OnlyMobileInline>
         </>
       )
     } else {

--- a/src/styles.js
+++ b/src/styles.js
@@ -149,3 +149,21 @@ export const OnlyDesktop = styled.div`
   ${media.phablet`display: none;`};
   ${media.phone`display: none;`};
 `
+
+export const OnlyMobileInline = styled.span`
+  display: none;
+  ${media.giant`display: none;`};
+  ${media.desktop`display: none;`};
+  ${media.tablet`display: none;`};
+  ${media.phablet`display: inline-block;`};
+  ${media.phone`display: inline-block;`};
+`
+
+export const OnlyDesktopInline = styled.span`
+  display: inline-block;
+  ${media.giant`display: inline-block;`};
+  ${media.desktop`display: inline-block;`};
+  ${media.tablet`display: inline-block;`};
+  ${media.phablet`display: none;`};
+  ${media.phone`display: none;`};
+`


### PR DESCRIPTION
This fixes the problem with Tooltips being misplaced on Chrome when the text which shows the Tooltip is on the left hand side of a `<p>`.

This also fixes the annoying warnings from React that a `<div>` is being placed inside of a `<p>`, because now it's a `<span>`.

Note: Currently, if the tooltip is too long, it won't line-break. This PR does not change this, and It's probably a non-issue for now.

Fix #870