### PR TITLE
[WIP] Gatsby migration fixes

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -85,6 +85,16 @@ if (process.env.CONTEXT === 'production') {
   })
 }
 
+if (process.env.ANALYZE) {
+  plugins.push({
+    resolve: 'gatsby-plugin-webpack-bundle-analyzer',
+    options: {
+      analyzerPort: 4000,
+      production: process.env.NODE_ENV === 'production'
+    }
+  })
+}
+
 module.exports = {
   plugins,
   siteMetadata: {

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -105,10 +105,24 @@ exports.createPages = async ({ graphql, actions }) => {
   })
 }
 
-exports.onCreatePage = ({ page, actions }) => {
-  if (/^\/404/.test(page.path)) {
-    const newPage = { ...page, context: { ...page.context, is404: true } }
+const notFoundRegexp = /^\/404/
+const trailingSlashRegexp = /\/$/
 
+exports.onCreatePage = ({ page, actions }) => {
+  let newPage = page
+
+  if (notFoundRegexp.test(newPage.path)) {
+    newPage = { ...newPage, context: { ...newPage.context, is404: true } }
+  }
+
+  if (page.path !== '/' && trailingSlashRegexp.test(newPage.path)) {
+    newPage = {
+      ...newPage,
+      path: newPage.path.replace(trailingSlashRegexp, '')
+    }
+  }
+
+  if (newPage !== page) {
     actions.deletePage(page)
     actions.createPage(newPage)
   }

--- a/middleware/notFound/index.js
+++ b/middleware/notFound/index.js
@@ -1,8 +1,0 @@
-/* eslint-env node */
-
-const path = require('path')
-
-module.exports = (req, res) => {
-  res.status(404)
-  res.sendFile(path.join(`${__dirname}`, '..', '..', 'public', '404.html'))
-}

--- a/middleware/notFound/index.js
+++ b/middleware/notFound/index.js
@@ -3,5 +3,6 @@
 const path = require('path')
 
 module.exports = (req, res) => {
+  res.status(404)
   res.sendFile(path.join(`${__dirname}`, '..', '..', 'public', '404.html'))
 }

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "react-use": "^13.24.0",
     "rehype-react": "^4.0.1",
     "request": "^2.88.0",
+    "serve-handler": "^6.1.2",
     "slick-carousel": "^1.8.1",
     "styled-components": "^4.4.1",
     "styled-reset": "^4.0.8",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "express": "^4.17.1",
     "gatsby": "^2.19.21",
     "gatsby-link": "^2.2.29",
+    "gatsby-plugin-webpack-bundle-analyzer": "^1.0.5",
     "github-markdown-css": "^3.0.1",
     "isomorphic-fetch": "^2.2.1",
     "lodash.fill": "^3.4.0",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "@reach/router": "^1.3.1",
     "@sentry/browser": "^5.12.1",
     "color": "^3.1.2",
+    "compression": "^1.7.4",
     "date-fns": "^2.8.1",
     "docsearch.js": "^2.6.3",
     "dom-scroll-into-view": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "node-cache": "^5.1.0",
     "perfect-scrollbar": "^1.4.0",
     "prismjs": "^1.19.0",
-    "promise": "^8.1.0",
+    "promise-polyfill": "^8.1.3",
     "prop-types": "^15.7.2",
     "react": "^16.12.0",
     "react-collapse": "^5.0.1",

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "node-cache": "^5.1.0",
     "perfect-scrollbar": "^1.4.0",
     "prismjs": "^1.19.0",
+    "promise": "^8.1.0",
     "prop-types": "^15.7.2",
     "react": "^16.12.0",
     "react-collapse": "^5.0.1",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "url": "git+https://github.com/iterative/dvc.org.git"
   },
   "author": "",
-  "license": "ISC",
+  "license": "Apache-2.0",
   "bugs": {
     "url": "https://github.com/iterative/dvc.org/issues"
   },

--- a/server.js
+++ b/server.js
@@ -2,18 +2,43 @@
 
 const express = require('express')
 const app = express()
+const serveHandler = require('serve-handler')
 
 const apiMiddleware = require('./middleware/api')
 const redirectsMiddleware = require('./middleware/redirects')
-const notFoundMiddleware = require('./middleware/notFound')
 
 const port = process.env.PORT || 3000
 
 app.use(redirectsMiddleware)
 app.use('/api', apiMiddleware)
 
-app.use(express.static('public', { cacheControl: true, maxAge: 0 }))
-
-app.use(notFoundMiddleware)
+app.use((req, res) => {
+  serveHandler(req, res, {
+    public: 'public',
+    cleanUrls: true,
+    trailingSlash: false,
+    directoryListing: false,
+    headers: [
+      {
+        source: '**/*.@(jpg|jpeg|gif|png)',
+        headers: [
+          {
+            key: 'Cache-Control',
+            value: 'max-age=86400'
+          }
+        ]
+      },
+      {
+        source: '!**/*.@(jpg|jpeg|gif|png)',
+        headers: [
+          {
+            key: 'Cache-Control',
+            value: 'max-age=0'
+          }
+        ]
+      }
+    ]
+  })
+})
 
 app.listen(port, () => console.log(`Ready on localhost:${port}!`))

--- a/server.js
+++ b/server.js
@@ -1,14 +1,17 @@
 /* eslint-env node */
 
 const express = require('express')
-const app = express()
+const compression = require('compression')
 const serveHandler = require('serve-handler')
+
+const app = express()
 
 const apiMiddleware = require('./middleware/api')
 const redirectsMiddleware = require('./middleware/redirects')
 
 const port = process.env.PORT || 3000
 
+app.use(compression())
 app.use(redirectsMiddleware)
 app.use('/api', apiMiddleware)
 

--- a/src/components/DocLayout/SidebarMenu/index.js
+++ b/src/components/DocLayout/SidebarMenu/index.js
@@ -76,7 +76,7 @@ export default function SidebarMenu({ id, sidebar, currentPath, onClick }) {
       })
     }
 
