### PR TITLE
Fix share buttons by importing slug via GraphQL

### DIFF
--- a/src/templates/blog-post.tsx
+++ b/src/templates/blog-post.tsx
@@ -79,6 +79,7 @@ export const pageQuery = graphql`
   query BlogPostPage($id: String!) {
     blogPost(id: { eq: $id }) {
       id
+      slug
       html
       timeToRead
       title


### PR DESCRIPTION
I overlooked re-adding the page slug when the schema changed in the Models update. It's being destructured and defined, it just wasn't imported in GraphQL.

Fixes  #1178