### PR TITLE
Fix Windows development

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,7 +78,8 @@
     "scroll": "^3.0.1",
     "serve-handler": "^6.1.2",
     "slick-carousel": "^1.8.1",
-    "unist-util-visit": "2.0.2"
+    "unist-util-visit": "2.0.2",
+    "upath": "^1.2.0"
   },
   "devDependencies": {
     "@babel/core": "^7.9.0",

--- a/src/gatsby/utils/resolvers/index.js
+++ b/src/gatsby/utils/resolvers/index.js
@@ -1,4 +1,4 @@
-const path = require('path')
+const path = require('upath')
 
 /** Source Path Resolver Builder
    This function makes Gatsby resolvers that connect a node to another node via

--- a/yarn.lock
+++ b/yarn.lock
@@ -16982,7 +16982,7 @@ unset-value@^1.0.0:
     has-value "^0.3.1"
     isobject "^3.0.0"
 
-upath@^1.1.1:
+upath@^1.1.1, upath@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/upath/-/upath-1.2.0.tgz#8f66dbcd55a883acdae4408af8b035a5044c1894"
   integrity sha512-aZwGpamFO61g3OlfT7OQCHqhGnW43ieH9WZeP7QxN/G/jS4jfqUkZxoryvJgVPEcrl5NL/ggHsSmLMHuH64Lhg==


### PR DESCRIPTION
Ever since Models dropped, we use `path.join` to resolve links between files at build time (e.g. Blog Posts and Authors). I believe this is what's breaking Windows development, so I used a small module called `upath` that wraps the path API with cross-platform safe versions of functions like `join`.

`upath` is already installed by another module as you can see in `yarn.lock`, but the other package specifies an earlier version. The minimal size difference at build time and completely unchanged bundle size make it not worth pinning our usage to the same version, in my opinion.

Fixes #1204, or at least I think it does. It will before merging, at least.