### PR TITLE
Rebuilds caching improvements

### DIFF
--- a/scripts/deploy-with-s3.js
+++ b/scripts/deploy-with-s3.js
@@ -24,10 +24,10 @@ const { remove, move, ensureDir } = require('fs-extra')
 const { s3Prefix, s3Bucket, s3Client } = require('./s3-utils')
 const { cleanUpPageData } = require('./page-data-utils')
 
-const rootDir = path.join(__dirname, '..')
 const cacheDirName = '.cache'
 const publicDirName = 'public'
 
+const rootDir = process.cwd()
 function localPath(dirName) {
   return path.join(rootDir, dirName)
 }

--- a/scripts/deploy-with-s3.js
+++ b/scripts/deploy-with-s3.js
@@ -133,9 +133,9 @@ async function main() {
     run('yarn build')
   }
 
-  console.time('Cleaned up outdated page data files for')
+  console.time('Cleaned up outdated page data files in')
   cleanUpPageData()
-  console.timeEnd('Cleaned up outdated page data files for')
+  console.timeEnd('Cleaned up outdated page data files in')
 
   await move(
     path.join(localPath(publicDirName), '404.html'),

--- a/scripts/deploy-with-s3.js
+++ b/scripts/deploy-with-s3.js
@@ -69,7 +69,7 @@ async function downloadFromS3(prefix, dir) {
     await ensureDir(localDirPath)
 
     console.log(`Downloading "${dir}" from s3://${s3Bucket}/${staticPrefix}`)
-    console.time(`"${dir}" downloaded for`)
+    console.time(`"${dir}" downloaded in`)
     await syncCall('downloadDir', {
       localDir: localDirPath,
       s3Params: {
@@ -77,7 +77,7 @@ async function downloadFromS3(prefix, dir) {
         Prefix: staticPrefix
       }
     })
-    console.timeEnd(`"${dir}" downloaded for`)
+    console.timeEnd(`"${dir}" downloaded in`)
   } catch (downloadError) {
     console.error('Error downloading initial data', downloadError)
     // Don't propagate. It's just a cache warming step
@@ -90,7 +90,7 @@ async function downloadAllFromS3(prefix) {
 
 async function uploadToS3(dir) {
   console.log(`Uploading "${dir}" to s3://${s3Bucket}/${s3Prefix}/${dir}`)
-  console.time(`"${dir}" uploaded for`)
+  console.time(`"${dir}" uploaded in`)
   await syncCall('uploadDir', {
     localDir: localPath(dir),
     deleteRemoved: true,
@@ -99,7 +99,7 @@ async function uploadToS3(dir) {
       Prefix: `${s3Prefix}/${dir}`
     }
   })
-  console.timeEnd(`"${dir}" uploaded for`)
+  console.timeEnd(`"${dir}" uploaded in`)
 }
 
 async function uploadAllToS3() {

--- a/scripts/deploy-with-s3.js
+++ b/scripts/deploy-with-s3.js
@@ -32,6 +32,8 @@ function localPath(dirName) {
   return path.join(rootDir, dirName)
 }
 
+const cacheDirs = [cacheDirName, publicDirName]
+
 function run(command) {
   execSync(command, {
     stdio: ['pipe', process.stdout, process.stderr]
@@ -83,8 +85,7 @@ async function downloadFromS3(prefix, dir) {
 }
 
 async function downloadAllFromS3(prefix) {
-  await downloadFromS3(prefix, publicDirName)
-  await downloadFromS3(prefix, cacheDirName)
+  return Promise.all(cacheDirs.map(dir => downloadFromS3(prefix, dir)))
 }
 
 async function uploadToS3(dir) {
@@ -102,13 +103,11 @@ async function uploadToS3(dir) {
 }
 
 async function uploadAllToS3() {
-  await uploadToS3(publicDirName)
-  await uploadToS3(cacheDirName)
+  return Promise.all(cacheDirs.map(uploadToS3))
 }
 
 async function clean() {
-  await remove(localPath(publicDirName))
-  await remove(localPath(cacheDirName))
+  return Promise.all(cacheDirs.map(dir => remove(localPath(dir))))
 }
 
 async function main() {

--- a/scripts/page-data-utils.js
+++ b/scripts/page-data-utils.js
@@ -62,7 +62,7 @@ const checkPageDataPath = (dir, pagesTree) => {
     if (itemStat.isDirectory()) {
       if (!pagesTree[item]) {
         console.warn(
-          `delete page-data folder for unexisted page at ${itemPath}`
+          `deleting page-data folder for outdated page at ${itemPath}`
         )
         return deleteDir(itemPath)
       } else {

--- a/scripts/page-data-utils.js
+++ b/scripts/page-data-utils.js
@@ -41,7 +41,7 @@ const buildTree = pages => {
 const deleteDir = dir => {
   if (fs.existsSync(dir)) {
     fs.readdirSync(dir).forEach(item => {
-      const currentPath = path.join(path, item)
+      const currentPath = path.join(dir, item)
       if (fs.lstatSync(currentPath).isDirectory()) {
         deleteFolderRecursive(currentPath)
       } else {

--- a/scripts/page-data-utils.js
+++ b/scripts/page-data-utils.js
@@ -65,7 +65,6 @@ const checkPageDataPath = (dir, pagesTree) => {
           `delete page-data folder for unexisted page at ${itemPath}`
         )
         return deleteDir(itemPath)
-        return
       } else {
         checkPageDataPath(itemPath, pagesTree[item])
       }


### PR DESCRIPTION
This PR-for-a-PR does a few things for this branch

- Fixes a breaking issue where `path.join` was being called with `path`
- Runs S3 downloads and uploads in parallel
- Changes some grammar in the console logs to read more smoothly (I'm open to reverting this if I'm misunderstanding)