### PR TITLE
docs: version: update output

### DIFF
--- a/content/docs/command-reference/version.md
+++ b/content/docs/command-reference/version.md
@@ -18,9 +18,11 @@ usage: dvc version [-h] [-q | -v]
 | `Python version`                            | Version of Python used in the environment where DVC is initialized                                                                                                    |
 | `Platform`                                  | Information about the operating system of the machine                                                                                                                 |
 | [`Binary`](#what-we-mean-by-binary)         | Shows whether DVC was installed from a package or from a binary release                                                                                               |
-| `Package manager`                           | Name of the package manager used to install DVC if any (`pip`, `conda`, etc)                                                                                          |
+| `Package`                                   | Name of the package manager used to install DVC if any (`pip`, `conda`, etc)                                                                                          |
+| `Supported remotes`                         | Remote types that have all needed dependencies installed for                                                                                                          |
 | `Cache`                                     | [Type of links](/doc/user-guide/large-dataset-optimization#file-link-types-for-the-dvc-cache) supported between the <abbr>workspace</abbr> and the <abbr>cache</abbr> |
 | `Filesystem type`                           | Shows the filesystem type (eg. ext4, FAT, etc.) and mount point of the cache and <abbr>workspace</abbr> directories                                                   |
+| `Repo`                                      | Shows whether we are in a DVC repo and/or Git repo                                                                                                                    |
 
 > If `dvc version` is executed outside a DVC project, no `Cache` is output and
 > the `Filesystem type` output is of the current working directory.
@@ -114,7 +116,9 @@ Python version: 3.7.1
 Platform: Linux-4.15.0-50-generic-x86_64-with-debian-buster-sid
 Binary: False
 Cache: reflink - False, hardlink - True, symlink - True
+Supported remotes: azure, gdrive, gs, hdfs, http, https, s3, ssh, oss
 Filesystem type (cache directory): ('ext4', '/dev/sdb3')
+Repo: dvc, git
 Filesystem type (workspace): ('ext4', '/dev/sdb3')
 ```
 
@@ -127,5 +131,6 @@ DVC version: 0.41.3+f36162
 Python version: 3.7.1
 Platform: Linux-4.15.0-50-generic-x86_64-with-debian-buster-sid
 Binary: False
+Supported remotes: azure, gdrive, gs, hdfs, http, https, s3, ssh, oss
 Filesystem type (workspace): ('ext4', '/dev/sdb3')
 ```


### PR DESCRIPTION
`dvc version` output was adjusted for urgent debugging purposes and I didn't
send a doc update because it is terribly ugly right now anyway. Instead, I've
created https://github.com/iterative/dvc/issues/3499 to tackle that, but
@shcheklein reasonably requested a temporary doc update just for the
sake of it, so here we go.

> You may disregard these recommendations if you used the **Edit on GitHub** button from dvc.org to improve a doc in place.

❗ Please read the guidelines in the [Contributing to the Documentation](https://dvc.org/doc/user-guide/contributing/docs) list if you make any substantial changes to the documentation or JS engine.

🐛 Please make sure to mention `Fix #issue` (if applicable) in the description of the PR. This causes GitHub to close it automatically when the PR is merged.

Please chose to [allow us](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to edit your branch when creating the PR.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
