### PR TITLE
simplify code contributions + reviews by fully automating the dev setup.

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,7 @@
+tasks:
+  - init: yarn install && yarn build
+    command: yarn develop
+
+ports:
+  - port: 8000
+    onOpen: open-preview

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![Maintainability](https://api.codeclimate.com/v1/badges/5872e0a572ec8b74bd8d/maintainability)](https://codeclimate.com/github/iterative/dvc.org/maintainability)
 [![CircleCI](https://circleci.com/gh/iterative/dvc.org.svg?style=svg)](https://circleci.com/gh/iterative/dvc.org)
+[![Gitpod Ready-to-Code](https://img.shields.io/badge/Gitpod-Ready--to--Code-blue?logo=gitpod)](https://gitpod.io/#https://github.com/iterative/dvc.org)
 
 [DVC](https://github.com/iterative/dvc) project website's source code.
 [Documentation](https://dvc.org/doc) and [blog](https://dvc.org/blog) content.

--- a/content/docs/user-guide/contributing/docs.md
+++ b/content/docs/user-guide/contributing/docs.md
@@ -53,9 +53,9 @@ We will review your PR as soon as possible. Thank you for contributing!
 
 ## Development environment
 
-We highly recommend running this web app locally to check documentation or blog
-changes before submitting them, and it's quite necessary when making changes to
-the website engine itself. Source code and content files need to be properly
+We highly recommend running this web app to check documentation or blog changes
+before submitting them, and it's quite necessary when making changes to the
+website engine itself. Source code and content files need to be properly
 formatted and linted as well, which is also ensured by the full setup below.
 
 Make sure you have a recent LTS version of [Node.js](https://nodejs.org/en/)
@@ -81,6 +81,13 @@ This will start the server on the default port, `8000`. Visit
 `http://localhost:8000/` and navigate to the page in question. This will also
 enable the Git pre-commit hook that will be formatting and linting your code and
 documentation files automatically.
+
+Alternatively you can contribute to dvc.org using Gitpod(a fully featured online
+development environment), with a single click it will launch a workspace and
+automatically: clone the repo, install the dependencies, run `yarn build` and
+start the webserver so that you can start straight away.
+
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
 
 ### All commands
 


### PR DESCRIPTION
Hi :slightly_smiling_face:

This Pr simplifies code contributions by fully automating the dev setup with Gitpod(a full-featured online cloud IDE) which is free for OSS. With a single click, it'll launch a workspace and automatically:

- clone the dvc.org repo.
- install the dependencies.
- run `yarn build`.
- start the webserver via `yarn start`.

so that anyone interested in contributing can start straight away without any friction.

this is how it looks:

![image](https://user-images.githubusercontent.com/46004116/80929522-1d218b00-8dc6-11ea-84d5-3a36d3f0ca9f.png)

You can give it a try on my fork of the repo via the following link:

https://gitpod.io/#https://github.com/nisarhassan12/dvc.org

A lot of popular OSS projects out there are already using Gitpod to streamline the experience for their contributors and maintainers, some of them are: 

- https://github.com/freeCodeCamp/freeCodeCamp
-  https://github.com/facebook/docusaurus
-  https://github.com/mozilla/pdf.js/

You can find a brief list of them at https://contribute.dev

![image](https://user-images.githubusercontent.com/46004116/80929615-e6984000-8dc6-11ea-8eac-f26de33f1ae5.png)

Prs can also be reviewed from within Gitpod.

