### PR TITLE
Add missing --local option in Azure instructions

### DIFF
--- a/content/docs/command-reference/remote/add.md
+++ b/content/docs/command-reference/remote/add.md
@@ -159,7 +159,7 @@ For more information about the variables DVC supports, please visit
 ### Click for Microsoft Azure Blob Storage
 
 ```dvc
-$ dvc remote add myremote azure://my-container-name/path
+$ dvc remote add --local myremote azure://my-container-name/path
 $ dvc remote modify --local myremote connection_string "my-connection-string"
 ```
 


### PR DESCRIPTION
When `dvc remote modify --local` is executed after `dvc remote add`, it shows the error `ERROR: configuration error - config file error: remote 'myremote' doesn't exists.`

This seems to be caused because the given `add` command writes to `.dvc/config` while the given `modify` command attempts to modify the remote in `.dvc/config.local`. 
This PR adds the missing `--local` option to the `add` command