### PR TITLE
[accessibility] hide the mobile menu on desktop from keyboard users.

### DIFF
--- a/src/components/HamburgerMenu/styles.module.css
+++ b/src/components/HamburgerMenu/styles.module.css
@@ -4,6 +4,7 @@
 
 .wrapper {
   display: block;
+  visibility: hidden;
   padding: 25px 15px 15px;
   position: fixed;
   z-index: 11;
@@ -18,6 +19,10 @@
   color: #fff;
   overflow-y: auto;
 
+  @media (--xs-scr) {
+    visibility: visible;
+  }
+
   &.opened {
     transform: translateX(0);
   }
@@ -26,6 +31,7 @@
 .toggleButton {
   position: fixed;
   display: none;
+  visibility: hidden;
   z-index: 999;
   right: 15px;
   top: 25px;
@@ -35,6 +41,7 @@
 
   @media (--xs-scr) {
     display: block;
+    visibility: visible;
   }
 }
 


### PR DESCRIPTION
Fixes the following from  #1149 

![image](https://user-images.githubusercontent.com/46004116/79691531-96bf6200-8279-11ea-85b4-d5cf9e8a5250.png)
 