### PR TITLE
deployment: set cache headers

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "debug": "node --inspect-brk server.js",
     "build": "next build",
     "test": "jest",
-    "start": "NODE_ENV=production node server.js",
+    "start": "./scripts/clear-cloudflare-cache.js; NODE_ENV=production node server.js",
     "format-staged": "pretty-quick --staged --no-restage --bail",
     "format-check": "prettier --check '{.,pages/**,public/static/docs/**,src/**}/*.{js,md,json}'",
     "lint-check": "eslint --ext .json,.js src pages",

--- a/scripts/clear-cloudflare-cache.js
+++ b/scripts/clear-cloudflare-cache.js
@@ -1,0 +1,49 @@
+#!/usr/bin/env node
+/* global process */
+
+// This script runs just before the app starts. If we are running the
+// production heroku app (the only one with the below env variables)
+// the cache gets cleared.
+//
+// To clear the cache yourself, you can use the button in the
+// cloudflare dashboard ("Caching tab > Purge everything"), or run
+// this script with the required environment variables:
+//
+// - CLOUDFLARE_TOKEN: a token with the "Zone.Cache Purge" permission.
+// You can generate this token in "My Profile > API Tokens"
+//
+// - CLOUDFLARE_ZONE_ID: The zone ID to purge. You can find it in the
+// sidebar of the "overview" tab for dvc.org
+
+const fetch = require('isomorphic-fetch');
+
+const { CLOUDFLARE_TOKEN, CLOUDFLARE_ZONE_ID } = process.env;
+
+async function main() {
+  const res = await fetch(
+    `https://api.cloudflare.com/client/v4/zones/${CLOUDFLARE_ZONE_ID}/purge_cache`,
+    {
+      method: 'POST',
+      headers: {
+        authorization: `Bearer ${CLOUDFLARE_TOKEN}`,
+        'content-type': 'application/json'
+      },
+      body: JSON.stringify({ purge_everything: true })
+    }
+  );
+
+  const body = await res.text();
+
+  if (!res.ok) {
+    throw new Error('Error response received from CloudFlare: ' + body);
+  }
+
+  console.log('Cleared cache successfully');
+}
+
+if (CLOUDFLARE_TOKEN) {
+  main().catch(e => {
+    console.error(e);
+    process.exit(1);
+  });
+}

--- a/scripts/exclude-links.txt
+++ b/scripts/exclude-links.txt
@@ -8,6 +8,7 @@ https://accounts.google.com/o/oauth2/auth
 https://api.github.com/repos/$
 https://blog.$
 https://circleci.com/gh/iterative/dvc.org
+https://api.cloudflare.com/client/v4/zones/$
 https://code.dvc.org/foo/bar
 https://data.dvc.org/foo/bar
 https://discuss.$

--- a/server.js
+++ b/server.js
@@ -28,10 +28,13 @@ app.prepare().then(() => {
     const { pathname, query } = parsedUrl
     const host = req.headers.host
 
+    res.setHeader('Cache-Control', 'public, max-age=0, s-maxage=99999')
+
     let [redirectCode, redirectLocation] = getRedirect(host, pathname, {
       req,
       dev
     })
+
     if (redirectLocation) {
       // HTTP redirects
 
@@ -40,7 +43,6 @@ app.prepare().then(() => {
         redirectLocation += '?' + queryStr
       }
       res.writeHead(redirectCode, {
-        'Cache-control': 'no-cache',
         Location: redirectLocation
       })
       res.end()


### PR DESCRIPTION
Set some cache headers in dvc.org, such that we can set cloudflare to respect the headers it gets.

These headers are for instant invalidation, making the client validate against cloudflare, but preventing cloudflare from validating against the server. After each deploy, the cache is cleared.