-    const node = document.getElementById(currentPath.replace(/\/$/, ''))
+    const node = document.getElementById(currentPath)
     const parent = document.getElementById(id)
 
     setIsScrollHidden(true)

--- a/src/components/DocLayout/index.js
+++ b/src/components/DocLayout/index.js
@@ -1,13 +1,11 @@
-/* global docsearch:readonly */
-
-import React, { useCallback, useEffect, useState } from 'react'
+import React, { useCallback, useState } from 'react'
 import PropTypes from 'prop-types'
 import Hamburger from '../Hamburger'
 import SearchForm from '../SearchForm'
 import MainLayout from '../MainLayout'
 import SidebarMenu from './SidebarMenu'
 
-import { Container, Backdrop, SearchArea, Side, SideToggle } from './styles'
+import { Container, Backdrop, Side, SideToggle } from './styles'
 
 import { structure } from '../../utils/sidebar'
 
@@ -15,28 +13,8 @@ const SIDEBAR_MENU = 'sidebar-menu'
 
 function DocLayout({ children, ...restProps }) {
   const [isMenuOpen, setIsMenuOpen] = useState(false)
-  const [isSearchAvaible, setIsSearchAvaible] = useState(false)
 
   const toggleMenu = useCallback(() => setIsMenuOpen(!isMenuOpen), [isMenuOpen])
-
-  useEffect(() => {
-    try {
-      docsearch
-
-      setIsSearchAvaible(true)
-
-      if (docsearch && isSearchAvaible) {
-        docsearch({
-          apiKey: '755929839e113a981f481601c4f52082',
-          indexName: 'dvc',
-          inputSelector: '#doc-search',
-          debug: false // Set to `true` if you want to inspect the dropdown
-        })
-      }
-    } catch (ReferenceError) {
-      // nothing there
-    }
-  }, [isSearchAvaible])
 
   return (
     <MainLayout {...restProps} isDocPage>
@@ -48,12 +26,7 @@ function DocLayout({ children, ...restProps }) {
         </SideToggle>
 
         <Side isOpen={isMenuOpen}>
-          {isSearchAvaible && (
-            <SearchArea>
-              <SearchForm />
-            </SearchArea>
-          )}
-
+          <SearchForm />
           <SidebarMenu
             sidebar={structure}
             currentPath={restProps.location.pathname}

--- a/src/components/DocLayout/styles.js
+++ b/src/components/DocLayout/styles.js
@@ -78,25 +78,6 @@ export const Side = styled.div`
   `};
 `
 
-export const SearchArea = styled.div`
-  height: 60px;
-  display: flex;
-  align-items: center;
-  background-color: #eef4f8;
-  z-index: 10;
-  position: sticky;
-  top: 0;
-
-  ${media.phablet`
-    position: relative;
-    padding: 0 20px;
-  `};
-
-  form {
-    height: 40px;
-  }
-`
-
 export const SideToggle = styled.div`
   display: none;
   position: fixed;

--- a/src/components/Documentation/Markdown/index.js
+++ b/src/components/Documentation/Markdown/index.js
@@ -55,6 +55,7 @@ ABBR.propTypes = {
 
 const renderAst = new rehypeReact({
   createElement: React.createElement,
+  Fragment: React.Fragment,
   components: { details: Details, abbr: ABBR }
 }).Compiler
 

--- a/src/components/Documentation/Markdown/styles.js
+++ b/src/components/Documentation/Markdown/styles.js
@@ -42,6 +42,10 @@ export const Content = styled.article`
       content: url(/img/external-link.svg);
     }
 
+    .anchor {
+      margin-left: -24px;
+    }
+
     pre[class*='language-'] {
       background: #40354d;
       color: #ccc;

--- a/src/components/Documentation/RightPanel/index.js
+++ b/src/components/Documentation/RightPanel/index.js
@@ -1,9 +1,10 @@
 import React from 'react'
-import Promise from 'promise'
 import PropTypes from 'prop-types'
 import throttle from 'lodash.throttle'
 
 import Tutorials from '../Tutorials'
+
+import { allImagesLoadedInContainer } from '../../../utils/images'
 
 import {
   Description,
@@ -17,25 +18,6 @@ import {
 
 const ROOT_ELEMENT = 'bodybag'
 const MARKDOWN_ROOT = '#markdown-root'
-
-const imageLoaded = url =>
-  new Promise(resolve => {
-    let img = new Image()
-
-    img.addEventListener('load', function onLoad() {
-      resolve()
-      img.removeEventListener('load', onLoad)
-      img = null
-    })
-    img.addEventListener('error', function onError() {
-      resolve()
-      img.removeEventListener('error', onError)
-      img = null
-    })
-    img.src = url
-  })
-
-const allImagesLoaded = urls => Promise.all(urls.map(imageLoaded))
 
 export default class RightPanel extends React.PureComponent {
   state = {
@@ -65,17 +47,10 @@ export default class RightPanel extends React.PureComponent {
     window.removeEventListener('resize', this.updateHeadingsPosition)
   }
 
-  initHeadingsPosition = () => {
-    const imagesUrls = Array.from(
-      document.querySelectorAll(`${MARKDOWN_ROOT} img`)
-    ).map(img => img.src)
-
-    if (imagesUrls.length) {
-      allImagesLoaded(imagesUrls).then(this.updateHeadingsPosition)
-    } else {
-      this.updateHeadingsPosition()
-    }
-  }
+  initHeadingsPosition = () =>
+    allImagesLoadedInContainer(document.querySelector(MARKDOWN_ROOT)).then(
+      this.updateHeadingsPosition
+    )
 
   updateHeadingsPosition = () => {
     const coordinates = this.props.headings.reduce((result, { slug }) => {

--- a/src/components/Layout/index.js
+++ b/src/components/Layout/index.js
@@ -16,6 +16,10 @@ const useAnchorNavigation = () => {
   useEffect(() => {
     const bodybag = document.getElementById('bodybag')
 
+    if (!bodybag) {
+      return
+    }
+
     if (location.hash) {
       const node = document.querySelector(location.hash)
 
@@ -23,7 +27,7 @@ const useAnchorNavigation = () => {
         allImagesLoadedInContainer(bodybag).then(() => node.scrollIntoView())
       }
     } else {
-      bodybag.scrollTo({ top: 0 })
+      bodybag.scrollTop = 0
     }
   }, [location.href])
 }

--- a/src/components/Layout/index.js
+++ b/src/components/Layout/index.js
@@ -6,22 +6,24 @@ import { GlobalStyle } from '../../styles'
 import MainLayout from '../MainLayout'
 import DocLayout from '../DocLayout'
 
+import { allImagesLoadedInContainer } from '../../utils/images'
+
 import './fonts/fonts.css'
 
 const useAnchorNavigation = () => {
   const location = useLocation()
 
   useEffect(() => {
+    const bodybag = document.getElementById('bodybag')
+
     if (location.hash) {
       const node = document.querySelector(location.hash)
 
       if (node) {
-        node.scrollIntoView()
+        allImagesLoadedInContainer(bodybag).then(() => node.scrollIntoView())
       }
     } else {
-      document
-        .getElementById('bodybag')
-        .scrollTo({ top: 0, behavior: 'smooth' })
+      bodybag.scrollTo({ top: 0 })
     }
   }, [location.href])
 }

--- a/src/components/SEO/index.js
+++ b/src/components/SEO/index.js
@@ -37,11 +37,11 @@ function SEO({
 
   const defaultMeta = [
     {
-      property: 'description',
+      name: 'description',
       content: metaDescription
     },
     {
-      property: 'keywords',
+      name: 'keywords',
       content: metaKeywords
     },
     {

--- a/src/components/SearchForm/index.js
+++ b/src/components/SearchForm/index.js
@@ -1,16 +1,55 @@
-import React from 'react'
+import React, { useEffect, useState } from 'react'
+import Promise from 'promise'
+import { loadResource } from '../../utils/resources'
 
-import { Input, Wrapper } from './styles'
+import { SearchArea, Input, Wrapper } from './styles'
 
 export default function SearchForm(props) {
+  const [isLoaded, setLoaded] = useState(false)
+
+  useEffect(() => {
+    // When mailchimp loads it adds AMD support and docsearch define new AMD
+    // unnamed(!) modules instead of global variable
+    if (window.define) {
+      window.define.amd = false
+    }
+
+    Promise.all([
+      loadResource(
+        'https://cdn.jsdelivr.net/npm/docsearch.js@2.6.2/dist/cdn/docsearch.min.css'
+      ),
+      loadResource(
+        'https://cdn.jsdelivr.net/npm/docsearch.js@2.6.2/dist/cdn/docsearch.min.js'
+      )
+    ]).then(() => setLoaded(true))
+  }, [])
+
+  useEffect(() => {
+    if (isLoaded) {
+      window.docsearch &&
+        window.docsearch({
+          apiKey: '755929839e113a981f481601c4f52082',
+          indexName: 'dvc',
+          inputSelector: '#doc-search',
+          debug: false // Set to `true` if you want to inspect the dropdown
+        })
+    }
+  }, [isLoaded])
+
+  if (!isLoaded) {
+    return null
+  }
+
   return (
-    <Wrapper novalidate>
-      <Input
-        type="text"
-        id="doc-search"
-        placeholder={`Search docs`}
-        {...props}
-      />
-    </Wrapper>
+    <SearchArea>
+      <Wrapper novalidate>
+        <Input
+          type="text"
+          id="doc-search"
+          placeholder={`Search docs`}
+          {...props}
+        />
+      </Wrapper>
+    </SearchArea>
   )
 }

--- a/src/components/SearchForm/index.js
+++ b/src/components/SearchForm/index.js
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react'
-import Promise from 'promise'
+import Promise from 'promise-polyfill'
 import { loadResource } from '../../utils/resources'
 
 import { SearchArea, Input, Wrapper } from './styles'

--- a/src/components/SearchForm/styles.js
+++ b/src/components/SearchForm/styles.js
@@ -1,5 +1,26 @@
 import styled from 'styled-components'
 
+import { media } from '../../styles'
+
+export const SearchArea = styled.div`
+  height: 60px;
+  display: flex;
+  align-items: center;
+  background-color: #eef4f8;
+  z-index: 10;
+  position: sticky;
+  top: 0;
+
+  ${media.phablet`
+    position: relative;
+    padding: 0 20px;
+  `};
+
+  form {
+    height: 40px;
+  }
+`
+
 export const Wrapper = styled.form`
   width: 100%;
   height: 100%;

--- a/src/html.js
+++ b/src/html.js
@@ -1,10 +1,7 @@
 /* eslint jsx-a11y/html-has-lang:0 */
 
 import React from 'react'
-import rejectionTracking from 'promise/lib/rejection-tracking'
 import PropTypes from 'prop-types'
-
-rejectionTracking.enable()
 
 export default function HTML(props) {
   return (

--- a/src/html.js
+++ b/src/html.js
@@ -1,7 +1,10 @@
 /* eslint jsx-a11y/html-has-lang:0 */
 
 import React from 'react'
+import rejectionTracking from 'promise/lib/rejection-tracking'
 import PropTypes from 'prop-types'
+
+rejectionTracking.enable()
 
 export default function HTML(props) {
   return (
@@ -12,14 +15,6 @@ export default function HTML(props) {
         <meta
           name="viewport"
           content="width=device-width, initial-scale=1, shrink-to-fit=no"
-        />
-        <link
-          rel="stylesheet"
-          href="https://cdn.jsdelivr.net/npm/docsearch.js@2.6.2/dist/cdn/docsearch.min.css"
-        />
-        <script
-          type="text/javascript"
-          src="https://cdn.jsdelivr.net/npm/docsearch.js@2.6.2/dist/cdn/docsearch.min.js"
         />
         {props.headComponents}
       </head>

--- a/src/html.js
+++ b/src/html.js
@@ -31,7 +31,6 @@ export default function HTML(props) {
           dangerouslySetInnerHTML={{ __html: props.body }}
         />
         {props.postBodyComponents}
-        <div id="modal-root"></div>
         <script
           type="text/javascript"
           src="//downloads.mailchimp.com/js/signup-forms/popup/embed.js"

--- a/src/html.js
+++ b/src/html.js
@@ -1,5 +1,9 @@
 /* eslint jsx-a11y/html-has-lang:0 */
 
+// polyfills
+import 'promise-polyfill/src/polyfill'
+import 'isomorphic-fetch'
+
 import React from 'react'
 import PropTypes from 'prop-types'
 

--- a/src/styles.js
+++ b/src/styles.js
@@ -32,7 +32,8 @@ const global = `
     outline: 0;
   }
 
-  img + em {
+  img + em,
+  .gatsby-highlight + p > em:only-child {
     color: #6a737d;
     font-size: 0.9em;
     display: block;

--- a/src/utils/images.js
+++ b/src/utils/images.js
@@ -1,0 +1,26 @@
+import Promise from 'promise'
+
+export const getImagesUrls = node =>
+  Array.from(node.querySelectorAll('img')).map(img => img.src)
+
+export const imageLoaded = url =>
+  new Promise(resolve => {
+    let img = new Image()
+
+    img.addEventListener('load', function onLoad() {
+      resolve()
+      img.removeEventListener('load', onLoad)
+      img = null
+    })
+    img.addEventListener('error', function onError() {
+      resolve()
+      img.removeEventListener('error', onError)
+      img = null
+    })
+    img.src = url
+  })
+
+export const allImagesLoaded = urls => Promise.all(urls.map(imageLoaded))
+
+export const allImagesLoadedInContainer = node =>
+  allImagesLoaded(getImagesUrls(node))

--- a/src/utils/images.js
+++ b/src/utils/images.js
@@ -1,4 +1,4 @@
-import Promise from 'promise'
+import Promise from 'promise-polyfill'
 
 export const getImagesUrls = node =>
   Array.from(node.querySelectorAll('img')).map(img => img.src)

--- a/src/utils/resources.js
+++ b/src/utils/resources.js
@@ -1,0 +1,37 @@
+import Promise from 'promise'
+
+const resourcesCache = {}
+const resourceNodeCreators = {
+  '\\.js$': ['script', { type: 'text/javascript' }, 'src'],
+  '\\.css$': [
+    'link',
+    { rel: 'stylesheet', type: 'text/css', media: 'all' },
+    'href'
+  ]
+}
+
+export const loadResource = url => {
+  if (!resourcesCache[url]) {
+    resourcesCache[url] = new Promise((resolve, reject) => {
+      const howToHandle = Object.keys(resourceNodeCreators).find(regExp =>
+        new RegExp(regExp).test(url)
+      )
+
+      if (!howToHandle) {
+        throw new Error(`You can't load resource with this url: ${url}`)
+      }
+
+      const [element, opts, urlProp] = resourceNodeCreators[howToHandle]
+      const resourceNode = document.createElement(element)
+
+      resourceNode.onload = resolve
+      resourceNode.onerror = reject
+      Object.keys(opts).forEach(opt => (resourceNode[opt] = opts[opt]))
+
+      resourceNode[urlProp] = url
+      document.head.appendChild(resourceNode)
+    })
+  }
+
+  return resourcesCache[url]
+}

--- a/src/utils/resources.js
+++ b/src/utils/resources.js
@@ -1,4 +1,4 @@
-import Promise from 'promise'
+import Promise from 'promise-polyfill'
 
 const resourcesCache = {}
 const resourceNodeCreators = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1871,6 +1871,11 @@ acorn-walk@^6.0.1:
   resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-6.2.0.tgz#123cb8f3b84c2171f1f7fb252615b1c78a6b1a8c"
   integrity sha512-7evsyfH1cLOCdAzZAd43Cic04yKydNx0cF+7tiA19p1XnLLPU4dpCQOqpjqwokFe//vS0QqfqqjCS2JkiIs0cA==
 
+acorn-walk@^7.1.1:
+  version "7.1.1"
+  resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-7.1.1.tgz#345f0dffad5c735e7373d2fec9a1023e6a44b83e"
+  integrity sha512-wdlPY2tm/9XBr7QkKlq0WQVgiuGTX6YWPyRyBviSoScBuLfTVQhvwg6wJ369GJ/1nPfTLMfnrFIfjqVg6d+jQQ==
+
 acorn@^5.5.3:
   version "5.7.4"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.7.4.tgz#3e8d8a9947d0599a1796d10225d7432f4a4acf5e"
@@ -1885,6 +1890,11 @@ acorn@^7.1.0:
   version "7.1.0"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.1.0.tgz#949d36f2c292535da602283586c2477c57eb2d6c"
   integrity sha512-kL5CuoXA/dgxlBbVrflsflzQ3PAas7RYZB52NOm/6839iVYJgKMJ3cQJD+t2i5+qFa8h3MDpEOJiS64E8JLnSQ==
+
+acorn@^7.1.1:
+  version "7.1.1"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.1.1.tgz#e35668de0b402f359de515c5482a1ab9f89a69bf"
+  integrity sha512-add7dgA5ppRPxCFJoAGfMDi7PIBXq1RtGo7BhbLaxwrXPOmw8gq48Y9ozT01hUKy9byMjlR20EJhu5zlkErEkg==
 
 address@1.0.3:
   version "1.0.3"
@@ -2598,6 +2608,16 @@ better-queue@^3.8.10:
     node-eta "^0.9.0"
     uuid "^3.0.0"
 
+bfj@^6.1.1:
+  version "6.1.2"
+  resolved "https://registry.yarnpkg.com/bfj/-/bfj-6.1.2.tgz#325c861a822bcb358a41c78a33b8e6e2086dde7f"
+  integrity sha512-BmBJa4Lip6BPRINSZ0BPEIfB1wUY/9rwbwvIHQA1KjX9om29B6id0wnWXq7m3bn5JrUVjeOTnVuhPT1FiHwPGw==
+  dependencies:
+    bluebird "^3.5.5"
+    check-types "^8.0.3"
+    hoopy "^0.1.4"
+    tryer "^1.0.1"
+
 big.js@^5.2.2:
   version "5.2.2"
   resolved "https://registry.yarnpkg.com/big.js/-/big.js-5.2.2.tgz#65f0af382f578bcdc742bd9c281e9cb2d7768328"
@@ -3114,6 +3134,11 @@ charenc@~0.0.1:
   resolved "https://registry.yarnpkg.com/charenc/-/charenc-0.0.2.tgz#c0a1d2f3a7092e03774bfa83f14c0fc5790a8667"
   integrity sha1-wKHS86cJLgN3S/qD8UwPxXkKhmc=
 
+check-types@^8.0.3:
+  version "8.0.3"
+  resolved "https://registry.yarnpkg.com/check-types/-/check-types-8.0.3.tgz#3356cca19c889544f2d7a95ed49ce508a0ecf552"
+  integrity sha512-YpeKZngUmG65rLudJ4taU7VLkOCTMhNl/u4ctNC56LQS/zJTyNH0Lrtwm1tfTsbLlwvlfsA2d1c8vCf/Kh2KwQ==
+
 cheerio@^1.0.0-rc.3:
   version "1.0.0-rc.3"
   resolved "https://registry.yarnpkg.com/cheerio/-/cheerio-1.0.0-rc.3.tgz#094636d425b2e9c0f4eb91a46c05630c9a1a8bf6"
@@ -3417,7 +3442,7 @@ command-exists@^1.2.2:
   resolved "https://registry.yarnpkg.com/command-exists/-/command-exists-1.2.8.tgz#715acefdd1223b9c9b37110a149c6392c2852291"
   integrity sha512-PM54PkseWbiiD/mMsbvW351/u+dafwTJ0ye2qB60G1aGQP9j3xK2gmMDc+R34L3nDtx4qMCitXT75mkbkGJDLw==
 
-commander@^2.11.0, commander@^2.20.0, commander@~2.20.3:
+commander@^2.11.0, commander@^2.18.0, commander@^2.20.0, commander@~2.20.3:
   version "2.20.3"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
   integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
@@ -4558,6 +4583,11 @@ ee-first@1.1.1:
   resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
   integrity sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=
 
+ejs@^2.6.1:
+  version "2.7.4"
+  resolved "https://registry.yarnpkg.com/ejs/-/ejs-2.7.4.tgz#48661287573dcc53e366c7a1ae52c3a120eec9ba"
+  integrity sha512-7vmuyh5+kuUyJKePhQfRQBhXV5Ce+RnaeeQArKu1EAMpL3WbgMt5WG6uQZpEVvYSSsxMXRKOewtDk9RaTKXRlA==
+
 electron-to-chromium@^1.3.349, electron-to-chromium@^1.3.47:
   version "1.3.360"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.360.tgz#1db9cb8d43f4c772546d94ea9be8b677a8ecb483"
@@ -5203,7 +5233,7 @@ express-graphql@^0.9.0:
     http-errors "^1.7.3"
     raw-body "^2.4.1"
 
-express@^4.17.1:
+express@^4.16.3, express@^4.17.1:
   version "4.17.1"
   resolved "https://registry.yarnpkg.com/express/-/express-4.17.1.tgz#4491fc38605cf51f8629d39c2b5d026f98a4c134"
   integrity sha512-mHJ9O79RqluphRrcw2X/GTh3k9tVv8YcoyY4Kkh4WDMUYKRZUq0h1o0w2rrrxBqM7VoeUVqgb27xlEMXTnYt4g==
@@ -5439,6 +5469,11 @@ filesize@3.5.11:
   version "3.5.11"
   resolved "https://registry.yarnpkg.com/filesize/-/filesize-3.5.11.tgz#1919326749433bb3cf77368bd158caabcc19e9ee"
   integrity sha512-ZH7loueKBoDb7yG9esn1U+fgq7BzlzW6NRi5/rMdxIZ05dj7GFD/Xc5rq2CDt5Yq86CyfSYVyx4242QQNZbx1g==
+
+filesize@^3.6.1:
+  version "3.6.1"
+  resolved "https://registry.yarnpkg.com/filesize/-/filesize-3.6.1.tgz#090bb3ee01b6f801a8a8be99d31710b3422bb317"
+  integrity sha512-7KjR1vv6qnicaPMi1iiTcI85CyYwRO/PSFCu6SvqL8jN2Wjt/NIYQTFtFs7fSDCYOstUkEWIQGFUg5YZQfjlcg==
 
 fill-range@^4.0.0:
   version "4.0.0"
@@ -5828,6 +5863,13 @@ gatsby-plugin-styled-components@^3.1.19:
   integrity sha512-ME4NSuFe6zzF/PqEoLRt6Xo7su484zwByOsQtQDK4U+X62tXgl+DfsW6Dz1p1k258OeN+uqJERQDaFlfWhfaAw==
   dependencies:
     "@babel/runtime" "^7.7.6"
+
+gatsby-plugin-webpack-bundle-analyzer@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/gatsby-plugin-webpack-bundle-analyzer/-/gatsby-plugin-webpack-bundle-analyzer-1.0.5.tgz#1e47b152cccbc5cbd74415cf70a659f5b5274fb5"
+  integrity sha512-CsdekOGjrWgk5RjymSkz8yKP/lyU6Kx1LmxA8qiUH9qbma+B8dKo3ALd2d6/3E57Wj1jUblTtTZPZCCCYRubMw==
+  dependencies:
+    webpack-bundle-analyzer "^3.3.2"
 
 gatsby-react-router-scroll@^2.1.21:
   version "2.1.21"
@@ -6437,6 +6479,14 @@ gzip-size@3.0.0:
   dependencies:
     duplexer "^0.1.1"
 
+gzip-size@^5.0.0:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/gzip-size/-/gzip-size-5.1.1.tgz#cb9bee692f87c0612b232840a873904e4c135274"
+  integrity sha512-FNHi6mmoHvs1mxZAds4PpdCS6QG8B4C1krxJsMutgxl5t3+GlRTzzI3NEkifXx2pVsOvJdOGSmIgDhQ55FwdPA==
+  dependencies:
+    duplexer "^0.1.1"
+    pify "^4.0.1"
+
 handle-thing@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/handle-thing/-/handle-thing-2.0.0.tgz#0e039695ff50c93fc288557d696f3c1dc6776754"
@@ -6720,6 +6770,11 @@ homedir-polyfill@^1.0.1:
   integrity sha512-eSmmWE5bZTK2Nou4g0AI3zZ9rswp7GRKoKXS1BLUkvPviOqs4YTN1djQIqrXy9k5gEtdLPy86JjRwsNM9tnDcA==
   dependencies:
     parse-passwd "^1.0.0"
+
+hoopy@^0.1.4:
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/hoopy/-/hoopy-0.1.4.tgz#609207d661100033a9a9402ad3dea677381c1b1d"
+  integrity sha512-HRcs+2mr52W0K+x8RzcLzuPPmVIKMSv97RGHy0Ea9y/mpcaK+xTrjICA04KAHi4GRzxliNqNJEFYWHghy3rSfQ==
 
 hosted-git-info@^2.1.4:
   version "2.8.5"
@@ -9806,6 +9861,11 @@ opencollective-postinstall@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/opencollective-postinstall/-/opencollective-postinstall-2.0.2.tgz#5657f1bede69b6e33a45939b061eb53d3c6c3a89"
   integrity sha512-pVOEP16TrAO2/fjej1IdOyupJY8KDUM1CvsaScRbw6oddvpQoOfGk4ywha0HKKVAD6RkW4x6Q+tNBwhf3Bgpuw==
+
+opener@^1.5.1:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/opener/-/opener-1.5.1.tgz#6d2f0e77f1a0af0032aca716c2c1fbb8e7e8abed"
+  integrity sha512-goYSy5c2UXE4Ra1xixabeVh1guIX/ZV/YokJksb6q2lubWu6UbvPQ20p542/sFIll1nl8JnCyK9oBaOcCWXwvA==
 
 opentracing@^0.14.4:
   version "0.14.4"
@@ -13402,6 +13462,11 @@ trough@^1.0.0:
   resolved "https://registry.yarnpkg.com/true-case-path/-/true-case-path-2.2.1.tgz#c5bf04a5bbec3fd118be4084461b3a27c4d796bf"
   integrity sha512-0z3j8R7MCjy10kc/g+qg7Ln3alJTodw9aDuVWZa3uiWqfuBMKeAeP2ocWcxoyM3D73yz3Jt/Pu4qPr4wHSdB/Q==
 
+tryer@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/tryer/-/tryer-1.0.1.tgz#f2c85406800b9b0f74c9f7465b81eaad241252f8"
+  integrity sha512-c3zayb8/kWWpycWYg87P71E1S1ZL6b6IJxfb5fvsUgsf0S2MVGaDhDXXjDMpdCpfWXqptc+4mXwmiy1ypXqRAA==
+
 ts-easing@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/ts-easing/-/ts-easing-0.2.0.tgz#c8a8a35025105566588d87dbda05dd7fbfa5a4ec"
@@ -14103,6 +14168,25 @@ webidl-conversions@^4.0.2:
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-4.0.2.tgz#a855980b1f0b6b359ba1d5d9fb39ae941faa63ad"
   integrity sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==
 
+webpack-bundle-analyzer@^3.3.2:
+  version "3.6.1"
+  resolved "https://registry.yarnpkg.com/webpack-bundle-analyzer/-/webpack-bundle-analyzer-3.6.1.tgz#bdb637c2304424f2fbff9a950c7be42a839ae73b"
+  integrity sha512-Nfd8HDwfSx1xBwC+P8QMGvHAOITxNBSvu/J/mCJvOwv+G4VWkU7zir9SSenTtyCi0LnVtmsc7G5SZo1uV+bxRw==
+  dependencies:
+    acorn "^7.1.1"
+    acorn-walk "^7.1.1"
+    bfj "^6.1.1"
+    chalk "^2.4.1"
+    commander "^2.18.0"
+    ejs "^2.6.1"
+    express "^4.16.3"
+    filesize "^3.6.1"
+    gzip-size "^5.0.0"
+    lodash "^4.17.15"
+    mkdirp "^0.5.1"
+    opener "^1.5.1"
+    ws "^6.0.0"
+
 webpack-dev-middleware@^3.7.2:
   version "3.7.2"
   resolved "https://registry.yarnpkg.com/webpack-dev-middleware/-/webpack-dev-middleware-3.7.2.tgz#0019c3db716e3fa5cecbf64f2ab88a74bab331f3"
@@ -14433,7 +14517,7 @@ ws@^5.2.0:
   dependencies:
     async-limiter "~1.0.0"
 
-ws@^6.2.1:
+ws@^6.0.0, ws@^6.2.1:
   version "6.2.1"
   resolved "https://registry.yarnpkg.com/ws/-/ws-6.2.1.tgz#442fdf0a47ed64f59b6a5d8ff130f4748ed524fb"
   integrity sha512-GIyAXC2cB7LjvpgMt9EKS2ldqr0MTrORaleiOno6TweZ6r3TKtoFQWay/2PceJ3RuBasOHzXNn5Lrw1X0bEjqA==

--- a/yarn.lock
+++ b/yarn.lock
@@ -3558,6 +3558,11 @@ contains-path@^0.1.0:
   resolved "https://registry.yarnpkg.com/contains-path/-/contains-path-0.1.0.tgz#fe8cf184ff6670b6baef01a9d4861a5cbec4120a"
   integrity sha1-/ozxhP9mcLa67wGp1IYaXL7EEgo=
 
+content-disposition@0.5.2:
+  version "0.5.2"
+  resolved "https://registry.yarnpkg.com/content-disposition/-/content-disposition-0.5.2.tgz#0cf68bb9ddf5f2be7961c3a85178cb85dba78cb4"
+  integrity sha1-DPaLud318r55YcOoUXjLhdunjLQ=
+
 content-disposition@0.5.3:
   version "0.5.3"
   resolved "https://registry.yarnpkg.com/content-disposition/-/content-disposition-0.5.3.tgz#e130caf7e7279087c5616c2007d0485698984fbd"
@@ -5332,6 +5337,13 @@ fast-shallow-equal@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fast-shallow-equal/-/fast-shallow-equal-1.0.0.tgz#d4dcaf6472440dcefa6f88b98e3251e27f25628b"
   integrity sha512-HPtaa38cPgWvaCFmRNhlc6NG7pv6NUHqjPgVAkWGoB9mQMwYB27/K0CvOM5Czy+qpT3e8XJ6Q4aPAnzpNpzNaw==
+
+fast-url-parser@1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/fast-url-parser/-/fast-url-parser-1.1.3.tgz#f4af3ea9f34d8a271cf58ad2b3759f431f0b318d"
+  integrity sha1-9K8+qfNNiicc9YrSs3WfQx8LMY0=
+  dependencies:
+    punycode "^1.3.2"
 
 fastest-stable-stringify@^1.0.1:
   version "1.0.1"
@@ -9074,6 +9086,18 @@ mime-db@1.43.0:
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.43.0.tgz#0a12e0502650e473d735535050e7c8f4eb4fae58"
   integrity sha512-+5dsGEEovYbT8UY9yD7eE4XTc4UwJ1jBYlgaQQF38ENsKR3wj/8q8RFZrF9WIZpB2V1ArTVFUva8sAul1NzRzQ==
 
+mime-db@~1.33.0:
+  version "1.33.0"
+  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.33.0.tgz#a3492050a5cb9b63450541e39d9788d2272783db"
+  integrity sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ==
+
+mime-types@2.1.18:
+  version "2.1.18"
+  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.18.tgz#6f323f60a83d11146f831ff11fd66e2fe5503bb8"
+  integrity sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==
+  dependencies:
+    mime-db "~1.33.0"
+
 mime-types@^2.1.12, mime-types@~2.1.19, mime-types@~2.1.24:
   version "2.1.25"
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.25.tgz#39772d46621f93e2a80a856c53b86a62156a6437"
@@ -9152,7 +9176,7 @@ minimatch@3.0.3:
   dependencies:
     brace-expansion "^1.0.0"
 
-minimatch@^3.0.3, minimatch@^3.0.4:
+minimatch@3.0.4, minimatch@^3.0.3, minimatch@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
   integrity sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==
@@ -10187,7 +10211,7 @@ path-is-absolute@^1.0.0:
   resolved "https://registry.yarnpkg.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz#174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f"
   integrity sha1-F0uSaHNVNP+8es5r9TpanhtcX18=
 
-path-is-inside@^1.0.1, path-is-inside@^1.0.2:
+path-is-inside@1.0.2, path-is-inside@^1.0.1, path-is-inside@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/path-is-inside/-/path-is-inside-1.0.2.tgz#365417dede44430d1c11af61027facf074bdfc53"
   integrity sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=
@@ -10211,6 +10235,11 @@ path-to-regexp@0.1.7:
   version "0.1.7"
   resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-0.1.7.tgz#df604178005f522f15eb4490e7247a1bfaa67f8c"
   integrity sha1-32BBeABfUi8V60SQ5yR6G/qmf4w=
+
+path-to-regexp@2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-2.2.1.tgz#90b617025a16381a879bc82a38d4e8bdeb2bcf45"
+  integrity sha512-gu9bD6Ta5bwGrrU8muHzVOBFFREpp2iRkVfhBJahwJ6p6Xw20SjT0MxLnwkjOibQmGSYhiUnf2FLe7k+jcFmGQ==
 
 path-type@^2.0.0:
   version "2.0.0"
@@ -10963,7 +10992,7 @@ punycode@1.3.2:
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.3.2.tgz#9653a036fb7c1ee42342f2325cceefea3926c48d"
   integrity sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=
 
-punycode@^1.2.4, punycode@^1.4.1:
+punycode@^1.2.4, punycode@^1.3.2, punycode@^1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.4.1.tgz#c0d5a63b2718800ad8e1eb0fa5269c84dd41845e"
   integrity sha1-wNWmOycYgArY4esPpSachN1BhF4=
@@ -11039,6 +11068,11 @@ randomfill@^1.0.3:
   dependencies:
     randombytes "^2.0.5"
     safe-buffer "^5.1.0"
+
+range-parser@1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/range-parser/-/range-parser-1.2.0.tgz#f49be6b487894ddc40dcc94a322f611092e00d5e"
+  integrity sha1-9JvmtIeJTdxA3MlKMi9hEJLgDV4=
 
 range-parser@^1.2.1, range-parser@~1.2.1:
   version "1.2.1"
@@ -12152,6 +12186,20 @@ serialize-javascript@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-2.1.2.tgz#ecec53b0e0317bdc95ef76ab7074b7384785fa61"
   integrity sha512-rs9OggEUF0V4jUSecXazOYsLfu7OGK2qIn3c7IPBiffz32XniEp/TX9Xmc9LQfK2nQ2QKHvZ2oygKUGU0lG4jQ==
+
+serve-handler@^6.1.2:
+  version "6.1.2"
+  resolved "https://registry.yarnpkg.com/serve-handler/-/serve-handler-6.1.2.tgz#f05b0421a313fff2d257838cba00cbcc512cd2b6"
+  integrity sha512-RFh49wX7zJmmOVDcIjiDSJnMH+ItQEvyuYLYuDBVoA/xmQSCuj+uRmk1cmBB5QQlI3qOiWKp6p4DUGY+Z5AB2A==
+  dependencies:
+    bytes "3.0.0"
+    content-disposition "0.5.2"
+    fast-url-parser "1.1.3"
+    mime-types "2.1.18"
+    minimatch "3.0.4"
+    path-is-inside "1.0.2"
+    path-to-regexp "2.2.1"
+    range-parser "1.2.0"
 
 serve-index@^1.9.1:
   version "1.9.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2205,6 +2205,11 @@ arrify@^2.0.1:
   resolved "https://registry.yarnpkg.com/arrify/-/arrify-2.0.1.tgz#c9655e9331e0abcd588d2a7cad7e9956f66701fa"
   integrity sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==
 
+asap@~2.0.6:
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/asap/-/asap-2.0.6.tgz#e50347611d7e690943208bbdafebcbc2fb866d46"
+  integrity sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=
+
 asn1.js@^4.0.0:
   version "4.10.1"
   resolved "https://registry.yarnpkg.com/asn1.js/-/asn1.js-4.10.1.tgz#b9c2bf5805f1e64aadeed6df3a2bfafb5a73f5a0"
@@ -10841,6 +10846,13 @@ promise-inflight@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/promise-inflight/-/promise-inflight-1.0.1.tgz#98472870bf228132fcbdd868129bad12c3c029e3"
   integrity sha1-mEcocL8igTL8vdhoEputEsPAKeM=
+
+promise@^8.1.0:
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/promise/-/promise-8.1.0.tgz#697c25c3dfe7435dd79fcd58c38a135888eaf05e"
+  integrity sha512-W04AqnILOL/sPRXziNicCjSNRruLAuIHEOVBazepu0545DDNGYHz7ar9ZgZ1fMU8/MA4mVxp5rkBWRi6OXIy3Q==
+  dependencies:
+    asap "~2.0.6"
 
 prompts@^2.0.1:
   version "2.3.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2215,11 +2215,6 @@ arrify@^2.0.1:
   resolved "https://registry.yarnpkg.com/arrify/-/arrify-2.0.1.tgz#c9655e9331e0abcd588d2a7cad7e9956f66701fa"
   integrity sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==
 
-asap@~2.0.6:
-  version "2.0.6"
-  resolved "https://registry.yarnpkg.com/asap/-/asap-2.0.6.tgz#e50347611d7e690943208bbdafebcbc2fb866d46"
-  integrity sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=
-
 asn1.js@^4.0.0:
   version "4.10.1"
   resolved "https://registry.yarnpkg.com/asn1.js/-/asn1.js-4.10.1.tgz#b9c2bf5805f1e64aadeed6df3a2bfafb5a73f5a0"
@@ -10936,12 +10931,10 @@ promise-inflight@^1.0.1:
   resolved "https://registry.yarnpkg.com/promise-inflight/-/promise-inflight-1.0.1.tgz#98472870bf228132fcbdd868129bad12c3c029e3"
   integrity sha1-mEcocL8igTL8vdhoEputEsPAKeM=
 
-promise@^8.1.0:
-  version "8.1.0"
-  resolved "https://registry.yarnpkg.com/promise/-/promise-8.1.0.tgz#697c25c3dfe7435dd79fcd58c38a135888eaf05e"
-  integrity sha512-W04AqnILOL/sPRXziNicCjSNRruLAuIHEOVBazepu0545DDNGYHz7ar9ZgZ1fMU8/MA4mVxp5rkBWRi6OXIy3Q==
-  dependencies:
-    asap "~2.0.6"
+promise-polyfill@^8.1.3:
+  version "8.1.3"
+  resolved "https://registry.yarnpkg.com/promise-polyfill/-/promise-polyfill-8.1.3.tgz#8c99b3cf53f3a91c68226ffde7bde81d7f904116"
+  integrity sha512-MG5r82wBzh7pSKDRa9y+vllNHz3e3d4CNj1PQE4BQYxLme0gKYYBm9YENq+UkEikyZ0XbiGWxYlVw3Rl9O/U8g==
 
 prompts@^2.0.1:
   version "2.3.0"


### PR DESCRIPTION
Fixes related to issues that we got after migrating to Gatsby.js in [this PR](https://github.com/iterative/dvc.org/pull/1025)

- [x]  404 code is not returned on 404
- [x] if I open https://dvc.org/doc/tutorials/versioning#automating-capturing Automatic Capturing is not highlighted on the right sidebar (and it’s not even active)
- [x]  go to the last anchor https://dvc.org/doc/tutorials/versioning#whats-next and then click Interactive Tutorial - behavior between previous version and the current one should be the same (no long scrolling animation)
- [x] styles are broken (different) in the new version - go carefully through all of them - make sure that docs are identical, inline code blocks, line spacing, list items spacing, notes, notes, cases like titles with links, etc, etc
- [x] in a Phablet mode Edit on Github button creates a second line (it might be related to styles issue - we already have two lines in the new version, compared to the previous one)
- [x] SEO problems - run Lighthouse new and old version
- [x] image subtitles are broken - check this page https://dvc.org/doc/tutorials/versioning , (Who doesn’t love ASCII directory art?)
- [x] make sure that GA runs the same way as before, with all the events
- [x] check Sentry - we are getting some new errors, hard to tell what page they come from, from what action