### PR TITLE
Explicitly add node_modules to cacheDirectories for Heroku

### DIFF
--- a/package.json
+++ b/package.json
@@ -162,5 +162,8 @@
     "*.css": [
       "yarn stylelint --fix"
     ]
-  }
+  },
+  "cacheDirectories": [
+    "node_modules"
+  ]
 }


### PR DESCRIPTION
Adding `node_modules` to `cacheDirectories` seems to download a more complete cache than the default behavior, despite the node buildpack docs saying node_modules are cached by default.

While out of the scope of a git PR, another part of reducing rebuild time on Heroku is setting the environment variable `YARN_PRODUCTION` to `false` so Heroku doesn't waste over a minute pruning devDependencies. 
I tried just moving the Gatsby packages from devDependencies to dependencies, but it takes nearly as long to prune a minimal set of devDependencies as it does with all of them.
Even without pruning devDependencies we're way below the slug max, and I don't see it growing a few hundred MB any time soon. This will be even less of a problem once images are removed from the source repo, though if the images do pose a problem we should be able to remove them like `public` and `.cache` after the build.