### PR TITLE
Fix docs sidebar highlight regression

### DIFF
--- a/src/components/Documentation/Layout/index.tsx
+++ b/src/components/Documentation/Layout/index.tsx
@@ -12,7 +12,9 @@ import styles from './styles.module.css'
 
 const Layout: LayoutComponent = ({ children, ...restProps }) => {
   const [isMenuOpen, setIsMenuOpen] = useState(false)
-  const { path } = restProps
+  const {
+    location: { pathname }
+  } = restProps
 
   const toggleMenu = useCallback(() => setIsMenuOpen(!isMenuOpen), [isMenuOpen])
 
@@ -41,7 +43,7 @@ const Layout: LayoutComponent = ({ children, ...restProps }) => {
         <div className={cn(styles.side, isMenuOpen && styles.opened)}>
           <SearchForm />
           <SidebarMenu
-            currentPath={path}
+            currentPath={pathname}
             onClick={(isLeafItemClicked: boolean): void => {
               if (matchMedia('--xs-scr') && isLeafItemClicked) {
                 toggleMenu()

--- a/src/components/Documentation/Layout/index.tsx
+++ b/src/components/Documentation/Layout/index.tsx
@@ -14,7 +14,7 @@ const Layout: LayoutComponent = ({ children, ...restProps }) => {
   const [isMenuOpen, setIsMenuOpen] = useState(false)
 
   // Remove trailing slash from location for normalized usage all throughout the app
-  const pathname: string = location.pathname.endsWith('/')
+  const pathname: string = restProps.location.pathname.endsWith('/')
     ? restProps.location.pathname.slice(
         0,
         restProps.location.pathname.length - 1

--- a/src/components/Documentation/Layout/index.tsx
+++ b/src/components/Documentation/Layout/index.tsx
@@ -12,14 +12,7 @@ import styles from './styles.module.css'
 
 const Layout: LayoutComponent = ({ children, ...restProps }) => {
   const [isMenuOpen, setIsMenuOpen] = useState(false)
-
-  // Remove trailing slash from location for normalized usage all throughout the app
-  const pathname: string = restProps.location.pathname.endsWith('/')
-    ? restProps.location.pathname.slice(
-        0,
-        restProps.location.pathname.length - 1
-      )
-    : restProps.location.pathname
+  const { path } = restProps
 
   const toggleMenu = useCallback(() => setIsMenuOpen(!isMenuOpen), [isMenuOpen])
 
@@ -48,7 +41,7 @@ const Layout: LayoutComponent = ({ children, ...restProps }) => {
         <div className={cn(styles.side, isMenuOpen && styles.opened)}>
           <SearchForm />
           <SidebarMenu
-            currentPath={pathname}
+            currentPath={path}
             onClick={(isLeafItemClicked: boolean): void => {
               if (matchMedia('--xs-scr') && isLeafItemClicked) {
                 toggleMenu()

--- a/src/components/Documentation/Layout/index.tsx
+++ b/src/components/Documentation/Layout/index.tsx
@@ -10,8 +10,17 @@ import { matchMedia } from '../../../utils/front/breakpoints'
 
 import styles from './styles.module.css'
 
-const Layout: LayoutComponent = ({ children, ...restProps }) => {
+const Layout: LayoutComponent = ({
+  children,
+  location: { pathname },
+  ...restProps
+}) => {
   const [isMenuOpen, setIsMenuOpen] = useState(false)
+
+  // Remove trailing slash from location for normalized usage all throughout the app
+  pathname = pathname.endsWith('/')
+    ? pathname.slice(0, pathname.length - 1)
+    : pathname
 
   const toggleMenu = useCallback(() => setIsMenuOpen(!isMenuOpen), [isMenuOpen])
 
@@ -40,7 +49,7 @@ const Layout: LayoutComponent = ({ children, ...restProps }) => {
         <div className={cn(styles.side, isMenuOpen && styles.opened)}>
           <SearchForm />
           <SidebarMenu
-            currentPath={restProps.location.pathname}
+            currentPath={pathname}
             onClick={(isLeafItemClicked: boolean): void => {
               if (matchMedia('--xs-scr') && isLeafItemClicked) {
                 toggleMenu()

--- a/src/components/Documentation/Layout/index.tsx
+++ b/src/components/Documentation/Layout/index.tsx
@@ -10,17 +10,16 @@ import { matchMedia } from '../../../utils/front/breakpoints'
 
 import styles from './styles.module.css'
 
-const Layout: LayoutComponent = ({
-  children,
-  location: { pathname },
-  ...restProps
-}) => {
+const Layout: LayoutComponent = ({ children, ...restProps }) => {
   const [isMenuOpen, setIsMenuOpen] = useState(false)
 
   // Remove trailing slash from location for normalized usage all throughout the app
-  pathname = pathname.endsWith('/')
-    ? pathname.slice(0, pathname.length - 1)
-    : pathname
+  const pathname: string = location.pathname.endsWith('/')
+    ? restProps.location.pathname.slice(
+        0,
+        restProps.location.pathname.length - 1
+      )
+    : restProps.location.pathname
 
   const toggleMenu = useCallback(() => setIsMenuOpen(!isMenuOpen), [isMenuOpen])
 

--- a/src/components/Page/index.tsx
+++ b/src/components/Page/index.tsx
@@ -43,7 +43,7 @@ const Page: React.FC<IPageProps> = props => {
 
   return (
     <>
-      <DefaultSEO pathname={props.path} />
+      <DefaultSEO pathname={props.location.pathname} />
       <LayoutComponent {...props} />
     </>
   )

--- a/src/components/Page/index.tsx
+++ b/src/components/Page/index.tsx
@@ -12,7 +12,9 @@ import './base.css'
 import './fonts/fonts.css'
 
 export interface IPageProps {
-  path: string
+  location: {
+    pathname: string
+  }
   pageContext: {
     is404: boolean
     isDocs: boolean
@@ -43,7 +45,7 @@ const Page: React.FC<IPageProps> = props => {
 
   return (
     <>
-      <DefaultSEO pathname={props.path} />
+      <DefaultSEO pathname={props.location.pathname} />
       <LayoutComponent {...props} />
     </>
   )

--- a/src/components/Page/index.tsx
+++ b/src/components/Page/index.tsx
@@ -12,7 +12,9 @@ import './base.css'
 import './fonts/fonts.css'
 
 export interface IPageProps {
-  path: string
+  location: {
+    pathname: string
+  }
   pageContext: {
     is404: boolean
     isDocs: boolean

--- a/src/components/Page/index.tsx
+++ b/src/components/Page/index.tsx
@@ -12,9 +12,7 @@ import './base.css'
 import './fonts/fonts.css'
 
 export interface IPageProps {
-  location: {
-    pathname: string
-  }
+  path: string
   pageContext: {
     is404: boolean
     isDocs: boolean
@@ -45,7 +43,7 @@ const Page: React.FC<IPageProps> = props => {
 
   return (
     <>
-      <DefaultSEO pathname={props.location.pathname} />
+      <DefaultSEO pathname={props.path} />
       <LayoutComponent {...props} />
     </>
   )

--- a/src/utils/shared/sidebar.js
+++ b/src/utils/shared/sidebar.js
@@ -195,6 +195,10 @@ function getPathWithSource(path) {
   return getItemByPath(path).path
 }
 function getParentsListFromPath(path) {
+  // If path is the homepage, indicate that it's the only one active.
+  // This will have to change if we add children under home, but we don't currently.
+  if (path === PATH_ROOT) return [PATH_ROOT]
+
   let currentPath = PATH_ROOT
 
   return path


### PR DESCRIPTION
Fixes #1323 
I jumped the gun on switching from `props.location`, that's the right place to source path at build time.
I think we just had the `location` global somewhere on accident.