### PR TITLE
cmd ref: import - support for non-DVC repos

### DIFF
--- a/content/docs/command-reference/import.md
+++ b/content/docs/command-reference/import.md
@@ -137,6 +137,39 @@ Several of the values above are pulled from the original stage file
 subfields under `repo` are used to save the origin and version of the
 dependency, respectively.
 
+### Importing from non-DVC repositories
+
+You can even import files (datasets) from Git repositories that are not
+specifically <abbr>DVC repositories</abbr>. Here's an example importing a
+dataset from [GSA's data repo](https://github.com/GSA/data).
+
+```dvc
+$ dvc import git@github.com:GSA/data \
+           enterprise-architecture/it-standards.csv
+Importing 'enterprise-architecture/it-standards.csv
+(git@github.com:GSA/data)' -> 'it-standards.csv'
+```
+
+The file is imported, and along with it, an import stage
+([DVC-file](/doc/user-guide/dvc-file-format)) file is created. Check  
+`it-standards.csv.dvc`:
+
+```yaml
+md5: adb33573716b6ef1218946cd457714e1
+locked: true
+deps:
+  - path: enterprise-architecture/it-standards.csv
+    repo:
+      url: git@github.com:GSA/data
+      rev_lock: af6a1feb542dc05b4d3e9c80deb50e6596876e5f
+outs:
+  - md5: 7e6de779a1ab286745c808f291d2d671
+    path: it-standards.csv
+    cache: true
+    metric: false
+    persist: false
+```
+
 ## Example: Importing and updating fixed revisions
 
 To import a specific version of a <abbr>data artifact</abbr>, we may use the

--- a/content/docs/command-reference/import.md
+++ b/content/docs/command-reference/import.md
@@ -231,9 +231,11 @@ use case.
 
 ## Example: Importing from any Git repository
 
-You can even import files from plain Git repos that are not <abbr>DVC repositories</abbr>. 
-For example, let's import a
-dataset from [GSA's data repo](https://github.com/GSA/data). 
+You can even import files from plain Git repos that are not <abbr>DVC
+  repositories</abbr>. For example, let's import a dataset from
+[GSA's data repo](https://github.com/GSA/data).
+
+> Note that Git-tracked files can be imported from DVC repos as well.
 
 ```dvc
 $ dvc import git@github.com:GSA/data \
@@ -242,7 +244,7 @@ Importing ...
 ```
 
 The file is imported, and along with it, an import stage
-([DVC-file](/doc/user-guide/dvc-file-format)) file is created. Check  
+([DVC-file](/doc/user-guide/dvc-file-format)) file is created. Check
 `it-standards.csv.dvc`:
 
 ```yaml
@@ -255,7 +257,6 @@ outs:
   - md5: 7e6de779a1ab286745c808f291d2d671
     path: it-standards.csv
 ```
-Notice in this snippet that the path and the url you specified earlier are saved
-in the `it-standards.csv.dvc` file, which means the imported file can later be
-updated using [`dvc update`](/doc/command-reference/update) from the upstream 
-repository.
+
+The `url` and `rev_lock` subfields under `repo` are used to save the origin and
+[version](https://git-scm.com/docs/revisions) of the dependency, respectively.

--- a/content/docs/command-reference/import.md
+++ b/content/docs/command-reference/import.md
@@ -255,5 +255,7 @@ outs:
   - md5: 7e6de779a1ab286745c808f291d2d671
     path: it-standards.csv
 ```
-Notice in this snippet that the path and the url you specified earlier are saved in the `it-standards.csv.dvc` file, 
-which means the imported file can later be updated using [`dvc update`](https://dvc.org/doc/command-reference/update) from the upstream repository.
+Notice in this snippet that the path and the url you specified earlier are saved
+in the `it-standards.csv.dvc` file, which means the imported file can later be
+updated using [`dvc update`](/doc/command-reference/update) from the upstream 
+repository.

--- a/content/docs/command-reference/import.md
+++ b/content/docs/command-reference/import.md
@@ -137,38 +137,6 @@ Several of the values above are pulled from the original stage file
 subfields under `repo` are used to save the origin and version of the
 dependency, respectively.
 
-### Example: Importing from any Git repository
-
-You can even import files (datasets) from Git repositories that are not
-specifically <abbr>DVC repositories</abbr>. Here's an example importing a
-dataset from [GSA's data repo](https://github.com/GSA/data).
-
-```dvc
-$ dvc import git@github.com:GSA/data \
-           enterprise-architecture/it-standards.csv
-Importing 'enterprise-architecture/it-standards.csv (git@github.com:GSA/data)' -> 'it-standards.csv'
-```
-
-The file is imported, and along with it, an import stage
-([DVC-file](/doc/user-guide/dvc-file-format)) file is created. Check  
-`it-standards.csv.dvc`:
-
-```yaml
-md5: adb33573716b6ef1218946cd457714e1
-locked: true
-deps:
-  - path: enterprise-architecture/it-standards.csv
-    repo:
-      url: git@github.com:GSA/data
-      rev_lock: af6a1feb542dc05b4d3e9c80deb50e6596876e5f
-outs:
-  - md5: 7e6de779a1ab286745c808f291d2d671
-    path: it-standards.csv
-    cache: true
-    metric: false
-    persist: false
-```
-
 ## Example: Importing and updating fixed revisions
 
 To import a specific version of a <abbr>data artifact</abbr>, we may use the
@@ -260,3 +228,32 @@ outs:
 
 See a full explanation in our [Data Registries](/doc/use-cases/data-registries)
 use case.
+
+## Example: Importing from any Git repository
+
+You can even import files from plain Git repos that are not <abbr>DVC repositories</abbr>. 
+For example, let's import a
+dataset from [GSA's data repo](https://github.com/GSA/data). 
+
+```dvc
+$ dvc import git@github.com:GSA/data \
+           enterprise-architecture/it-standards.csv
+Importing ...
+```
+
+The file is imported, and along with it, an import stage
+([DVC-file](/doc/user-guide/dvc-file-format)) file is created. Check  
+`it-standards.csv.dvc`:
+
+```yaml
+deps:
+  - path: enterprise-architecture/it-standards.csv
+    repo:
+      url: git@github.com:GSA/data
+      rev_lock: af6a1feb542dc05b4d3e9c80deb50e6596876e5f
+outs:
+  - md5: 7e6de779a1ab286745c808f291d2d671
+    path: it-standards.csv
+```
+Notice in this snippet that the path and the url you specified earlier are saved in the `it-standards.csv.dvc` file, 
+which means the imported file can later be updated using [`dvc update`](https://dvc.org/doc/command-reference/update) from the upstream repository.

--- a/content/docs/command-reference/import.md
+++ b/content/docs/command-reference/import.md
@@ -137,7 +137,7 @@ Several of the values above are pulled from the original stage file
 subfields under `repo` are used to save the origin and version of the
 dependency, respectively.
 
-### Importing from non-DVC repositories
+### Example: Importing from any Git repository
 
 You can even import files (datasets) from Git repositories that are not
 specifically <abbr>DVC repositories</abbr>. Here's an example importing a

--- a/content/docs/command-reference/import.md
+++ b/content/docs/command-reference/import.md
@@ -146,8 +146,7 @@ dataset from [GSA's data repo](https://github.com/GSA/data).
 ```dvc
 $ dvc import git@github.com:GSA/data \
            enterprise-architecture/it-standards.csv
-Importing 'enterprise-architecture/it-standards.csv
-(git@github.com:GSA/data)' -> 'it-standards.csv'
+Importing 'enterprise-architecture/it-standards.csv (git@github.com:GSA/data)' -> 'it-standards.csv'
 ```
 
 The file is imported, and along with it, an import stage

--- a/content/docs/command-reference/import.md
+++ b/content/docs/command-reference/import.md
@@ -233,15 +233,15 @@ use case.
 
 You can even import files from plain Git repos that are not <abbr>DVC
 repositories</abbr>. For example, let's import a dataset from
-[GSA's data repo](https://github.com/GSA/data).
-
-> Note that Git-tracked files can be imported from DVC repos as well.
+[GSA's data repo](https://github.com/GSA/data):
 
 ```dvc
 $ dvc import git@github.com:GSA/data \
            enterprise-architecture/it-standards.csv
 Importing ...
 ```
+
+> Note that Git-tracked files can be imported from DVC repos as well.
 
 The file is imported, and along with it, an import stage
 ([DVC-file](/doc/user-guide/dvc-file-format)) file is created. Check

--- a/content/docs/command-reference/import.md
+++ b/content/docs/command-reference/import.md
@@ -232,7 +232,7 @@ use case.
 ## Example: Importing from any Git repository
 
 You can even import files from plain Git repos that are not <abbr>DVC
-  repositories</abbr>. For example, let's import a dataset from
+repositories</abbr>. For example, let's import a dataset from
 [GSA's data repo](https://github.com/GSA/data).
 
 > Note that Git-tracked files can be imported from DVC repos as well.


### PR DESCRIPTION
Additional, final fix #898  
Specific addition: [#898(comment)](https://github.com/iterative/dvc.org/issues/898#issuecomment-632894650)
Please check the link of the non-DVC git repository. I couldn't find any non-DVC repo in iterative that could provide for a dataset file. In case of any modifications, I would be happy to make changes to the link.  

- [X] ❗ Please read the guidelines in the [Contributing to the Documentation](https://dvc.org/doc/user-guide/contributing/docs) list if you make any substantial changes to the documentation or JS engine.

- [X] 🐛 Please make sure to mention `Fix #issue` (if applicable) in the description of the PR. This causes GitHub to close it automatically when the PR is merged.

- [X] Please choose to [allow us](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to edit your branch when creating the PR.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
