### PR TITLE
Fix sidebar support for empty links (/doc/ trailing slash issue)

### DIFF
--- a/src/utils/shared/sidebar.js
+++ b/src/utils/shared/sidebar.js
@@ -154,7 +154,7 @@ function getFirstPage() {
 
 function getItemByPath(path) {
   const normalizedPath = path.replace(/\/$/, '')
-  const isRoot = normalizedPath === PATH_ROOT.slice(0, -1)
+  const isRoot = normalizedPath === PATH_ROOT
   const item = isRoot
     ? normalizedSidebar[0]
     : findItemByField(normalizedSidebar, 'path', normalizedPath)
@@ -173,12 +173,11 @@ function getItemBySource(source) {
 function getPathWithSource(path) {
   return getItemByPath(path).path
 }
-
 function getParentsListFromPath(path) {
-  let currentPath = PATH_ROOT.slice(0, -1)
+  let currentPath = PATH_ROOT
 
   return path
-    .replace(PATH_ROOT, '')
+    .replace(PATH_ROOT + '/', '')
     .split('/')
     .map(part => {
       const path = `${currentPath}/${part}`

--- a/src/utils/shared/sidebar.js
+++ b/src/utils/shared/sidebar.js
@@ -21,7 +21,7 @@
 const startCase = require('lodash/startCase')
 const sidebar = require('../../../content/docs/sidebar.json')
 
-const PATH_ROOT = '/doc/'
+const PATH_ROOT = '/doc'
 const FILE_ROOT = '/docs/'
 const FILE_EXTENSION = '.md'
 
@@ -80,8 +80,10 @@ function normalizeItem({ rawItem, parentPath, resultRef, prevRef }) {
   const sourceFileName = source ? source : slug + FILE_EXTENSION
   const sourcePath = FILE_ROOT + parentPath + sourceFileName
 
+  const relativePath = parentPath + slug
+
   return {
-    path: PATH_ROOT + parentPath + slug,
+    path: relativePath ? `${PATH_ROOT}/${relativePath}` : PATH_ROOT,
     source: source === false ? false : sourcePath,
     label: label ? label : startCase(slug),
     tutorials: tutorials || {},


### PR DESCRIPTION
There was a hard-coded `/doc/` prepended to every path before, but now we start
with `/doc` and add a second slash only if something comes after.

This is a quick fix, but this problem stems from the `sidebar.json` setup still having influence in many places of the site. Ideally it should be _just_ be the canonical ToC and have nothing to do with link generation, but that's a problem for another time.

fixes #1264 