### PR TITLE
use example-get-started repo in pull examples 

### DIFF
--- a/content/docs/command-reference/checkout.md
+++ b/content/docs/command-reference/checkout.md
@@ -121,6 +121,7 @@ $ dvc fetch -aT
 
 We run `dvc fetch -aT` to get data for all Git branches and tags from
 [remote storage](/doc/command-reference/remote) to the <abbr>cache</abbr>.
+This way it's all available for the `checkout` examples below.
 
 </details>
 

--- a/content/docs/command-reference/checkout.md
+++ b/content/docs/command-reference/checkout.md
@@ -118,6 +118,14 @@ $ git clone https://github.com/iterative/example-get-started
 $ cd example-get-started
 ```
 
+This project comes with a predefined HTTP
+[remote storage](/doc/command-reference/remote). We use `dvc fetch` to get data
+from remote storage:
+
+```dvc
+$ dvc fetch -aT
+```
+
 </details>
 
 The workspace looks something like this:
@@ -145,11 +153,9 @@ baseline-experiment     <- First simple version of the model
 bigrams-experiment      <- Uses bigrams to improve the model
 ```
 
-This project comes with a predefined HTTP
-[remote storage](/doc/command-reference/remote). We can now just run `dvc pull`
-that will fetch and checkout the most recent `model.pkl`, `data.xml`, and other
-files that are tracked by DVC. The model file hash
-`662eb7f64216d9c2c1088d0a5e2c6951` will be used in the `train.dvc`
+We can now just run `dvc pull` that will fetch and checkout the most recent
+`model.pkl`, `data.xml`, and other files that are tracked by DVC. The model file
+hash `662eb7f64216d9c2c1088d0a5e2c6951` will be used in the `train.dvc`
 [stage file](/doc/command-reference/run):
 
 ```dvc
@@ -188,7 +194,6 @@ DVC-files. But it did nothing with the `model.pkl` and `matrix.pkl` files. Git
 doesn't track those files; DVC does, so we must do this:
 
 ```dvc
-$ dvc fetch
 $ dvc checkout
 M       model.pkl
 M       data\features\
@@ -198,10 +203,7 @@ MD5 (model.pkl) = 43630cce66a2432dcecddc9dd006d0a7
 ```
 
 What happened is that DVC went through the DVC-files and adjusted the current
-set of <abbr>output</abbr> files to match the `outs` in them. `dvc fetch` is run
-this once to download missing data from the remote storage to the
-<abbr>cache</abbr>. (Alternatively, we could have just run `dvc pull` to do
-`dvc fetch` + `dvc checkout` in one step.)
+set of <abbr>output</abbr> files to match the `outs` in them.
 
 ## Example: Automating DVC checkout
 

--- a/content/docs/command-reference/checkout.md
+++ b/content/docs/command-reference/checkout.md
@@ -116,15 +116,11 @@ Start by cloning our example repo if you don't already have it:
 ```dvc
 $ git clone https://github.com/iterative/example-get-started
 $ cd example-get-started
-```
-
-This project comes with a predefined HTTP
-[remote storage](/doc/command-reference/remote). We use `dvc fetch` to get data
-from remote storage:
-
-```dvc
 $ dvc fetch -aT
 ```
+
+We run `dvc fetch -aT` to get data for all Git branches and tags from
+[remote storage](/doc/command-reference/remote) to the <abbr>cache</abbr>.
 
 </details>
 
@@ -153,13 +149,13 @@ baseline-experiment     <- First simple version of the model
 bigrams-experiment      <- Uses bigrams to improve the model
 ```
 
-We can now just run `dvc pull` that will fetch and checkout the most recent
-`model.pkl`, `data.xml`, and other files that are tracked by DVC. The model file
-hash `662eb7f64216d9c2c1088d0a5e2c6951` will be used in the `train.dvc`
+We can now just run `dvc checkout` that will update the most recent `model.pkl`,
+`data.xml`, and other files that are tracked by DVC. The model file hash
+`662eb7f64216d9c2c1088d0a5e2c6951` will be used in the `train.dvc`
 [stage file](/doc/command-reference/run):
 
 ```dvc
-$ dvc pull
+$ dvc checkout
 
 $ md5 model.pkl
 MD5 (model.pkl) = 662eb7f64216d9c2c1088d0a5e2c6951

--- a/content/docs/command-reference/checkout.md
+++ b/content/docs/command-reference/checkout.md
@@ -119,9 +119,10 @@ $ cd example-get-started
 $ dvc fetch -aT
 ```
 
-We run `dvc fetch -aT` to get data for all Git branches and tags from
-[remote storage](/doc/command-reference/remote) to the <abbr>cache</abbr>.
-This way it's all available for the `checkout` examples below.
+We run `dvc fetch` with the `-aT` flags to get the DVC-tracked data from all Git
+branches and tags from [remote storage](/doc/command-reference/remote) to the
+<abbr>cache</abbr>. This way it's all available for the `checkout` examples
+below.
 
 </details>
 


### PR DESCRIPTION
This PR updates `\content\docs\commands-reference\checkout.md` and `\content\docs\commands-reference\pull.md` to fix #528.
`checkout` example is simplified by using 'dvc fetch`. 

---
Some specific subtasks:
- [x] https://github.com/iterative/dvc.org/issues/528#issuecomment-631823231:
  > dvc fetch could be hidden in the "Click and expand to setup the project"...
- [x] https://github.com/iterative/dvc.org/issues/528#issuecomment-632997691:
  > fetch -aT is not currently used in the expandable section. The suggestion is to add it there so it can be removed from the block further down. There's an explanation about it under that block too, which would probably need to go away (moved into the expandable section too).
- [x] &
  > However the fetch + checkout parenthesis would have to go away too (not moved, just gone). Instead maybe we can just link "fetch" and "checkout" in `We can now just run dvc pull that will fetch and checkout the...`