### PR TITLE
Change "docs/home" to "docs"

### DIFF
--- a/content/blog/2020-04-30-gsod-ideas-2020.md
+++ b/content/blog/2020-04-30-gsod-ideas-2020.md
@@ -121,10 +121,10 @@ few skills we look for in applicants.
    friendly wording as much as possible and pay close attention to consistency
    in our terminology. Our team will help with copy editing.
 
-1. **Command line experience.** [DVC](/doc/home) is a command line tool that
-   builds on top of [Git](https://git-scm.com/), so being able to play with it
-   and test the features will be very useful. Creating and managing files,
-   GNU/Linux commands, file and permission administration are desired skills.
+1. **Command line experience.** [DVC](/doc) is a command line tool that builds
+   on top of [Git](https://git-scm.com/), so being able to play with it and test
+   the features will be very useful. Creating and managing files, GNU/Linux
+   commands, file and permission administration are desired skills.
 
 1. **People skills.** We put a high value on communication: the ability to
    discuss ideas, explain your goals, report progress, and work kindly with more

--- a/content/docs/sidebar.json
+++ b/content/docs/sidebar.json
@@ -1,6 +1,7 @@
 [
   {
-    "slug": "home",
+    "slug": "",
+    "label": "Home",
     "source": "index.md"
   },
   {

--- a/redirects-list.json
+++ b/redirects-list.json
@@ -19,7 +19,7 @@
   "^/((?:deb|rpm)/.+)                                                                     https://s3-us-east-2.amazonaws.com/dvc-s3-repo/$1 303",
   "^/(?:help|chat)/?$                                                                     https://discordapp.com/invite/dvwXA2N 303",
   "^/(?:docs|documentation)(/.*)?$                                                        /doc$1",
-  "^/doc/?$                                                                               /doc/home 307",
+  "^/doc/home/?$                                                                          /doc",
   "^/doc/get-started(/.*)?$                                                               /doc/tutorials/get-started$1",
   "^/doc/tutorial/?$                                                                      /doc/tutorials",
   "^/doc/tutorial/(.*)?                                                                   /doc/tutorials/deep/$1",

--- a/redirects-list.json
+++ b/redirects-list.json
@@ -19,7 +19,7 @@
   "^/((?:deb|rpm)/.+)                                                                     https://s3-us-east-2.amazonaws.com/dvc-s3-repo/$1 303",
   "^/(?:help|chat)/?$                                                                     https://discordapp.com/invite/dvwXA2N 303",
   "^/(?:docs|documentation)(/.*)?$                                                        /doc$1",
-  "^/doc/home/?$                                                                          /doc",
+  "^/doc/home/?$                                                                          /doc 307",
   "^/doc/get-started(/.*)?$                                                               /doc/tutorials/get-started$1",
   "^/doc/tutorial/?$                                                                      /doc/tutorials",
   "^/doc/tutorial/(.*)?                                                                   /doc/tutorials/deep/$1",

--- a/redirects-list.json
+++ b/redirects-list.json
@@ -18,13 +18,13 @@
 
   "^/((?:deb|rpm)/.+)                                                                     https://s3-us-east-2.amazonaws.com/dvc-s3-repo/$1 303",
   "^/(?:help|chat)/?$                                                                     https://discordapp.com/invite/dvwXA2N 303",
-  "^/(?:docs|documentation)(/.*)?$                                                        /doc$1",
+  "^/(?:documentation)/?$                                                                 /doc",
+  "^/(?:documentation)/(.*)?/?$                                                           /doc/$1",
   "^/doc/home/?$                                                                          /doc 307",
   "^/doc/get-started(/.*)?$                                                               /doc/tutorials/get-started$1",
   "^/doc/tutorial/?$                                                                      /doc/tutorials",
   "^/doc/tutorial/(.*)?                                                                   /doc/tutorials/deep/$1",
   "^/doc/commands-reference(/.*)?$                                                        /doc/command-reference$1",
   "^/doc/use-cases/data-and-model-files-versioning/?$                                     /doc/use-cases/versioning-data-and-model-files",
-
   "^/(.+)/$                                                                               /$1"
 ]

--- a/redirects-list.json
+++ b/redirects-list.json
@@ -18,12 +18,12 @@
 
   "^/((?:deb|rpm)/.+)                                                                     https://s3-us-east-2.amazonaws.com/dvc-s3-repo/$1 303",
   "^/(?:help|chat)/?$                                                                     https://discordapp.com/invite/dvwXA2N 303",
-  "^/(?:documentation)/?$                                                                 /doc",
-  "^/(?:documentation)/(.*)?/?$                                                           /doc/$1",
+  "^/(?:docs|documentation)(/.*)?$                                                        /doc$1",
   "^/doc/get-started(/.*)?$                                                               /doc/tutorials/get-started$1",
   "^/doc/tutorial/?$                                                                      /doc/tutorials",
   "^/doc/tutorial/(.*)?                                                                   /doc/tutorials/deep/$1",
   "^/doc/commands-reference(/.*)?$                                                        /doc/command-reference$1",
   "^/doc/use-cases/data-and-model-files-versioning/?$                                     /doc/use-cases/versioning-data-and-model-files",
+
   "^/(.+)/$                                                                               /$1"
 ]

--- a/redirects-list.json
+++ b/redirects-list.json
@@ -20,7 +20,6 @@
   "^/(?:help|chat)/?$                                                                     https://discordapp.com/invite/dvwXA2N 303",
   "^/(?:documentation)/?$                                                                 /doc",
   "^/(?:documentation)/(.*)?/?$                                                           /doc/$1",
-  "^/doc/home/?$                                                                          /doc 307",
   "^/doc/get-started(/.*)?$                                                               /doc/tutorials/get-started$1",
   "^/doc/tutorial/?$                                                                      /doc/tutorials",
   "^/doc/tutorial/(.*)?                                                                   /doc/tutorials/deep/$1",

--- a/src/components/Link/index.tsx
+++ b/src/components/Link/index.tsx
@@ -15,7 +15,7 @@ export type ILinkProps = {
 
 const PROTOCOL_REGEXP = /^https?:\/\//
 const isRelative = (url: string): boolean => !PROTOCOL_REGEXP.test(url)
-const isMailto = (url: string): boolean => url && url.startsWith('mailto:')
+const isMailto = (url: string): boolean => url.startsWith('mailto:')
 
 const ResultLinkComponent: React.FC<ILinkProps> = ({
   href,
@@ -83,7 +83,7 @@ const Link: React.FC<ILinkProps> = ({ href, ...restProps }) => {
 
   const location = new URL(href)
   // Navigate from @reach/router handles hash links incorrectly. Fix it
-  if (href && href.startsWith('#')) {
+  if (href.startsWith('#')) {
     href = currentLocation.pathname + href
   }
 

--- a/src/components/Link/index.tsx
+++ b/src/components/Link/index.tsx
@@ -15,7 +15,7 @@ export type ILinkProps = {
 
 const PROTOCOL_REGEXP = /^https?:\/\//
 const isRelative = (url: string): boolean => !PROTOCOL_REGEXP.test(url)
-const isMailto = (url: string): boolean => url.startsWith('mailto:')
+const isMailto = (url: string): boolean => url && url.startsWith('mailto:')
 
 const ResultLinkComponent: React.FC<ILinkProps> = ({
   href,
@@ -83,7 +83,7 @@ const Link: React.FC<ILinkProps> = ({ href, ...restProps }) => {
 
   const location = new URL(href)
   // Navigate from @reach/router handles hash links incorrectly. Fix it
-  if (href.startsWith('#')) {
+  if (href && href.startsWith('#')) {
     href = currentLocation.pathname + href
   }
 

--- a/src/gatsby/models/docs/onCreateMarkdownContentNode.js
+++ b/src/gatsby/models/docs/onCreateMarkdownContentNode.js
@@ -9,7 +9,6 @@ function createMarkdownDocsNode(api, { parentNode }) {
   const { name, relativePath } = parentNode
   splitDir[0] = 'doc'
 
-  // Make a special exemption for the root doc.
   const slug = path.posix.join('/', ...splitDir, name === 'index' ? '/' : name)
 
   const fieldData = {

--- a/src/gatsby/models/docs/onCreateMarkdownContentNode.js
+++ b/src/gatsby/models/docs/onCreateMarkdownContentNode.js
@@ -10,10 +10,7 @@ function createMarkdownDocsNode(api, { parentNode }) {
   splitDir[0] = 'doc'
 
   // Make a special exemption for the root doc.
-  const slug =
-    parentNode.relativePath === 'docs/index.md'
-      ? '/doc/home'
-      : path.posix.join('/', ...splitDir, name === 'index' ? '/' : name)
+  const slug = path.posix.join('/', ...splitDir, name === 'index' ? '/' : name)
 
   const fieldData = {
     slug,

--- a/src/gatsby/models/docs/onCreateMarkdownContentNode.js
+++ b/src/gatsby/models/docs/onCreateMarkdownContentNode.js
@@ -9,7 +9,7 @@ function createMarkdownDocsNode(api, { parentNode }) {
   const { name, relativePath } = parentNode
   splitDir[0] = 'doc'
 
-  const slug = path.posix.join('/', ...splitDir, name === 'index' ? '/' : name)
+  const slug = path.posix.join('/', ...splitDir, name === 'index' ? '' : name)
 
   const fieldData = {
     slug,

--- a/src/utils/shared/sidebar.js
+++ b/src/utils/shared/sidebar.js
@@ -28,7 +28,7 @@ const FILE_EXTENSION = '.md'
 function validateRawItem({ slug, source, children }) {
   const isSourceDisabled = source === false
 
-  if (!slug) {
+  if (typeof slug !== 'string') {
     throw Error("'slug' field is required in objects in sidebar.json")
   }
 


### PR DESCRIPTION
Address #1073 partially
With some minor changes that allow a blank string slug in sidebar.json, this can be done without making the docs homepage a special exemption.
The existing redirect from /docs to /docs/home also had to be reversed.