### PR TITLE
blog: use pip install --upgrade for installing pre-release 1.0

### DIFF
--- a/content/blog/2020-05-04-dvc-3-years-and-1-0-release.md
+++ b/content/blog/2020-05-04-dvc-3-years-and-1-0-release.md
@@ -96,7 +96,7 @@ You can install the pre-release version from the development branch (instruction
 on [our website](https://dvc.org/doc/install/pre-release)) or through pip:
 
 ```dvc
-$ pip install --pre dvc
+$ pip install --upgrade --pre dvc
 ```
 
 The new DVC is inspired by discussions and contributions from our community -


### PR DESCRIPTION
> You may disregard these recommendations if you used the **Edit on GitHub** button from dvc.org to improve a doc in place.

❗ Please read the guidelines in the [Contributing to the Documentation](https://dvc.org/doc/user-guide/contributing/docs) list if you make any substantial changes to the documentation or JS engine.

🐛 Please make sure to mention `Fix #issue` (if applicable) in the description of the PR. This causes GitHub to close it automatically when the PR is merged.

Please chose to [allow us](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to edit your branch when creating the PR.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

pip won't automatically upgrade an existing 0.93 install to the 1.0 pre-release unless `--upgrade` is specified

discord context: https://discordapp.com/channels/485586884165107732/563406153334128681/707178181987270717

(also `--upgrade` can be used safely for fresh installs)