### PR TITLE
'Installing DVC without Git' link fixed

### DIFF
--- a/content/docs/command-reference/init.md
+++ b/content/docs/command-reference/init.md
@@ -19,7 +19,7 @@ advanced scenarios:
 
 - [Initializing DVC in subdirectories](#initializing-dvc-in-subdirectories) -
   support for monorepos, nested <abbr>DVC projects</abbr>, etc.
-- [Initializing DVC without Git](#how-does-it-affect-dvc-commands) - support for
+- [Initializing DVC without Git](#initializing-dvc-without-git) - support for
   SCM other than Git, deployment automation cases, etc.
 
 At DVC initialization, a new `.dvc/` directory is created for internal


### PR DESCRIPTION
A small fix for a broken link.  
Also, it must be pointed out that while [Issue#540](https://github.com/iterative/dvc.org/issues/540#issue-479205049) says:
> Git is the only SCM supported on DVC and probably will be for a long time. also, most of the docs use likely Git-specific language such as "tags" and "branches", as well as git ... commands in sample code blocks.

The command-reference says:
> Even though there are DVC features that require DVC to be run in the Git repo, DVC can work well with other version control systems.

Although the `--no-scm` usage is stated, it must be made clear that that particular non-Git repository should be a DVC repo. (Based on my understanding from the docs)

Something along these lines must be pointed out explicitly in within the [init section of command-reference](https://github.com/utkarshsingh99/dvc.org/blob/master/content/docs/command-reference/init.md#initializing-dvc-without-git). 

@jorgeorpinel @shcheklein if this is relevant, I can make an issue for this or add to this PR.