### PR TITLE
Fix mobile doc sidebar

### DIFF
--- a/src/components/Documentation/Layout/SidebarMenu/index.tsx
+++ b/src/components/Documentation/Layout/SidebarMenu/index.tsx
@@ -24,7 +24,7 @@ interface ISidebarMenuItemProps {
   label: string
   path: string
   source: boolean | string
-  onClick: (e: React.MouseEvent) => void
+  onClick: (isLeafItemClicked: boolean) => void
   activePaths?: Array<string>
   type?: string
 }
@@ -40,6 +40,8 @@ const SidebarMenuItem: React.FC<ISidebarMenuItemProps> = ({
   const isActive = activePaths && includes(activePaths, path)
   const isRootParent =
     activePaths && activePaths.length > 1 && activePaths[0] === path
+  const isLeafItem = children === undefined || children.length === 0
+  const currentLevelOnClick = (): void => onClick(isLeafItem)
 
   const className = cn(
     styles.sectionLink,
@@ -54,7 +56,7 @@ const SidebarMenuItem: React.FC<ISidebarMenuItemProps> = ({
         href={path}
         id={path}
         className={className}
-        onClick={onClick}
+        onClick={currentLevelOnClick}
         target="_blank"
       >
         {label} <ExternalLinkIcon />
@@ -64,7 +66,7 @@ const SidebarMenuItem: React.FC<ISidebarMenuItemProps> = ({
         href={getPathWithSource(path)}
         id={path}
         className={className}
-        onClick={onClick}
+        onClick={currentLevelOnClick}
       >
         {label}
       </Link>
@@ -91,7 +93,7 @@ const SidebarMenuItem: React.FC<ISidebarMenuItemProps> = ({
 
 interface ISidebarMenuProps {
   currentPath: string
-  onClick: (e: React.MouseEvent) => void
+  onClick: (isLeafItemClicked: boolean) => void
 }
 
 const SidebarMenu: React.FC<ISidebarMenuProps> = ({ currentPath, onClick }) => {

--- a/src/components/Documentation/Layout/SidebarMenu/styles.module.css
+++ b/src/components/Documentation/Layout/SidebarMenu/styles.module.css
@@ -54,12 +54,16 @@
   text-decoration: none;
   color: var(--color-gray-light);
 
-  &.active {
-    color: var(--color-gray-hover);
-  }
-
   &:hover {
     color: #3c3937;
+
+    @media (--xs-scr) {
+      color: var(--color-gray-light);
+    }
+  }
+
+  &.active {
+    color: var(--color-gray-hover);
   }
 
   &::before {

--- a/src/components/Documentation/Layout/SidebarMenu/styles.module.css
+++ b/src/components/Documentation/Layout/SidebarMenu/styles.module.css
@@ -60,10 +60,6 @@
 
   &:hover {
     color: #3c3937;
-
-    @media (--xs-scr) {
-      color: var(--color-gray-light);
-    }
   }
 
   &::before {

--- a/src/components/Documentation/Layout/index.tsx
+++ b/src/components/Documentation/Layout/index.tsx
@@ -41,9 +41,11 @@ const Layout: LayoutComponent = ({ children, ...restProps }) => {
           <SearchForm />
           <SidebarMenu
             currentPath={restProps.location.pathname}
-            onClick={(): void =>
-              matchMedia('--xs-scr') ? toggleMenu() : undefined
-            }
+            onClick={(isLeafItemClicked: boolean): void => {
+              if (matchMedia('--xs-scr') && isLeafItemClicked) {
+                toggleMenu()
+              }
+            }}
           />
         </div>
         <div className={styles.content}>{children}</div>


### PR DESCRIPTION
Fixes #808

There is some conflict in the mobile doc sidebar. Some root sidebar items have their own articles. When the user clicks to that item two things happen:

1. article opens
2. submenu in the sidebar collapsed

On mobile this cause problem because both logic can't be visible at the same time. I think a better way to solve the issue is to separate 1 and 2 logic to different clicks (ie need special UI element to collapse submenu). To do it need some other design for a mobile sidebar.

As a quick fix, I implement the following logic: the mobile doc sidebar doesn't close on navigating until leaf item is selected.

