### PR TITLE
link-check: ignore URLs preceded by `#`

### DIFF
--- a/scripts/utils.sh
+++ b/scripts/utils.sh
@@ -13,7 +13,7 @@ urlfinder(){  # expects <base_url> <files>...
   base_url="$1"
   content="$(cat "${@:2}")"  # read once (could be file descriptors)
   # explicit links not in markdown
-  echo "$content" | pcregrep -o '(?<!\]\()https?://[^\s<>{}"'"'"'`]+'
+  echo "$content" | pcregrep -o '(?<!\]\(|#)https?://[^\s<>{}"'"'"'`]+'
   # explicit links in markdown
   echo "$content" | pcregrep -o '(?<=\])\(https?://[^[\]\s]+\)' | pcregrep -o '\((?:[^)(]*(?R)?)*+\)' | pcregrep -o '(?<=\().*(?=\))'
   # relative links in markdown


### PR DESCRIPTION
- [x] ignore URLs immediately preceded by `#`
- fixes https://github.com/iterative/dvc.org/pull/1226#issuecomment-623717893