### PR TITLE
Add service account information for GCloud

### DIFF
--- a/public/static/docs/command-reference/remote/modify.md
+++ b/public/static/docs/command-reference/remote/modify.md
@@ -297,7 +297,7 @@ including obtaining the necessary credentials, and how to form `gdrive://` URLs.
   $ dvc remote modify myremote credentialpath /path/to/my/creds/[FILE_NAME].json
   ```
   
-  Google Cloud is migrating to allowing only Service Accounts for application logins. To ensure forward compatibility and better security - its best practice to set up a Goole Sevice account for your project. You can follow these steps:
+  For best practices and to ensure forward compatibility and better security - set up a Goole Sevice account for your project. You can follow these steps:
   
   - [Create a GCloud Service account for the `projectname` above](https://www.google.com/search?client=safari&rls=en&q=gcloud+service+account&ie=UTF-8&oe=UTF-8).
 
@@ -305,7 +305,7 @@ including obtaining the necessary credentials, and how to form `gdrive://` URLs.
   
   - Download the JSON credentials for your newly created service account and store them somewhere safe.
   
-  - Ensure you habve the [gcloud command line tools installed.](https://cloud.google.com/sdk/docs/quickstarts)
+  - Ensure you have the [gcloud command line tools installed.](https://cloud.google.com/sdk/docs/quickstarts)
   
   - Run `gcloud auth login` to ensure you are logged in to your google project.
   

--- a/public/static/docs/command-reference/remote/modify.md
+++ b/public/static/docs/command-reference/remote/modify.md
@@ -296,6 +296,28 @@ including obtaining the necessary credentials, and how to form `gdrive://` URLs.
   ```dvc
   $ dvc remote modify myremote credentialpath /path/to/my/creds/[FILE_NAME].json
   ```
+  
+  Google Cloud is migrating to allowing only Service Accounts for application logins. To ensure forward compatibility and better security - its best practice to set up a Goole Sevice account for your project. You can follow these steps:
+  
+  - [Create a GCloud Service account for the `projectname` above](https://www.google.com/search?client=safari&rls=en&q=gcloud+service+account&ie=UTF-8&oe=UTF-8).
+
+  - Ensure the account has read and write access to any bucket resource hosting the remote `url` you set up above. Best practice is to limit the access credentials to only what the DVC service requires. You can check out the IAM roles for `Storage Object Creator` and `Storage Object Viewer` which limit an account to only create and view .. you guessed it - `Storage Objects`.
+  
+  - Download the JSON credentials for your newly created service account and store them somewhere safe.
+  
+  - Ensure you habve the [gcloud command line tools installed.](https://cloud.google.com/sdk/docs/quickstarts)
+  
+  - Run `gcloud auth login` to ensure you are logged in to your google project.
+  
+  - Run `gcloud auth list` to verify you see both your own account and the service accont you created above.
+  
+  - Set up your `GOOGLE_APPLICATION_CREDENTIALS` environmental variable. This is used to associate credentials for a service account.
+  
+  - `export GOOGLE_APPLICATION_CREDENTIALS="/home/user/Downloads/[FILE_NAME].json"` 
+  
+  - Run DVC from the same terminal session.
+  
+  - You may need to additionally run `gcloud config set account my-service-account-name@my-project-id.iam.gserviceaccount.com` to set the active gcloud auth.
 
 </details>
 


### PR DESCRIPTION
This commit adds some additional instructions to successfully set up a service account and configure a DVC command line remote that is pointing to a GCS bucket to use said service account. 

Its unclear to me if the remote setup needs the separate `GOOGLE_APPLICATION_CREDENTIALS` env call - but it worked here.

Fix #3005

> You may disregard these recommendations if you used the **Edit on GitHub** button from dvc.org to improve a doc in place.

❗ Please read the guidelines in the [Contributing to the Documentation](https://dvc.org/doc/user-guide/contributing/docs) list if you make any substantial changes to the documentation or JS engine.

🐛 Please make sure to mention `Fix #issue` (if applicable) in the description of the PR. This causes GitHub to close it automatically when the PR is merged.

Please chose to [allow us](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to edit your branch when creating the PR.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
