### PR TITLE
Correct dvc push and git push order

### DIFF
--- a/content/docs/command-reference/install.md
+++ b/content/docs/command-reference/install.md
@@ -43,7 +43,7 @@ to forget that the `dvc push` command is necessary to upload new or updated data
 files and directories tracked by DVC to
 [remote storage](/doc/command-reference/remote).
 
-This hook automates `dvc push` after `git push`.
+This hook automates `dvc push` before `git push`.
 
 ## Installed Git hooks
 


### PR DESCRIPTION
As mentioned elsewhere in the page, the pre-push hook executes dvc push before git push.

> You may disregard these recommendations if you used the **Edit on GitHub** button from dvc.org to improve a doc in place.

❗ Please read the guidelines in the [Contributing to the Documentation](https://dvc.org/doc/user-guide/contributing/docs) list if you make any substantial changes to the documentation or JS engine.

🐛 Please make sure to mention `Fix #issue` (if applicable) in the description of the PR. This causes GitHub to close it automatically when the PR is merged.

Please chose to [allow us](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to edit your branch when creating the PR.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
