### PR TITLE
Fix `dvc get` example

### DIFF
--- a/public/static/docs/command-reference/get.md
+++ b/public/static/docs/command-reference/get.md
@@ -113,7 +113,7 @@ We can also use `dvc get` to retrieve any file or directory that exists in a git
 repository.
 
 ```dvc
-$ dvc get https://github.com/schacon/cowsay/install.sh install.sh
+$ dvc get https://github.com/schacon/cowsay install.sh
 $ ls
 install.sh
 ```


### PR DESCRIPTION
Disregard the recommendations below if you use **Edit on GitHub** button to improve the docs in place.

❗ Please read the guidelines in the [Contributing to the Documentation](https://dvc.org/doc/user-guide/contributing/docs) list if you make any substantial changes to the documentation or JS engine.

🐛 Please make sure to mention `Fix #issue` (if applicable) in the description of the PR. This enables GitHub to link the PR to the corresponding bug and close it automatically when PR is merged.

Thank you for the contribution - we'll try to review and merge it as soon as possible. 🙏


Sorry for polluting with a branch, didn't notice before. It's a simple fix of fixing the repo `url` for `dvc get` example.
