### PR TITLE
Small null check fix to abbrs inside details blocks

### DIFF
--- a/src/components/Documentation/Markdown/index.tsx
+++ b/src/components/Documentation/Markdown/index.tsx
@@ -146,7 +146,9 @@ const Markdown: React.FC<IMarkdownProps> = ({
     touchstartXRef.current = e.changedTouches[0].screenX
   }, [])
   const onTouchEnd = useCallback(e => {
-    touchendXRef.current = e.changedTouches[0].screenX
+    const changedTouch = e.changedTouches[0]
+    if (!changedTouch) return
+    touchendXRef.current = changedTouch.screenX
     handleSwipeGesture()
   }, [])
 


### PR DESCRIPTION
Docs `abbr` tags inside `details` breaks on responsive view simulated touch for me because e.changedTouches[0] is null. This null check fixes that.

Related to #510 