### PR TITLE
Removed repeating 'myremote' remote name

### DIFF
--- a/content/docs/user-guide/setup-google-drive-remote.md
+++ b/content/docs/user-guide/setup-google-drive-remote.md
@@ -48,13 +48,13 @@ folder i.e. `gdrive://<base>/path/to/folder`. The base can be one of:
    (these two can only be referenced by ID).
 
    ```dvc
-   $ dvc remote add myremote myremote gdrive://0AIac4JZqHhKmUk9PDA
+   $ dvc remote add myremote gdrive://0AIac4JZqHhKmUk9PDA
    ```
 
    or
 
    ```dvc
-   $ dvc remote add myremote myremote \
+   $ dvc remote add myremote \
                          gdrive://0AIac4JZqHhKmUk9PDA/Data/text
    ```
 


### PR DESCRIPTION
There was double remote name, so it didn't work.