### PR TITLE
Add optional link field to authors

### DIFF
--- a/content/authors/dmitry_petrov.md
+++ b/content/authors/dmitry_petrov.md
@@ -1,6 +1,7 @@
 ---
 name: Dmitry Petrov
 avatar: dmitry_petrov.png
+link: https://twitter.com/fullstackml
 ---
 
 Creator of [http://dvc.org](http://dvc.org) — Git for ML. Ex-Data Scientist

--- a/content/authors/elle_obrien.md
+++ b/content/authors/elle_obrien.md
@@ -1,6 +1,7 @@
 ---
 name: Elle O'Brien
 avatar: elle_obrien.jpg
+link: https://twitter.com/andronovhopf
 ---
 
 Data scientist at [http://dvc.org](http://dvc.org)

--- a/content/authors/george_vyshnya.md
+++ b/content/authors/george_vyshnya.md
@@ -1,6 +1,7 @@
 ---
 name: George Vyshnya
 avatar: george_vyshnya.jpeg
+link: https://www.linkedin.com/in/gvyshnya
 ---
 
 Seasoned Data Scientist / Software Developer with blended experience in software

--- a/content/authors/jorge_orpinel.md
+++ b/content/authors/jorge_orpinel.md
@@ -1,6 +1,7 @@
 ---
 name: Jorge Orpinel Pérez
 avatar: jorge.jpg
+https://www.linkedin.com/in/jorgeorpinel
 ---
 
 Technical writer and developer at [http://dvc.org](http://dvc.org)

--- a/content/authors/jorge_orpinel.md
+++ b/content/authors/jorge_orpinel.md
@@ -1,7 +1,7 @@
 ---
 name: Jorge Orpinel Pérez
 avatar: jorge.jpg
-https://www.linkedin.com/in/jorgeorpinel
+link: https://www.linkedin.com/in/jorgeorpinel
 ---
 
 Technical writer and developer at [http://dvc.org](http://dvc.org)

--- a/content/authors/jorge_orpinel.md
+++ b/content/authors/jorge_orpinel.md
@@ -1,7 +1,7 @@
 ---
 name: Jorge Orpinel Pérez
 avatar: jorge.jpg
-link: https://www.linkedin.com/in/jorgeorpinel
+link: https://twitter.com/jorgeorpinel
 ---
 
 Technical writer and developer at [http://dvc.org](http://dvc.org)

--- a/content/authors/marcel_rd.md
+++ b/content/authors/marcel_rd.md
@@ -1,6 +1,7 @@
 ---
 name: Marcel Ribeiro-Dantas
 avatar: marcel.jpg
+link: https://twitter.com/mribeirodantas
 ---
 
 Early Stage Researcher at [Institut Curie](https://intstitut-curie.org) with

--- a/content/authors/marija_ilic.md
+++ b/content/authors/marija_ilic.md
@@ -1,6 +1,7 @@
 ---
 name: Marija Ilić
 avatar: marija_ilic.png
+link: https://medium.com/@zoldin
 ---
 
 Data scientist at Njuškalo, Croatia.

--- a/content/authors/marija_ilic.md
+++ b/content/authors/marija_ilic.md
@@ -1,7 +1,7 @@
 ---
 name: Marija Ilić
 avatar: marija_ilic.png
-link: https://medium.com/@zoldin
+link: https://www.linkedin.com/in/marija-ili%C4%87-65b8a53
 ---
 
 Data scientist at Njuškalo, Croatia.

--- a/content/authors/svetlana_grinchenko.md
+++ b/content/authors/svetlana_grinchenko.md
@@ -1,6 +1,7 @@
 ---
 name: Svetlana Grinchenko
 avatar: svetlana_grinchenko.jpeg
+link: https://twitter.com/a142hr
 ---
 
 Head of developer relations at [http://dvc.org](http://dvc.org)

--- a/content/docs/user-guide/contributing/blog.md
+++ b/content/docs/user-guide/contributing/blog.md
@@ -134,8 +134,10 @@ Write front matter in the following format:
 ```yml
 name: John Doe
 avatar: avatar.jpeg
+link: https://www.twitter.com/johndoe
 ```
 
 - `name` – **Required.** Author's name.
 - `avatar` - **Required.** Path to the author's avatar, relative to
   `static/uploads/avatars` (1024x1024 is recommended).
+- `link` - Optional location that the author's name will link to.

--- a/src/components/Blog/FeedMeta/index.tsx
+++ b/src/components/Blog/FeedMeta/index.tsx
@@ -15,6 +15,7 @@ interface IBlogFeedMetaProps {
   date: string
   name: string
   timeToRead: string
+  link?: string
 }
 
 const FeedMeta: React.FC<IBlogFeedMetaProps> = ({
@@ -23,13 +24,22 @@ const FeedMeta: React.FC<IBlogFeedMetaProps> = ({
   commentsCount,
   date,
   name,
-  timeToRead
+  timeToRead,
+  link
 }) => {
   return (
     <div className={styles.wrapper}>
       <Image fixed={avatar.fixed} className={styles.avatar} />
       <ul className={styles.list}>
-        <li className={styles.item}>{name}</li>
+        <li className={styles.item}>
+          {link ? (
+            <Link href={link} className={styles.link}>
+              {name}
+            </Link>
+          ) : (
+            name
+          )}
+        </li>
         <li className={styles.item}>
           {date} • {timeToRead} min read
         </li>

--- a/src/components/Blog/Post/index.tsx
+++ b/src/components/Blog/Post/index.tsx
@@ -31,7 +31,7 @@ const Post: React.FC<IBlogPostData> = ({
   descriptionLong,
   commentsUrl,
   tags,
-  author: { name, avatar },
+  author: { name, avatar, link },
   slug
 }) => {
   const wrapperRef = useRef<HTMLDivElement>(null)
@@ -79,6 +79,7 @@ const Post: React.FC<IBlogPostData> = ({
                 avatar={avatar}
                 date={date}
                 timeToRead={timeToRead}
+                link={link}
               />
             </div>
           </div>

--- a/src/gatsby/models/authors/createSchemaCustomization.js
+++ b/src/gatsby/models/authors/createSchemaCustomization.js
@@ -11,7 +11,8 @@ async function createAuthorSchemaCustomization(api) {
       name: 'AuthorPosts',
       fields: {
         totalCount: 'Int!',
-        nodes: '[BlogPost]'
+        nodes: '[BlogPost]',
+        link: 'String'
       }
     }),
     buildObjectType({

--- a/src/gatsby/models/authors/createSchemaCustomization.js
+++ b/src/gatsby/models/authors/createSchemaCustomization.js
@@ -11,8 +11,7 @@ async function createAuthorSchemaCustomization(api) {
       name: 'AuthorPosts',
       fields: {
         totalCount: 'Int!',
-        nodes: '[BlogPost]',
-        link: 'String'
+        nodes: '[BlogPost]'
       }
     }),
     buildObjectType({
@@ -20,6 +19,7 @@ async function createAuthorSchemaCustomization(api) {
       interfaces: ['Node'],
       fields: {
         ...markdownParentFields,
+        link: 'String',
         avatar: {
           type: 'ImageSharp',
           resolve: resolveAuthorAvatar

--- a/src/gatsby/models/authors/onCreateMarkdownContentNode.js
+++ b/src/gatsby/models/authors/onCreateMarkdownContentNode.js
@@ -3,7 +3,7 @@ function createMarkdownAuthorNode(api, { parentNode }) {
   const { node, actions, createNodeId, createContentDigest } = api
   const { createNode, createParentChildLink } = actions
   const { frontmatter, rawMarkdownBody } = node
-  const { path, name, avatar } = frontmatter
+  const { path, name, avatar, link } = frontmatter
   const { relativePath } = parentNode
 
   const fieldData = {
@@ -11,6 +11,7 @@ function createMarkdownAuthorNode(api, { parentNode }) {
     rawMarkdownBody,
     path,
     name,
+    link,
     avatar
   }
 

--- a/src/templates/blog-post.tsx
+++ b/src/templates/blog-post.tsx
@@ -42,6 +42,7 @@ export interface IBlogPostData {
   pictureComment?: string
   author: {
     name: string
+    link?: string
     avatar: {
       fixed: FixedObject
     }
@@ -87,6 +88,7 @@ export const pageQuery = graphql`
       commentsUrl
       author {
         name
+        link
         avatar {
           fixed(width: 40, height: 40, quality: 50, cropFocus: CENTER) {
             ...GatsbyImageSharpFixed_withWebp


### PR DESCRIPTION
This is a quick addition to allow for optionally linking arbitrary pages to authors, making them clickable on Blog Posts.

Fixes #1161, and is an interim fix while we make something more elaborate in #1120

Just add `link: https://mysocialmedia.com/profile` to an author's Markdown frontmatter and that Author's name will become a link in Blog posts! I haven't committed any content changes yet, so we'll have to do that to have an example on display.

We'll probably need to add docs for this somewhere as well.