### PR TITLE
Re-add abbrs within details

### DIFF
--- a/content/docs/command-reference/import-url.md
+++ b/content/docs/command-reference/import-url.md
@@ -146,7 +146,7 @@ $ git checkout 2-remote
 $ mkdir data
 ```
 
-You should now have a blank workspace, just before the
+You should now have a blank <abbr>workspace</abbr>, just before the
 [Add Files](/doc/tutorials/get-started/add-files) chapter.
 
 </details>

--- a/content/docs/command-reference/remote/add.md
+++ b/content/docs/command-reference/remote/add.md
@@ -355,9 +355,10 @@ $ dvc remote add myremote https://example.com/path/to/dir
 A "local remote" is a directory in the machine's file system.
 
 > While the term may seem contradictory, it doesn't have to be. The "local" part
-> refers to the machine where the project is stored, so it can be any directory
-> accessible to the same system. The "remote" part refers specifically to the
-> project/repository itself. Read "local, but external" storage.
+> refers to the machine where the <abbr>project</abbr> is stored, so it can be
+> any directory accessible to the same system. The "remote" part refers
+> specifically to the project/repository itself. Read "local, but external"
+> storage.
 
 Using an absolute path (recommended):
 

--- a/content/docs/command-reference/remote/index.md
+++ b/content/docs/command-reference/remote/index.md
@@ -76,9 +76,9 @@ For the typical process to share the <abbr>project</abbr> via remote, see
 ### What is a "local remote" ?
 
 While the term may seem contradictory, it doesn't have to be. The "local" part
-refers to the machine where the project is stored, so it can be any directory
-accessible to the same system. The "remote" part refers specifically to the
-project/repository itself. Read "local, but external" storage.
+refers to the machine where the <abbr>project</abbr> is stored, so it can be any
+directory accessible to the same system. The "remote" part refers specifically
+to the project/repository itself. Read "local, but external" storage.
 
 </details>
 

--- a/content/docs/command-reference/remote/list.md
+++ b/content/docs/command-reference/remote/list.md
@@ -46,9 +46,9 @@ Let's for simplicity add a _default_ local remote:
 ### What is a "local remote" ?
 
 While the term may seem contradictory, it doesn't have to be. The "local" part
-refers to the machine where the project is stored, so it can be any directory
-accessible to the same system. The "remote" part refers specifically to the
-project/repository itself. Read "local, but external" storage.
+refers to the machine where the <abbr>project</abbr> is stored, so it can be any
+directory accessible to the same system. The "remote" part refers specifically
+to the project/repository itself. Read "local, but external" storage.
 
 </details>
 

--- a/content/docs/tutorials/get-started/add-files.md
+++ b/content/docs/tutorials/get-started/add-files.md
@@ -40,7 +40,7 @@ Committing DVC-files with Git allows us to track different versions of the
 
 ### Expand to learn about DVC internals
 
-`dvc add` moves the actual data file to the cache directory (see
+`dvc add` moves the actual data file to the <abbr>cache directory</abbr> (see
 [DVC Files and Directories](/doc/user-guide/dvc-files-and-directories)), while
 the entries in the workspace may be file links to the actual files in the DVC
 cache.

--- a/content/docs/tutorials/get-started/add-files.md
+++ b/content/docs/tutorials/get-started/add-files.md
@@ -40,7 +40,7 @@ Committing DVC-files with Git allows us to track different versions of the
 
 ### Expand to learn about DVC internals
 
-`dvc add` moves the actual data file to the <abbr>cache directory</abbr> (see
+`dvc add` moves the actual data file to the <abbr>cache</abbr> directory (see
 [DVC Files and Directories](/doc/user-guide/dvc-files-and-directories)), while
 the entries in the workspace may be file links to the actual files in the DVC
 cache.

--- a/content/docs/tutorials/get-started/configure.md
+++ b/content/docs/tutorials/get-started/configure.md
@@ -16,9 +16,9 @@ For simplicity, let's setup a local remote:
 ### What is a "local remote" ?
 
 While the term may seem contradictory, it doesn't have to be. The "local" part
-refers to the machine where the project is stored, so it can be any directory
-accessible to the same system. The "remote" part refers specifically to the
-project/repository itself. Read "local, but external" storage.
+refers to the machine where the <abbr>project</abbr> is stored, so it can be any
+directory accessible to the same system. The "remote" part refers specifically
+to the project/repository itself. Read "local, but external" storage.
 
 </details>
 

--- a/content/docs/tutorials/pipelines.md
+++ b/content/docs/tutorials/pipelines.md
@@ -103,7 +103,7 @@ When we run `dvc add` `Posts.xml.zip`, DVC creates a
 ### Expand to learn about DVC internals
 
 At DVC initialization, a new `.dvc/` directory is created for internal
-configuration, as well as some <abbr>cache</abbr>
+configuration and <abbr>cache</abbr>
 [files and directories](/doc/user-guide/dvc-files-and-directories) that are
 hidden from the user. This directory is automatically staged with `git add`, so
 it can be easily committed with Git.

--- a/content/docs/tutorials/pipelines.md
+++ b/content/docs/tutorials/pipelines.md
@@ -126,9 +126,9 @@ This file can be committed with Git instead of the data file itself.
 
 The data file `Posts.xml.zip` is linked (or copied) from
 `.dvc/cache/ce/68b98d82545628782c66192c96f2d2`, and added to `.gitignore`. Even
-if you remove it from the workspace, or `git checkout` a different commit, the
-data is not lost if a corresponding DVC-file is committed. It's enough to run
-`dvc checkout` or `dvc pull` to restore data files.
+if you remove it from the <abbr>workspace</abbr>, or `git checkout` a different
+commit, the data is not lost if a corresponding DVC-file is committed. It's
+enough to run `dvc checkout` or `dvc pull` to restore data files.
 
 </details>
 
@@ -183,10 +183,10 @@ outs:
 ```
 
 Just like the DVC-file we created earlier with `dvc add`, this stage file uses
