### PR TITLE
Change tag page paths to be under /blog

### DIFF
--- a/content/blog/2020-04-06-april-20-dvc-heartbeat.md
+++ b/content/blog/2020-04-06-april-20-dvc-heartbeat.md
@@ -30,8 +30,8 @@ tags:
 ---
 
 Welcome to the April Heartbeat, our
-[monthly roundup of cool happenings](https://dvc.org/tags/heartbeat), good reads
-and other bright spots in our community.
+[monthly roundup of cool happenings](https://dvc.org/blog/tags/heartbeat), good
+reads and other bright spots in our community.
 
 ## News
 

--- a/src/components/Blog/Post/index.tsx
+++ b/src/components/Blog/Post/index.tsx
@@ -94,7 +94,7 @@ const Post: React.FC<IBlogPostData> = ({
             <div className={styles.tags}>
               {tags.map(tag => (
                 <Link
-                  href={`/tags/${tagToSlug(tag)}`}
+                  href={`/blog/tags/${tagToSlug(tag)}`}
                   className={styles.tag}
                   key={tag}
                 >

--- a/src/gatsby/models/blog/createPages.js
+++ b/src/gatsby/models/blog/createPages.js
@@ -131,7 +131,7 @@ const createPages = async ({ graphql, actions }) => {
 
   const tagPagesPromise = Promise.all(
     _tags.map(({ fieldValue: tag, pageInfo: { itemCount } }) => {
-      const basePath = `/tags/${tagToSlug(tag)}`
+      const basePath = `/blog/tags/${tagToSlug(tag)}`
 
       for (const page of pagesGenerator({ basePath, itemCount })) {
         actions.createPage({


### PR DESCRIPTION
Also change existing links to tag pages to use this new format

Fixes #1222, disregarding the question about RSS because we don't currently use tags in the RSS feed. We could add them somehow, but that's another issue.