### PR TITLE
Make Link component recognize mailto links

### DIFF
--- a/src/components/Link/index.tsx
+++ b/src/components/Link/index.tsx
@@ -15,13 +15,14 @@ export type ILinkProps = {
 
 const PROTOCOL_REGEXP = /^https?:\/\//
 const isRelative = (url: string): boolean => !PROTOCOL_REGEXP.test(url)
+const isMailto = (url: string): boolean => url.startsWith('mailto:')
 
 const ResultLinkComponent: React.FC<ILinkProps> = ({
   href,
   children,
   ...restProps
 }) => {
-  if (!isRelative(href) || restProps.target) {
+  if (!isRelative(href) || isMailto(href) || restProps.target) {
     let rel = 'noopener noreferrer'
 
     if (restProps.rel) {


### PR DESCRIPTION
Basically, Gatsby Link is only for regular links within the site. We currently have a wrapper that chooses whether to use it or a raw `a` tag depending on if the link is within the site or not. This change adds a step to that check that filters out links that start with `mailto:`, making them work properly wherever this wrapper component is used, like the support page.

Fixes #1201