### PR TITLE
Fix for 'update' of null error in Sentry

### DIFF
--- a/src/components/Documentation/SidebarMenu/index.js
+++ b/src/components/Documentation/SidebarMenu/index.js
@@ -76,9 +76,11 @@ export default function SidebarMenu({ id, sidebar, currentPath, onClick }) {
     setIsScrollHidden(true)
 
     setTimeout(() => {
-      psRef.current.update()
-      scrollIntoView(node, parent, { onlyScrollIfNeeded: true })
-      setIsScrollHidden(false)
+      if (psRef.current) {
+        psRef.current.update()
+        scrollIntoView(node, parent, { onlyScrollIfNeeded: true })
+        setIsScrollHidden(false)
+      }
     }, 400)
 
     return () => {

--- a/src/components/Documentation/SidebarMenu/index.js
+++ b/src/components/Documentation/SidebarMenu/index.js
@@ -75,15 +75,14 @@ export default function SidebarMenu({ id, sidebar, currentPath, onClick }) {
 
     setIsScrollHidden(true)
 
-    setTimeout(() => {
-      if (psRef.current) {
-        psRef.current.update()
-        scrollIntoView(node, parent, { onlyScrollIfNeeded: true })
-        setIsScrollHidden(false)
-      }
+    const timeout = setTimeout(() => {
+      psRef.current.update()
+      scrollIntoView(node, parent, { onlyScrollIfNeeded: true })
+      setIsScrollHidden(false)
     }, 400)
 
     return () => {
+      clearTimeout(timeout)
       psRef.current.destroy()
       psRef.current = null
     }


### PR DESCRIPTION
We were trying to update Perfect Scrollbar after 400ms timeout. If the was user already left the page it caused an error. Now we only update it if the ref to perfect scrollbar is sill present on page after timeout.

See:

https://sentry.io/organizations/iterative/issues/1529236771/
https://sentry.io/organizations/iterative/issues/1525523962/

And others like that.