### PR TITLE
redirects: do not redirect to HTTPS on localhost

### DIFF
--- a/scripts/exclude-links.txt
+++ b/scripts/exclude-links.txt
@@ -18,6 +18,7 @@ https://dvc.org/static/img/<filename>.gif
 https://example.com/data.txt
 https://example.com/foo
 https://example.com/foo/bar?baz
+https://dvc.org/foo/bar?baz
 https://example.com/path/to/data
 https://example.com/path/to/data.csv
 https://example.com/path/to/dir

--- a/src/utils/redirects.js
+++ b/src/utils/redirects.js
@@ -34,7 +34,8 @@ const matchRedirectList = (host, pathname) => {
 }
 
 const getRedirect = (host, pathname, { req, dev } = {}) => {
-  if (req != null && req.headers['x-forwarded-proto'] !== 'https' && !dev) {
+  const httpsRedirect = req != null && !dev && !/^localhost(:\d+)?$/.test(host)
+  if (httpsRedirect && req.headers['x-forwarded-proto'] !== 'https') {
     return [301, `https://${host.replace(/^www\./, '')}${req.url}`]
   }
 

--- a/src/utils/redirects.test.js
+++ b/src/utils/redirects.test.js
@@ -37,8 +37,8 @@ describe('getRedirect', () => {
       url: '/foo/bar?baz'
     }
     expect(
-      getRedirect('www.example.com', '/not-used', { req: fakeReq, dev: false })
-    ).toEqual([301, 'https://example.com/foo/bar?baz'])
+      getRedirect('www.dvc.org', '/not-used', { req: fakeReq, dev: false })
+    ).toEqual([301, 'https://dvc.org/foo/bar?baz'])
   })
 
   const itRedirects = (source, target, code = 301) => {


### PR DESCRIPTION
This prevents an HTTPS redirect while testing with `yarn build && yarn start` on localhost.