### PR TITLE
Add a script in package.json enabling "yarn run dev"

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "index.js",
   "scripts": {
     "develop": "gatsby develop",
+    "dev": "gatsby develop",
     "build": "gatsby build",
     "start": "./scripts/clear-cloudflare-cache.js; node ./src/server/index.js",
     "heroku-postbuild": "./scripts/deploy-with-s3.js",


### PR DESCRIPTION
Fulfilling a simple request from #1084, up to the team whether to accept it or not.
I think this also finally fixes #1084, as Models seems to have enabled the sidebar to hot reload.

The last bit about clearing the cache comes from an understandable misconception, I believe. Clearing Gatsby's cache all the time would mean we need to spend ~10m transforming images each build- any HMR issues within Gatsby should be able to be solved without blowing away cache all the time when properly implemented.