-`md5` hashes (that point to the cache) to describe and version control
-dependencies and outputs. Output `data/Posts.xml` file is saved as
+`md5` hashes (that point to the <abbr>cache</abbr>) to describe and version
+control dependencies and outputs. Output `data/Posts.xml` file is saved as
 `.dvc/cache/a3/04afb96060aad90176268345e10355` and linked (or copied) to the
-workspace, as well as added to `.gitignore`.
+<abbr>workspace</abbr>, as well as added to `.gitignore`.
 
 Two things are worth noticing here. First, by analyzing dependencies and outputs
 that DVC-files describe, we can restore the full series of commands (pipeline

--- a/content/docs/tutorials/pipelines.md
+++ b/content/docs/tutorials/pipelines.md
@@ -103,8 +103,8 @@ When we run `dvc add` `Posts.xml.zip`, DVC creates a
 ### Expand to learn about DVC internals
 
 At DVC initialization, a new `.dvc/` directory is created for internal
-configuration and <abbr>cache</abbr>
-[files and directories](/doc/user-guide/dvc-files-and-directories), that are
+configuration, as well as some <abbr>cache</abbr>
+[files and directories](/doc/user-guide/dvc-files-and-directories) that are
 hidden from the user. This directory is automatically staged with `git add`, so
 it can be easily committed with Git.
 

--- a/content/docs/tutorials/versioning.md
+++ b/content/docs/tutorials/versioning.md
@@ -163,9 +163,9 @@ $ git tag -a "v1.0" -m "model v1.0, 1000 images"
 ### Expand to learn more about DVC internals
 
 As we mentioned briefly, DVC does not commit the `data/` directory and
-`model.h5` file with Git. Instead, `dvc add` stores them in the cache (usually
-in `.dvc/cache`) and adds them to `.gitignore`. We then `git commit` DVC-files
-that contain file hashes that point to cached data.
+`model.h5` file with Git. Instead, `dvc add` stores them in the
+<abbr>cache</abbr> (usually in `.dvc/cache`) and adds them to `.gitignore`. We
+then `git commit` DVC-files that contain file hashes that point to cached data.
 
 In this case we created `data.dvc` and `model.h5.dvc`. Refer to
 [DVC-File Format](/doc/user-guide/dvc-file-format) to learn more about how these

--- a/content/docs/tutorials/versioning.md
+++ b/content/docs/tutorials/versioning.md
@@ -281,8 +281,8 @@ the `v2.0` tag.
 ### Expand to learn more about DVC internals
 
 As we have learned already, DVC keeps data files out of Git (by adjusting
-`.gitignore`) and puts them into the cache (usually it's a `.dvc/cache`
-directory inside the repository). Instead, DVC creates
+`.gitignore`) and puts them into the <abbr>cache</abbr> (usually it's a
+`.dvc/cache` directory inside the repository). Instead, DVC creates
 [DVC-files](/doc/user-guide/dvc-file-format). These text files serve as data
 placeholders that point to the cached files, and they can be easily version
 controlled with Git.

--- a/content/docs/user-guide/basic-concepts/dvc-project.md
+++ b/content/docs/user-guide/basic-concepts/dvc-project.md
@@ -1,0 +1,20 @@
+---
+name: 'DVC Project'
+match:
+  [
+    'DVC project',
+    'DVC projects',
+    project,
+    projects,
+    'DVC repository',
+    'DVC repositories',
+    repository,
+    repositories,
+  ]
+---
+
+Initialized by running `dvc init` in the **workspace** (typically in a Git
+repository). It will contain the
+[`.dvc/` directory](/doc/user-guide/dvc-files-and-directories) and
+[DVC-files](/doc/user-guide/dvc-file-format) created with commands such as
+`dvc add` or `dvc run`.


### PR DESCRIPTION
Having `abbr`s in `details` used to break them, leading to #510. 

At some point since then, the issue was fixed and `abbr` works within `details` with no problem, even in quotes.

This branch re-adds the `abbr`s removed in #510.
I think this also fixes #510, unless I missed something from the list or there are other docs to re-introduce this to.

Uses the list from [this comment](https://github.com/iterative/dvc.org/issues/510#issuecomment-520898641)

* [x]  We should add `<abbr>` to term "project" in the first `<details>` section of static/docs/get-started/configure.md, for now removed in [ce3d940](https://github.com/iterative/dvc.org/commit/ce3d940031e10a366298a24870557a5194af3d98).
* [x]  Re-add `<abbr>` in tags static/docs/get-started/add-files.md removed temporarily in [ed4062e](https://github.com/iterative/dvc.org/commit/ed4062eba4d09ec2e98abc3e8f2ef3ae808cd4f4).
* [x]  Undo also [6d642ef](https://github.com/iterative/dvc.org/commit/6d642ef4b8b7b90b36266a1aad19aa573de9c05d).
* [x]  And [d28add6](https://github.com/iterative/dvc.org/commit/d28add6869e29168a1175cf941f68bf18781056a)