### PR TITLE
link-check: fix exclusions

### DIFF
--- a/scripts/exclude-links-check.sh
+++ b/scripts/exclude-links-check.sh
@@ -3,11 +3,12 @@
 set -euo pipefail
 
 source "$(dirname "$0")"/utils.sh
+base_url="${CHECK_LINKS_RELATIVE_URL:-https://dvc.org}"
 exclude="${CHECK_LINKS_EXCLUDE_LIST:-$(dirname "$0")/exclude-links.txt}"
 [ -f "$exclude" ] && exclude="$(cat "$exclude")"
 
 missing="$(
-  urlfinder $(git ls-files '*.css' '*.js' '*.jsx' '*.md' '*.tsx' '*.ts' '*.json' ':!redirects-list.json' ':!*.test.js') \
+  urlfinder "$base_url" $(git ls-files '*.css' '*.js' '*.jsx' '*.md' '*.tsx' '*.ts' '*.json' ':!redirects-list.json' ':!*.test.js') \
   | sed 's/#.*//g' | sort -u \
   | comm -13 - <(echo "$exclude" | sort -u)
 )"

--- a/scripts/exclude-links.txt
+++ b/scripts/exclude-links.txt
@@ -9,6 +9,8 @@ https://api.github.com/repos/$
 https://circleci.com/gh/iterative/dvc.org
 https://discuss.$
 https://drive.google.com/drive/folders/0AIac4JZqHhKmUk9PDA
+https://dvc.org/img/<filename>.gif
+https://dvc.org/uploads/images/2020-02-10/image.png
 https://example.com/data.txt
 https://example.com/file.csv
 https://example.com/path/to/data.csv

--- a/scripts/link-check-git-all.sh
+++ b/scripts/link-check-git-all.sh
@@ -7,8 +7,8 @@ pushd "$repo"
 # can't do git ls-files since some may be untracked
 (find .github/ content/docs/ src/ \
   -name '*.css' -o -name '*.js' -o -name '*.jsx' -o -name '*.md' -o -name '*.tsx' -o \
-  -name '*.ts' -o -name '*.json' && ls *.js *.jsx *.md *.tsx *.ts *.json) \
-  | grep -Ev '(redirects-list\.json|\.test\.js)$' \
+  -name '*.ts' -o -name '*.json' && ls *.css *.js *.jsx *.md *.tsx *.ts *.json) \
+  | grep -Ev '(package-lock\.json|redirects-list\.json|\.test\.js)$' \
   | xargs -n1 -P8 "$(dirname "$0")"/link-check.sh
 
 popd


### PR DESCRIPTION
- [x] add `*.css` to daily checks
- [x] fix missing `base_url` in `yarn link-check-exclude`
- [x] exclude `package-lock.json` (otherwise takes a massive amount of time for local runs)
- [x] add exclusions
```
ERROR:404:https://dvc.org/img/<filename>.gif
ERROR:404:https://dvc.org/uploads/images/2020-02-10/image.png
```
- ~~consider adding these (warnings) to exclusions?~~
```
WARNING:000:http://0.0.0.0:$
WARNING:000:http://$
```
- related #1189, #1169

Tip: run full test locally using `yarn link-check >> /dev/null` to only see errors (takes a few min, runs using 8 processes).