### PR TITLE
fonts: prevent browser from changing font-size

### DIFF
--- a/public/static/fonts/fonts.css
+++ b/public/static/fonts/fonts.css
@@ -1,3 +1,9 @@
+/* Prevent mobile browsers from changing font-size */
+* {
+  -webkit-text-size-adjust: none;
+  text-size-adjust: none;
+}
+
 @font-face {
   font-family: BrandonGrotesque;
   src: url('/static/fonts/Brandon_reg.otf');


### PR DESCRIPTION
Since the font-size changed depending on the container, this is probably the text inflation algorithm.

Added a prefixed version because iOS needs it. The unprefixed version is there to avoid the text inflation algorithm on other browsers, and future versions of iOS.

Closes #125