### PR TITLE
Fix and improve cache pruning

### DIFF
--- a/src/gatsby/prune-cache.js
+++ b/src/gatsby/prune-cache.js
@@ -1,9 +1,18 @@
-const fs = require('fs').promises
+const fs = require('fs')
 const crawlPageData = require('../utils/shared/crawlPageData')
 
 async function removeFile(filePath) {
-  console.log(`Removing stale page-data at "${filePath}"`)
-  return fs.unlink(filePath)
+  return new Promise((resolve, reject) =>
+    fs.unlink(filePath, err => {
+      if (err) {
+        console.error(`Couldn't remove stale page data at "${filePath}"!`)
+        reject(err)
+      } else {
+        console.log(`Removed stale page data at "${filePath}"`)
+        resolve()
+      }
+    })
+  )
 }
 
 module.exports = async function pruneStalePageCache({ graphql }) {
@@ -48,7 +57,6 @@ module.exports = async function pruneStalePageCache({ graphql }) {
       ? null
       : cachedPagePath === '/index'
       ? null
-      : console.log(`Removing file at ${pageDataPath}=${cachedPagePath}`) &&
-        removeFile(pageDataPath)
+      : removeFile(pageDataPath)
   })
 }

--- a/src/utils/shared/crawlPageData.js
+++ b/src/utils/shared/crawlPageData.js
@@ -1,15 +1,15 @@
-const fs = require('fs').promises
-const path = require('path')
+const fs = require('fs')
+const path = require('upath')
 
 async function crawlPageData(dataPath, onPageData) {
-  const stat = await fs.stat(dataPath)
+  const stat = fs.statSync(dataPath)
   if (stat.isDirectory()) {
-    const paths = await fs.readdir(dataPath)
+    const paths = fs.readdirSync(dataPath)
     return Promise.all(
       paths.map(name => crawlPageData(path.join(dataPath, name), onPageData))
     )
   } else if (path.basename(dataPath) === 'page-data.json') {
-    return onPageData(dataPath)
+    return await onPageData(dataPath)
   }
 }
 


### PR DESCRIPTION
I had some testing behavior in the cache pruner that logged file removals without
actually doing them using `&&` (`console.log` returns falsy). This would be fine if 
I had marked it in a TODO or any comment whatsoever.

Anyway, this commit fixes that.

I also changed the logic to use regular `fs` and `Promise.new` instead of
`fs.promises` to avoid the experimental warning. `upath` is used because
I believe that without it cache pruning won't work on Windows.