### PR TITLE
Change comment proxy cache TTL to 1 minute

### DIFF
--- a/src/server/middleware/api/comments.js
+++ b/src/server/middleware/api/comments.js
@@ -13,7 +13,7 @@ const { isProduction } = require('../../utils')
 
 const { FORUM_URL } = require('../../../../src/consts')
 
-const cache = new NodeCache({ stdTTL: 900 })
+const cache = new NodeCache({ stdTTL: 60 })
 
 const getCommentCount = async (req, res) => {
   const {


### PR DESCRIPTION
I'm not certain that we should do this, but this is the fix for #1232. 
The cache could be at 15 minutes currently for a good reason (does @fabiosantoscode know?), but I'm not aware of any discourse cache limits, and we don't have an API key here so I can't see how it would track usage to do any throttling.

I personally think the comment count being delayed on the website isn't much of an issue that actually impacts users, but that's not for me to decide and this looks like a simple fix.

If somehow cache is living past the specified TTL, this deploy preview can still be useful considering its TTL is one minute as opposed to master's 15. I'm not familiar with Discourse and how to use it so I haven't run a test yet, but I can try it.