### PR TITLE
Ensure icon on sidebar bullets is rotated when link is active

### DIFF
--- a/src/components/Documentation/Layout/SidebarMenu/styles.module.css
+++ b/src/components/Documentation/Layout/SidebarMenu/styles.module.css
@@ -75,11 +75,11 @@
     height: 5px;
     width: 8px;
     background: url('/img/triangle_dark.svg') no-repeat center center;
-
-    &.active {
-      transform: rotate(-90deg);
-    }
   }
+}
+
+.active::before {
+  transform: rotate(-90deg);
 }
 
 .footer {

--- a/src/components/Documentation/Layout/SidebarMenu/styles.module.css
+++ b/src/components/Documentation/Layout/SidebarMenu/styles.module.css
@@ -78,8 +78,14 @@
   }
 }
 
+@keyframes rotateIcon {
+  100% {
+    transform: rotate(-90deg);
+  }
+}
+
 .active::before {
-  transform: rotate(-90deg);
+  animation: rotateIcon 0.5s forwards;
 }
 
 .footer {


### PR DESCRIPTION
Fix #1143 

Ensure the icon for the sidebar links is rotated for active links

I traced the issue back to the the CSS modules migration https://github.com/iterative/dvc.org/pull/1106

Solution:
Nest the icon rotate CSS rule under the `.active` class, for it to take effect when the `.active` class is added

Before (all icons face down)
<img width="559" alt="Screenshot 2020-04-16 at 16 54 06" src="https://user-images.githubusercontent.com/3721994/79464616-f6f89e80-8002-11ea-9db0-71885e876528.png">


After (active icons face right)
<img width="521" alt="Screenshot 2020-04-16 at 16 54 17" src="https://user-images.githubusercontent.com/3721994/79464632-fd871600-8002-11ea-9cb9-2e539283962a.png">
