### PR TITLE
Change how relative fragments are handled.

### DIFF
--- a/src/components/Link/index.tsx
+++ b/src/components/Link/index.tsx
@@ -20,13 +20,29 @@ const isMailto = (url: string): boolean => url.startsWith('mailto:')
 const ResultLinkComponent: React.FC<ILinkProps> = ({
   href,
   children,
+  rel,
   ...restProps
 }) => {
-  if (!isRelative(href) || isMailto(href) || restProps.target) {
-    let rel = 'noopener noreferrer'
+  // Handle all situations where a basic `a` must be used over Gatsby Link
+  const hrefIsRelative = isRelative(href)
+  const hrefIsMailto = isMailto(href)
+  const hrefHasTarget = restProps.target
+  // Fragments within the page should be `a`, but links to other pages
+  // that have anchors should be okay.
+  const hrefIsRelativeFragment = href.startsWith('#')
 
-    if (restProps.rel) {
-      rel = `${rel} ${restProps.rel}`
+  if (
+    !hrefIsRelative ||
+    hrefIsMailto ||
+    hrefHasTarget ||
+    hrefIsRelativeFragment
+  ) {
+    /*
+       Change external links without an explicit rel to have 'noopener
+       noreferrer', but leave explicitly defined rels alone.
+    */
+    if (!hrefIsRelative && typeof rel !== 'string') {
+      rel = 'noopener noreferrer'
     }
 
     return (
@@ -82,10 +98,6 @@ const Link: React.FC<ILinkProps> = ({ href, ...restProps }) => {
   )
 
   const location = new URL(href)
-  // Navigate from @reach/router handles hash links incorrectly. Fix it
-  if (href.startsWith('#')) {
-    href = currentLocation.pathname + href
-  }
 
   if (location.host === currentLocation.host) {
     // Replace link href with redirect if it exists


### PR DESCRIPTION
Fixes #1140 as I understand it, but somebody please do check for possible regressions.

I can successfully do the following behavior:

> Click one the links from the right side content bar.
> 
> Click back in your browser.
> 
> The same should work and return to the exact link in the document you got the section.

I can't think of any behavior this change would break, as both the previous and current behavior only apply to fragment links within the same page (with the `href`'s first character being `#`), and other fragment links are left alone.

One thing to check, though, is the previous behavior of combining existing `rel` props with `noopener noreferrer` on all external links. The behavior I replaced it with only does so if the link is external and doesn't already specify a rel, as I figure covering basic external links is important but if the writer is going out of their way to add a rel then they should assume full control.  
If we depend on the prior behavior and can't do without it, I can revert this branch to have that functionality while keeping the fix.