### PR TITLE
Fix build on Windows

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -53,7 +53,8 @@ exports.onCreateNode = ({ node, actions, getNode }) => {
   const { createNodeField } = actions
 
   if (node.internal.type === 'MarkdownRemark') {
-    const contentPath = path.join(__dirname, 'content')
+    // We need replace to fix paths on Windows and Git-bash
+    const contentPath = path.join(__dirname, 'content').replace(/\\/g, '/')
     const source = node.fileAbsolutePath.replace(contentPath, '')
     let value
 

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -53,7 +53,7 @@ exports.onCreateNode = ({ node, actions, getNode }) => {
   const { createNodeField } = actions
 
   if (node.internal.type === 'MarkdownRemark') {
-    // We need replace to fix paths on Windows and Git-bash
+    // We need replace to fix paths for Windows
     const contentPath = path.join(__dirname, 'content').replace(/\\/g, '/')
     const source = node.fileAbsolutePath.replace(contentPath, '')
     let value


### PR DESCRIPTION
On Windows it returns paths with backslashes https://github.com/iterative/dvc.org/pull/1109/commits/36ead01363386b7e9c9f204bc4a4c9483a3c61e3#diff-fda05457e393bada716f508859bfc604R57
But `node.fileAbsolutePath` contains path with normal slashes.