### PR TITLE
Move API calls on community page to client side

### DIFF
--- a/pages/community.js
+++ b/pages/community.js
@@ -1,17 +1,11 @@
 import React from 'react'
 import Head from 'next/head'
 
-import {
-  getLatestIssues,
-  getLatestTopics,
-  getLatestPosts
-} from '../src/utils/api'
-
 import Community from '../src/components/Community'
 
 import { META_BASE_TITLE } from '../src/consts'
 
-export default function CommunityPage(props) {
+export default function CommunityPage() {
   return (
     <>
       <Head>
@@ -28,19 +22,7 @@ export default function CommunityPage(props) {
         />
         <title>Community | {META_BASE_TITLE}</title>
       </Head>
-      <Community {...props} />
+      <Community />
     </>
   )
-}
-
-CommunityPage.getInitialProps = async ({ req }) => {
-  const issues = await getLatestIssues(req)
-  const posts = await getLatestPosts(req)
-  const topics = await getLatestTopics(req)
-
-  return {
-    issues,
-    posts,
-    topics
-  }
 }

--- a/src/components/Community/Learn/index.js
+++ b/src/components/Community/Learn/index.js
@@ -10,6 +10,7 @@ import CommunityBlock from '../Block'
 import CommunityButton from '../Button'
 import CommunitySection from '../Section'
 
+import { getLatestPosts, getCommentsCount } from '../../../utils/api'
 import { pluralizeComments } from '../../../utils/i18n'
 
 import {
@@ -53,9 +54,7 @@ function CommunityBlogPost({
 
   useEffect(() => {
     if (commentsUrl) {
-      fetch(`/api/comments?url=${commentsUrl}`)
-        .then(result => result.json())
-        .then(data => setCount(data.count))
+      getCommentsCount(commentsUrl).then(result => setCount(result))
     }
   }, [])
 
@@ -185,7 +184,17 @@ CommunityDocumentation.propTypes = {
   url: PropTypes.string
 }
 
-export default function CommunityLearn({ posts, theme }) {
+export default function CommunityLearn({ theme }) {
+  const [isPostsLoaded, setIsPostsLoaded] = useState(false)
+  const [posts, setPosts] = useState([])
+
+  useEffect(() => {
+    getLatestPosts().then(result => {
+      setPosts(result)
+      setIsPostsLoaded(true)
+    })
+  }, [])
+
   return (
     <Wrapper>
       <CommunitySection
@@ -255,15 +264,17 @@ export default function CommunityLearn({ posts, theme }) {
                 )
               }
             >
-              {posts.length ? (
+              {!isPostsLoaded && <Placeholder>Loading...</Placeholder>}
+              {isPostsLoaded &&
+                !!posts.length &&
                 posts.map(post => (
                   <CommunityBlogPost
                     {...post}
                     key={post.url}
                     color={theme.color}
                   />
-                ))
-              ) : (
+                ))}
+              {isPostsLoaded && !posts.length && (
                 <Placeholder>Blog is unavailable right now</Placeholder>
               )}
             </CommunityBlock>
@@ -286,7 +297,6 @@ export default function CommunityLearn({ posts, theme }) {
 }
 
 CommunityLearn.propTypes = {
-  posts: PropTypes.array,
   theme: PropTypes.shape({
     backgroundColor: PropTypes.string,
     color: PropTypes.string

--- a/src/components/Community/Learn/index.js
+++ b/src/components/Community/Learn/index.js
@@ -251,7 +251,7 @@ export default function CommunityLearn({ theme }) {
             >
               {!ready && <Placeholder>Loading...</Placeholder>}
               {error && (
-                <Placeholder>Blog is unavailable right now</Placeholder>
+                <Placeholder>Blog unavailable right now</Placeholder>
               )}
               {posts &&
                 posts.map(post => (

--- a/src/components/Community/Learn/index.js
+++ b/src/components/Community/Learn/index.js
@@ -250,9 +250,7 @@ export default function CommunityLearn({ theme }) {
               }
             >
               {!ready && <Placeholder>Loading...</Placeholder>}
-              {error && (
-                <Placeholder>Blog unavailable right now</Placeholder>
-              )}
+              {error && <Placeholder>Blog unavailable right now</Placeholder>}
               {posts &&
                 posts.map(post => (
                   <CommunityBlogPost

--- a/src/components/Community/Meet/index.js
+++ b/src/components/Community/Meet/index.js
@@ -1,4 +1,4 @@
-import React, { useCallback } from 'react'
+import React, { useCallback, useEffect, useState } from 'react'
 import PropTypes from 'prop-types'
 import formatDistanceToNow from 'date-fns/formatDistanceToNow'
 
@@ -8,6 +8,7 @@ import CommunitySection from '../Section'
 
 import { pluralizeComments } from '../../../utils/i18n'
 import { logEvent } from '../../../utils/ga'
+import { getLatestIssues, getLatestTopics } from '../../../utils/api'
 
 import data from '../data'
 
@@ -110,7 +111,24 @@ CommunityIssue.propTypes = {
   color: PropTypes.string
 }
 
-export default function CommunityMeet({ issues, theme, topics }) {
+export default function CommunityMeet({ theme }) {
+  const [isIssuesLoaded, setIsIssuesLoaded] = useState(false)
+  const [issues, setIssues] = useState([])
+
+  const [isTopicsLoaded, setIsTopicsLoaded] = useState(false)
+  const [topics, setTopics] = useState([])
+
+  useEffect(() => {
+    getLatestIssues().then(result => {
+      setIssues(result)
+      setIsIssuesLoaded(true)
+    })
+    getLatestTopics().then(result => {
+      setTopics(result)
+      setIsTopicsLoaded(true)
+    })
+  }, [])
+
   return (
     <Wrapper>
       <CommunitySection
@@ -191,15 +209,17 @@ export default function CommunityMeet({ issues, theme, topics }) {
               }
               icon="/static/img/community/discourse.svg"
             >
-              {topics.length ? (
+              {!isTopicsLoaded && <Placeholder>Loading...</Placeholder>}
+              {isTopicsLoaded &&
+                !!topics.length &&
                 topics.map(topic => (
                   <CommunityTopic
                     {...topic}
                     key={topic.url}
                     color={theme.color}
                   />
-                ))
-              ) : (
+                ))}
+              {isTopicsLoaded && !topics.length && (
                 <Placeholder>Forum is unavailable right now</Placeholder>
               )}
             </CommunityBlock>
@@ -231,15 +251,17 @@ export default function CommunityMeet({ issues, theme, topics }) {
               }
               icon="/static/img/community/github.svg"
             >
-              {issues.length ? (
+              {!isIssuesLoaded && <Placeholder>Loading...</Placeholder>}
+              {isIssuesLoaded &&
+                !!issues.length &&
                 issues.map(issue => (
                   <CommunityIssue
                     {...issue}
                     key={issue.url}
                     color={theme.color}
                   />
-                ))
-              ) : (
+                ))}
+              {isIssuesLoaded && !issues.lengts && (
                 <Placeholder>Github is unavailable right now</Placeholder>
               )}
             </CommunityBlock>

--- a/src/components/Community/Meet/index.js
+++ b/src/components/Community/Meet/index.js
@@ -238,7 +238,7 @@ export default function CommunityMeet({ theme }) {
             >
               {!issuesReady && <Placeholder>Loading...</Placeholder>}
               {issuesError && (
-                <Placeholder>Github is unavailable right now</Placeholder>
+                <Placeholder>Github unavailable right now</Placeholder>
               )}
               {issues &&
                 issues.map(issue => (

--- a/src/components/Community/Meet/index.js
+++ b/src/components/Community/Meet/index.js
@@ -197,7 +197,7 @@ export default function CommunityMeet({ theme }) {
             >
               {!topicsReady && <Placeholder>Loading...</Placeholder>}
               {topicsError && (
-                <Placeholder>Forum is unavailable right now</Placeholder>
+                <Placeholder>Forum unavailable right now</Placeholder>
               )}
               {topics &&
                 topics.map(topic => (

--- a/src/components/Community/Meet/index.js
+++ b/src/components/Community/Meet/index.js
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useState } from 'react'
+import React, { useCallback } from 'react'
 import PropTypes from 'prop-types'
 import formatDistanceToNow from 'date-fns/formatDistanceToNow'
 
@@ -8,7 +8,7 @@ import CommunitySection from '../Section'
 
 import { pluralizeComments } from '../../../utils/i18n'
 import { logEvent } from '../../../utils/ga'
-import { getLatestIssues, getLatestTopics } from '../../../utils/api'
+import { useIssues, useTopics } from '../../../utils/api'
 
 import data from '../data'
 
@@ -112,22 +112,8 @@ CommunityIssue.propTypes = {
 }
 
 export default function CommunityMeet({ theme }) {
-  const [isIssuesLoaded, setIsIssuesLoaded] = useState(false)
-  const [issues, setIssues] = useState([])
-
-  const [isTopicsLoaded, setIsTopicsLoaded] = useState(false)
-  const [topics, setTopics] = useState([])
-
-  useEffect(() => {
-    getLatestIssues().then(result => {
-      setIssues(result)
-      setIsIssuesLoaded(true)
-    })
-    getLatestTopics().then(result => {
-      setTopics(result)
-      setIsTopicsLoaded(true)
-    })
-  }, [])
+  const { erorr: issuesError, ready: issuesReady, result: issues } = useIssues()
+  const { erorr: topicsError, ready: topicsReady, result: topics } = useTopics()
 
   return (
     <Wrapper>
@@ -195,7 +181,7 @@ export default function CommunityMeet({ theme }) {
                 </HeaderLink>
               }
               action={
-                topics.length && (
+                topics && (
                   <CommunityButton
                     theme={theme}
                     href="https://discuss.dvc.org"
@@ -209,9 +195,11 @@ export default function CommunityMeet({ theme }) {
               }
               icon="/static/img/community/discourse.svg"
             >
-              {!isTopicsLoaded && <Placeholder>Loading...</Placeholder>}
-              {isTopicsLoaded &&
-                !!topics.length &&
+              {!topicsReady && <Placeholder>Loading...</Placeholder>}
+              {topicsError && (
+                <Placeholder>Forum is unavailable right now</Placeholder>
+              )}
+              {topics &&
                 topics.map(topic => (
                   <CommunityTopic
                     {...topic}
@@ -219,9 +207,6 @@ export default function CommunityMeet({ theme }) {
                     color={theme.color}
                   />
                 ))}
-              {isTopicsLoaded && !topics.length && (
-                <Placeholder>Forum is unavailable right now</Placeholder>
-              )}
             </CommunityBlock>
           </Item>
           <Item>
@@ -237,7 +222,7 @@ export default function CommunityMeet({ theme }) {
                 </HeaderLink>
               }
               action={
-                issues.length && (
+                issues && (
                   <CommunityButton
                     theme={theme}
                     href="https://github.com/iterative/dvc/issues"
@@ -251,9 +236,11 @@ export default function CommunityMeet({ theme }) {
               }
               icon="/static/img/community/github.svg"
             >
-              {!isIssuesLoaded && <Placeholder>Loading...</Placeholder>}
-              {isIssuesLoaded &&
-                !!issues.length &&
+              {!issuesReady && <Placeholder>Loading...</Placeholder>}
+              {issuesError && (
+                <Placeholder>Github is unavailable right now</Placeholder>
+              )}
+              {issues &&
                 issues.map(issue => (
                   <CommunityIssue
                     {...issue}
@@ -261,9 +248,6 @@ export default function CommunityMeet({ theme }) {
                     color={theme.color}
                   />
                 ))}
-              {isIssuesLoaded && !issues.lengts && (
-                <Placeholder>Github is unavailable right now</Placeholder>
-              )}
             </CommunityBlock>
           </Item>
         </Items>
@@ -273,10 +257,8 @@ export default function CommunityMeet({ theme }) {
 }
 
 CommunityMeet.propTypes = {
-  issues: PropTypes.array,
   theme: PropTypes.shape({
     backgroundColor: PropTypes.string,
     color: PropTypes.string
-  }),
-  topics: PropTypes.array
+  })
 }

--- a/src/components/Community/index.js
+++ b/src/components/Community/index.js
@@ -1,5 +1,4 @@
 import React from 'react'
-import PropTypes from 'prop-types'
 
 import Page from '../Page'
 import Subscribe from '../Subscribe'
@@ -18,23 +17,17 @@ const themes = {
   purple: { backgroundColor: '#DCD6F1', color: '#955DD6' }
 }
 
-export default function Community({ issues, posts, topics }) {
+export default function Community() {
   return (
     <Page stickHeader={true}>
       <PageWrapper>
         <CommunityHero />
-        <CommunityMeet issues={issues} topics={topics} theme={themes.purple} />
+        <CommunityMeet theme={themes.purple} />
         <CommunityContribute theme={themes.orange} />
-        <CommunityLearn posts={posts} theme={themes.green} />
+        <CommunityLearn theme={themes.green} />
         <CommunityEvents theme={themes.purple} />
         <Subscribe />
       </PageWrapper>
     </Page>
   )
-}
-
-Community.propTypes = {
-  issues: PropTypes.array,
-  posts: PropTypes.array,
-  topics: PropTypes.array
 }

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -6,10 +6,9 @@ export function makeAbsoluteURL(req, uri) {
 
   return `${protocol}//${host}${uri}`
 }
-
-export async function getLatestIssues(req) {
+export async function getLatestIssues() {
   try {
-    const res = await fetch(makeAbsoluteURL(req, '/api/github'))
+    const res = await fetch('/api/github')
 
     if (res.status !== 200) return []
 
@@ -23,9 +22,9 @@ export async function getLatestIssues(req) {
   }
 }
 
-export async function getLatestPosts(req) {
+export async function getLatestPosts() {
   try {
-    const res = await fetch(makeAbsoluteURL(req, '/api/blog'))
+    const res = await fetch('/api/blog')
 
     if (res.status !== 200) return []
 
@@ -39,9 +38,9 @@ export async function getLatestPosts(req) {
   }
 }
 
-export async function getLatestTopics(req) {
+export async function getLatestTopics() {
   try {
-    const res = await fetch(makeAbsoluteURL(req, '/api/discourse'))
+    const res = await fetch('/api/discourse')
 
     if (res.status !== 200) return []
 
@@ -52,5 +51,18 @@ export async function getLatestTopics(req) {
     console.error(e)
 
     return []
+  }
+}
+
+export async function getCommentsCount(commentsUrl) {
+  try {
+    const res = await fetch(`/api/comments?url=${commentsUrl}`)
+
+    if (res.status === 200) {
+      const { count } = await res.json()
+      return count
+    }
+  } catch (e) {
+    console.error(e)
   }
 }

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -22,7 +22,7 @@ const useAPICall = url => {
 
         if (!cancelled) {
           if (res.status !== 200) {
-            setError('Wrong response types')
+            setError('Bad response status')
           } else {
             setResult(await res.json())
           }


### PR DESCRIPTION
Right now on community we fetch data from APIs inside `getInitialProps` it locks page render until we get all responses and also prevents us from caching renders results for this page as static html.

This PR moves these requests to the client side.