### PR TITLE
Open footer social links in the new tab

### DIFF
--- a/src/components/Footer/index.js
+++ b/src/components/Footer/index.js
@@ -21,7 +21,7 @@ import {
 const docsPage = getFirstPage()
 
 const SocialLink = ({ src, href, children }) => (
-  <Link src={src} href={href}>
+  <Link src={src} href={href} target="_blank" rel="noreferrer noopener">
     {children}
   </Link>
 )


### PR DESCRIPTION
Now discord link in the footer doesn't work. It happens because Gatsby.js don't know anything about `/chat` redirect in the server.js. I suggest open these links in the new tab as it is for the same links in the header.
But also I think that we should duplicate redirects on front side and I have plan to do this in the merging PR.
