### PR TITLE
Overhaul how GitHub stars are handled

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -1,5 +1,6 @@
 /* eslint-env node */
 
+require('dotenv').config()
 const path = require('path')
 
 require('./config/prismjs/dvc')
@@ -39,6 +40,25 @@ const plugins = [
     options: {
       name: 'content',
       path: path.join(__dirname, 'content')
+    }
+  },
+  {
+    resolve: `gatsby-source-github-api`,
+    options: {
+      // token: required by the GitHub API
+      token: process.env.GITHUB_TOKEN,
+
+      // GraphQLquery: defaults to a search query
+      graphQLQuery: `
+          {
+            repository(owner: "iterative", name: "dvc") {
+              stargazers {
+                totalCount
+              }
+            }
+          }
+      `,
+      variables: {}
     }
   },
   {

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -43,25 +43,6 @@ const plugins = [
     }
   },
   {
-    resolve: `gatsby-source-github-api`,
-    options: {
-      // token: required by the GitHub API
-      token: process.env.GITHUB_TOKEN,
-
-      // GraphQLquery: defaults to a search query
-      graphQLQuery: `
-          {
-            repository(owner: "iterative", name: "dvc") {
-              stargazers {
-                totalCount
-              }
-            }
-          }
-      `,
-      variables: {}
-    }
-  },
-  {
     resolve: 'gatsby-source-filesystem',
     options: {
       name: 'images',
@@ -218,6 +199,28 @@ const plugins = [
     }
   }
 ]
+
+if (process.env.GITHUB_TOKEN) {
+  plugins.push({
+    resolve: `gatsby-source-github-api`,
+    options: {
+      // token: required by the GitHub API
+      token: process.env.GITHUB_TOKEN,
+
+      // GraphQLquery: defaults to a search query
+      graphQLQuery: `
+          {
+            repository(owner: "iterative", name: "dvc") {
+              stargazers {
+                totalCount
+              }
+            }
+          }
+        `,
+      variables: {}
+    }
+  })
+}
 
 if (process.env.CONTEXT === 'production') {
   plugins.push({

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "gatsby-image": "^2.3.1",
     "gatsby-link": "^2.3.2",
     "gatsby-plugin-parent-resolvers": "^1.0.1",
+    "gatsby-source-github-api": "^0.2.1",
     "github-markdown-css": "^4.0.0",
     "iso-url": "^0.4.7",
     "isomorphic-fetch": "^2.2.1",

--- a/scripts/deploy-with-s3.js
+++ b/scripts/deploy-with-s3.js
@@ -60,7 +60,12 @@ const cacheDirs = [
   ['.cache', '-cache/']
 ]
 
-const { s3Prefix, withEntries, prefixIsEmpty } = require('./s3-utils')
+const {
+  s3Prefix,
+  withEntries,
+  prefixIsEmpty,
+  cleanEntry
+} = require('./s3-utils')
 const { move } = require('fs-extra')
 const { downloadAllFromS3, uploadAllToS3, cleanAllLocal } = withEntries(
   cacheDirs
@@ -101,7 +106,9 @@ async function main() {
       console.error(buildError)
       console.error('\nRetrying with a cleared cache:\n')
 
-      await cleanAllLocal()
+      // Clear only .cache so we re-use images
+      await cleanEntry(cacheDirs[1])
+
       run('yarn build')
     }
   }

--- a/scripts/exclude-links.txt
+++ b/scripts/exclude-links.txt
@@ -5,7 +5,6 @@ https://$
 http://s3-external-1.amazonaws.com/bucket/path
 https://accounts.google.com/o/oauth2/auth
 https://api.cloudflare.com/client/v4/zones/$
-https://api.github.com/repos/$
 https://circleci.com/gh/iterative/dvc.org
 https://discuss.$
 https://drive.google.com/drive/folders/0AIac4JZqHhKmUk9PDA
@@ -16,7 +15,6 @@ https://example.com/file.csv
 https://example.com/path/to/data.csv
 https://example.com/path/to/dir
 https://example.com/path/to/file
-https://github.com/$
 https://github.com/example/project.git
 https://github.com/example/registry
 https://github.com/iterative/dvc.org/blob/master/content$

--- a/scripts/s3-utils.js
+++ b/scripts/s3-utils.js
@@ -94,8 +94,12 @@ async function uploadToS3(dir, childPrefix, basePrefix = s3Prefix) {
   console.timeEnd(timeString)
 }
 
+async function cleanEntry([dir]) {
+  return remove(localPath(dir))
+}
+
 async function cleanAllLocal(entries) {
-  return Promise.all(entries.map(([dir]) => remove(localPath(dir))))
+  return Promise.all(entries.map(cleanEntry))
 }
 
 async function downloadAllFromS3(entries, basePrefix) {
@@ -137,6 +141,7 @@ module.exports = {
   uploadAllToS3,
   downloadAllFromS3,
   withEntries,
+  cleanEntry,
   cleanAllLocal,
   prefixIsEmpty
 }

--- a/src/components/Home/LandingHero/GithubLine/index.tsx
+++ b/src/components/Home/LandingHero/GithubLine/index.tsx
@@ -14,8 +14,12 @@ const GithubLine: React.FC = () => {
       <Link href="https://github.com/iterative/dvc" className={styles.link}>
         GitHub
       </Link>
-      <img className={styles.starIcon} src="/img/star_small.svg" alt="" />
-      <span className={styles.count}>{stars || '---'}</span>
+      {stars && (
+        <span className={styles.starCount}>
+          <img className={styles.starIcon} src="/img/star_small.svg" alt="" />
+          <span className={styles.count}>{stars}</span>
+        </span>
+      )}
     </div>
   )
 }

--- a/src/components/Home/LandingHero/GithubLine/index.tsx
+++ b/src/components/Home/LandingHero/GithubLine/index.tsx
@@ -5,7 +5,7 @@ import useStars from '../../../../gatsby/hooks/stars'
 import styles from './styles.module.css'
 
 const GithubLine: React.FC = () => {
-  const count = useStars()
+  const stars = useStars()
 
   return (
     <div className={styles.container}>
@@ -15,7 +15,7 @@ const GithubLine: React.FC = () => {
         GitHub
       </Link>
       <img className={styles.starIcon} src="/img/star_small.svg" alt="" />
-      <span className={styles.count}>{count}</span>
+      <span className={styles.count}>{stars || '---'}</span>
     </div>
   )
 }

--- a/src/components/Home/LandingHero/GithubLine/index.tsx
+++ b/src/components/Home/LandingHero/GithubLine/index.tsx
@@ -1,27 +1,17 @@
-import React, { useEffect, useState } from 'react'
-import fetch from 'isomorphic-fetch'
+import React from 'react'
 import Link from '../../../Link'
+import useStars from '../../../../gatsby/hooks/stars'
 
 import styles from './styles.module.css'
 
-const repo = `iterative/dvc`
-const gh = `https://github.com/${repo}`
-const api = `https://api.github.com/repos/${repo}`
-
 const GithubLine: React.FC = () => {
-  const [count, setCount] = useState('–––')
-
-  useEffect(() => {
-    fetch(api)
-      .then(res => res.json())
-      .then(data => setCount(data.stargazers_count))
-  }, [count, setCount])
+  const count = useStars()
 
   return (
     <div className={styles.container}>
       <img className={styles.githubLogo} src="/img/github_small.png" alt="" />
       We’re on
-      <Link href={gh} className={styles.link}>
+      <Link href="https://github.com/iterative/dvc" className={styles.link}>
         GitHub
       </Link>
       <img className={styles.starIcon} src="/img/star_small.svg" alt="" />

--- a/src/gatsby/hooks/stars.ts
+++ b/src/gatsby/hooks/stars.ts
@@ -18,7 +18,7 @@ export default function useStars(): number {
   // Run an IIFE to update from the server on the client side.
   useEffect(() => {
     ;(async (): Promise<void> => {
-      const res = await fetch(`/api/github/stars?current=${stars}`)
+      const res = await fetch(`/api/github/stars`)
       if (res.status === 200) {
         const json = await res.json()
         setStars(json.stars)

--- a/src/gatsby/hooks/stars.ts
+++ b/src/gatsby/hooks/stars.ts
@@ -23,7 +23,7 @@ export default function useStars(): number {
 
   // Run an IIFE to update from the server on the client side.
   useEffect(() => {
-    ;(async (): undefined => {
+    ;(async (): Promise<void> => {
       const res = await fetch(`/api/github/stars?current=${stars}`)
       if (res.status === 200) {
         const json = await res.json()

--- a/src/gatsby/hooks/stars.ts
+++ b/src/gatsby/hooks/stars.ts
@@ -1,0 +1,36 @@
+import { useEffect, useState } from 'react'
+import { useStaticQuery, graphql } from 'gatsby'
+import fetch from 'isomorphic-fetch'
+
+export default function useStars(): number {
+  // Get the amount of stars from build time
+  const staticStars = useStaticQuery(graphql`
+    query GithubStarsQuery {
+      githubData {
+        data {
+          repository {
+            stargazers {
+              totalCount
+            }
+          }
+        }
+      }
+    }
+  `).githubData.data.repository.stargazers.totalCount
+
+  // Maintain an updatable state so we can update stars on delivery
+  const [stars, setStars] = useState(staticStars)
+
+  // Run an IIFE to update from the server on the client side.
+  useEffect(() => {
+    ;(async (): undefined => {
+      const res = await fetch(`/api/github/stars?current=${stars}`)
+      if (res.status === 200) {
+        const json = await res.json()
+        setStars(json.stars)
+      }
+    })()
+  }, [])
+
+  return stars
+}

--- a/src/gatsby/hooks/stars.ts
+++ b/src/gatsby/hooks/stars.ts
@@ -22,6 +22,10 @@ export default function useStars(): number {
       if (res.status === 200) {
         const json = await res.json()
         setStars(json.stars)
+      } else {
+        console.log(
+          `Stars update response status was ${res.status}! Skipping update.`
+        )
       }
     })()
   }, [])

--- a/src/gatsby/hooks/stars.ts
+++ b/src/gatsby/hooks/stars.ts
@@ -6,17 +6,11 @@ export default function useStars(): number {
   // Get the amount of stars from build time
   const staticStars = useStaticQuery(graphql`
     query GithubStarsQuery {
-      githubData {
-        data {
-          repository {
-            stargazers {
-              totalCount
-            }
-          }
-        }
+      staticGithubData {
+        stars
       }
     }
-  `).githubData.data.repository.stargazers.totalCount
+  `).staticGithubData.stars
 
   // Maintain an updatable state so we can update stars on delivery
   const [stars, setStars] = useState(staticStars)

--- a/src/gatsby/hooks/stars.ts
+++ b/src/gatsby/hooks/stars.ts
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react'
 import { useStaticQuery, graphql } from 'gatsby'
 import fetch from 'isomorphic-fetch'
 
-export default function useStars(): number {
+export default function useStars(): number | null {
   // Get the amount of stars from build time
   const staticStars = useStaticQuery(graphql`
     query GithubStarsQuery {
@@ -13,7 +13,7 @@ export default function useStars(): number {
   `).staticGithubData.stars
 
   // Maintain an updatable state so we can update stars on delivery
-  const [stars, setStars] = useState(staticStars)
+  const [stars, setStars] = useState(null)
 
   // Run an IIFE to update from the server on the client side.
   useEffect(() => {
@@ -23,9 +23,10 @@ export default function useStars(): number {
         const json = await res.json()
         setStars(json.stars)
       } else {
-        console.log(
-          `Stars update response status was ${res.status}! Skipping update.`
+        console.warn(
+          `Stars update response status was ${res.status}! Using static value.`
         )
+        setStars(staticStars)
       }
     })()
   }, [])

--- a/src/gatsby/models.js
+++ b/src/gatsby/models.js
@@ -6,6 +6,7 @@ const imageSourcePaths = require('./models/image-source-paths')
 const jsonFiles = require('./models/json-files')
 const communityPage = require('./models/community')
 const glossary = require('./models/glossary')
+const github = require('./models/github')
 
 const models = [
   markdownContent,
@@ -15,7 +16,8 @@ const models = [
   imageSourcePaths,
   jsonFiles,
   communityPage,
-  glossary
+  glossary,
+  github
 ]
 
 module.exports = models

--- a/src/gatsby/models/authors/onCreateMarkdownContentNode.js
+++ b/src/gatsby/models/authors/onCreateMarkdownContentNode.js
@@ -1,6 +1,6 @@
 async function createMarkdownAuthorNode(api, { parentNode, createChildNode }) {
   if (parentNode.relativeDirectory.split('/')[0] !== 'authors') return
-  const { node, actions, createNodeId, createContentDigest } = api
+  const { node, createNodeId, createContentDigest } = api
   const { frontmatter, rawMarkdownBody } = node
   const { path, name, avatar, link } = frontmatter
   const { relativePath } = parentNode

--- a/src/gatsby/models/github/index.js
+++ b/src/gatsby/models/github/index.js
@@ -1,0 +1,52 @@
+/*
+   GitHub Static Data
+
+   This model serves as an intermediary between the templates and
+   gatsby-plugin-github-api. If no GITHUB_TOKEN is specified, this node will be
+   filled with default dummy data instead of throwing like using the plugin
+   alone does.
+*/
+
+async function createStaticGithubDataNode(api, fieldData = {}) {
+  const {
+    actions: { createNode },
+    createNodeId,
+    createContentDigest
+  } = api
+
+  const fields = {
+    stars: 8888,
+    parent: null,
+    ...fieldData
+  }
+
+  const node = {
+    id: createNodeId('DVCGithubStaticData'),
+    children: [],
+    ...fields,
+    internal: {
+      type: 'StaticGithubData',
+      contentDigest: createContentDigest(fields)
+    }
+  }
+
+  await createNode(node)
+
+  return node
+}
+
+module.exports = {
+  sourceNodes: createStaticGithubDataNode,
+  async onCreateNode(api) {
+    const {
+      node,
+      actions: { createParentChildLink }
+    } = api
+    if (node.internal.type !== 'GithubData') return
+    const child = await createStaticGithubDataNode(api, {
+      parent: node.id,
+      stars: node.rawResult.data.repository.stargazers.totalCount
+    })
+    await createParentChildLink({ child, parent: node })
+  }
+}

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -19,6 +19,7 @@ const express = require('express')
 const compression = require('compression')
 const { s3Url } = require('./config')
 const { isProduction } = require('./utils')
+require('dotenv').config()
 
 const port = process.env.PORT || 3000
 const app = express()

--- a/src/server/middleware/api/github.js
+++ b/src/server/middleware/api/github.js
@@ -60,9 +60,7 @@ async function getFreshGithubData() {
 
 async function issues(_, res) {
   if (!process.env.GITHUB_TOKEN) {
-    res
-      .status(200)
-      .json({ issues: [], error: 'No GITHUB_TOKEN specified on the server!' })
+    res.status(403)
   } else {
     if (cache.get('issues')) {
       if (!isProduction) console.log('Using cache for "issues"')
@@ -94,7 +92,7 @@ async function getStars() {
 
 async function stars(req, res) {
   if (!process.env.GITHUB_TOKEN) {
-    res.status(403).json({ error: 'No GITHUB_TOKEN specified on the server!' })
+    res.status(403)
   } else {
     const stars = await getStars()
     if (stars) {

--- a/src/server/middleware/api/github.js
+++ b/src/server/middleware/api/github.js
@@ -92,18 +92,15 @@ async function getStars() {
 
 async function stars(req, res) {
   if (!process.env.GITHUB_TOKEN) {
+    // We have no GitHub key, so reject as unauthorized
     res.status(403)
   } else {
     const stars = await getStars()
     if (stars) {
-      // If the data in unchanged, return a minimal response indicating so.
-      if (Number(req.query.current) === stars) {
-        console.log(`GitHub stars not changed from ${stars}`)
-        res.status(304)
-      } else {
-        res.status(200).json({ stars })
-      }
+      // If we got stars, successfully return a data payload with them
+      res.status(200).json({ stars })
     } else {
+      // Stars are missing for some reason, return 404
       res.status(404)
     }
   }

--- a/src/server/middleware/api/github.js
+++ b/src/server/middleware/api/github.js
@@ -5,9 +5,64 @@ const { isProduction } = require('../../utils')
 
 const cache = new NodeCache({ stdTTL: 900 })
 
-module.exports = async (_, res) => {
+async function getFreshGithubData() {
+  try {
+    const { repository } = await graphql(
+      `
+        {
+          repository(owner: "iterative", name: "dvc") {
+            stargazers {
+              totalCount
+            }
+            issues(
+              first: 3
+              states: OPEN
+              orderBy: { field: CREATED_AT, direction: DESC }
+            ) {
+              edges {
+                node {
+                  title
+                  createdAt
+                  url
+                  comments {
+                    totalCount
+                  }
+                }
+              }
+            }
+          }
+        }
+      `,
+      {
+        headers: {
+          authorization: `token ${process.env.GITHUB_TOKEN}`
+        }
+      }
+    )
+
+    const issues = repository.issues.edges.map(({ node }) => ({
+      title: node.title,
+      url: node.url,
+      comments: node.comments.totalCount,
+      date: node.createdAt
+    }))
+
+    const stars = repository.stargazers.totalCount
+
+    cache.set('issues', issues)
+    cache.set('stars', stars)
+
+    return { issues, stars }
+  } catch (e) {
+    return { error: e.message || e }
+  }
+}
+
+async function issues(_, res) {
   if (!process.env.GITHUB_TOKEN) {
-    res.status(200).json({ issues: [] })
+    res
+      .status(200)
+      .json({ issues: [], error: 'No GITHUB_TOKEN specified on the server!' })
   } else {
     if (cache.get('issues')) {
       if (!isProduction) console.log('Using cache for "issues"')
@@ -15,51 +70,48 @@ module.exports = async (_, res) => {
       res.status(200).json({ issues: cache.get('issues') })
     } else {
       console.log('Not using cache for "issues"')
+      const { issues } = await getFreshGithubData()
+      if (!issues) {
+        res.status(404)
+      } else {
+        res.status(200).json({ issues })
+      }
     }
+  }
+}
 
-    try {
-      const { repository } = await graphql(
-        `
-          {
-            repository(owner: "iterative", name: "dvc") {
-              issues(
-                first: 3
-                states: OPEN
-                orderBy: { field: CREATED_AT, direction: DESC }
-              ) {
-                edges {
-                  node {
-                    title
-                    createdAt
-                    url
-                    comments {
-                      totalCount
-                    }
-                  }
-                }
-              }
-            }
-          }
-        `,
-        {
-          headers: {
-            authorization: `token ${process.env.GITHUB_TOKEN}`
-          }
-        }
-      )
+async function getStars() {
+  const cachedValue = cache.get('stars')
+  if (cachedValue) {
+    if (!isProduction) console.log('Using cache for "stars"')
+    return cachedValue
+  } else {
+    console.log('Not using cache for "stars"')
+    const { stars } = await getFreshGithubData()
+    return stars
+  }
+}
 
-      const issues = repository.issues.edges.map(({ node }) => ({
-        title: node.title,
-        url: node.url,
-        comments: node.comments.totalCount,
-        date: node.createdAt
-      }))
-
-      cache.set('issues', issues)
-
-      res.status(200).json({ issues })
-    } catch (e) {
+async function stars(req, res) {
+  if (!process.env.GITHUB_TOKEN) {
+    res.status(403).json({ error: 'No GITHUB_TOKEN specified on the server!' })
+  } else {
+    const stars = await getStars()
+    if (stars) {
+      // If the data in unchanged, return a minimal response indicating so.
+      if (Number(req.query.current) === stars) {
+        console.log(`GitHub stars not changed from ${stars}`)
+        res.status(304)
+      } else {
+        res.status(200).json({ stars })
+      }
+    } else {
       res.status(404)
     }
   }
+}
+
+module.exports = {
+  stars,
+  issues
 }

--- a/src/server/middleware/api/github.js
+++ b/src/server/middleware/api/github.js
@@ -60,17 +60,19 @@ async function getFreshGithubData() {
 
 async function issues(_, res) {
   if (!process.env.GITHUB_TOKEN) {
-    res.status(403)
+    // We have no GitHub key, so reject as unauthorized
+    res.status(403).send()
   } else {
-    if (cache.get('issues')) {
+    const cachedValue = cache.get('issues')
+    if (cachedValue) {
       if (!isProduction) console.log('Using cache for "issues"')
-
-      res.status(200).json({ issues: cache.get('issues') })
+      res.status(200).json({ issues: cachedValue })
     } else {
       console.log('Not using cache for "issues"')
       const { issues } = await getFreshGithubData()
       if (!issues) {
-        res.status(404)
+        // No cached nor fresh issues found: return 404
+        res.status(404).send()
       } else {
         res.status(200).json({ issues })
       }
@@ -93,15 +95,15 @@ async function getStars() {
 async function stars(req, res) {
   if (!process.env.GITHUB_TOKEN) {
     // We have no GitHub key, so reject as unauthorized
-    res.status(403)
+    res.status(403).send()
   } else {
     const stars = await getStars()
     if (stars) {
       // If we got stars, successfully return a data payload with them
       res.status(200).json({ stars })
     } else {
-      // Stars are missing for some reason, return 404
-      res.status(404)
+      // Stars are missing for some reason: return 404
+      res.status(404).send()
     }
   }
 }

--- a/src/server/middleware/api/index.js
+++ b/src/server/middleware/api/index.js
@@ -6,7 +6,7 @@ const { issues, stars } = require('./github')
 
 routes.get('/comments', comments)
 routes.get('/discourse', discourse)
-routes.get('/github', issues)
+routes.get('/github/issues', issues)
 routes.get('/github/stars', stars)
 
 module.exports = routes

--- a/src/server/middleware/api/index.js
+++ b/src/server/middleware/api/index.js
@@ -2,10 +2,11 @@ const routes = require('express').Router()
 
 const comments = require('./comments')
 const discourse = require('./discourse')
-const github = require('./github')
+const { issues, stars } = require('./github')
 
 routes.get('/comments', comments)
 routes.get('/discourse', discourse)
-routes.get('/github', github)
+routes.get('/github', issues)
+routes.get('/github/stars', stars)
 
 module.exports = routes

--- a/src/utils/front/api.ts
+++ b/src/utils/front/api.ts
@@ -62,7 +62,7 @@ export function useIssues(): UseApiResult<
   IGithubIssuesResponse,
   IGithubIssue[]
 > {
-  const response = useAPICall<IGithubIssuesResponse>('/api/github')
+  const response = useAPICall<IGithubIssuesResponse>('/api/github/issues')
 
   return { ...response, result: response.result?.issues }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,15 @@
 # yarn lockfile v1
 
 
+"101@^1.0.0", "101@^1.5.0":
+  version "1.6.3"
+  resolved "https://registry.yarnpkg.com/101/-/101-1.6.3.tgz#9071196e60c47e4ce327075cf49c0ad79bd822fd"
+  integrity sha512-4dmQ45yY0Dx24Qxp+zAsNLlMF6tteCyfVzgbulvSyC7tCyd3V8sW76sS0tHq8NpcbXfWTKasfyfzU1Kd86oKzw==
+  dependencies:
+    clone "^1.0.2"
+    deep-eql "^0.1.3"
+    keypather "^1.10.2"
+
 "@babel/code-frame@^7.0.0", "@babel/code-frame@^7.8.3":
   version "7.8.3"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.8.3.tgz#33e25903d7481181534e12ec0a25f16b6fcf419e"
@@ -5107,6 +5116,13 @@ dedent@^0.7.0:
   resolved "https://registry.yarnpkg.com/dedent/-/dedent-0.7.0.tgz#2495ddbaf6eb874abb0e1be9df22d2e5a544326c"
   integrity sha1-JJXduvbrh0q7Dhvp3yLS5aVEMmw=
 
+deep-eql@^0.1.3:
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/deep-eql/-/deep-eql-0.1.3.tgz#ef558acab8de25206cd713906d74e56930eb69f2"
+  integrity sha1-71WKyrjeJSBs1xOQbXTlaTDrafI=
+  dependencies:
+    type-detect "0.1.1"
+
 deep-equal@^1.0.1, deep-equal@^1.1.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/deep-equal/-/deep-equal-1.1.1.tgz#b5c98c942ceffaf7cb051e24e1434a25a2e6076a"
@@ -7432,6 +7448,14 @@ gatsby-source-filesystem@^2.2.2:
     valid-url "^1.0.9"
     xstate "^4.9.1"
 
+gatsby-source-github-api@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/gatsby-source-github-api/-/gatsby-source-github-api-0.2.1.tgz#80390254644054214debe5e9fdcdac7d316506c0"
+  integrity sha512-mu4ek8KjtiSjI0Wj9afeylSGdcOmD0piUy/RpEbuu5B+fj8LRW3h+SBvzwYmQhSsxYnwCXc2gjci6Efu2iQwzQ==
+  dependencies:
+    graphql-fetch "^1.0.1"
+    uuid "^3.1.0"
+
 gatsby-telemetry@^1.3.9:
   version "1.3.9"
   resolved "https://registry.yarnpkg.com/gatsby-telemetry/-/gatsby-telemetry-1.3.9.tgz#8ac311f6b3139cdf8e562b23a0e87d917de9ac0b"
@@ -8032,6 +8056,14 @@ graphql-config@^2.0.1:
     js-yaml "^3.10.0"
     lodash "^4.17.4"
     minimatch "^3.0.4"
+
+graphql-fetch@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/graphql-fetch/-/graphql-fetch-1.0.1.tgz#145112b27c603f06387a41ca4db58dd1edcaad9e"
+  integrity sha1-FFESsnxgPwY4ekHKTbWN0e3KrZ4=
+  dependencies:
+    "101" "^1.5.0"
+    isomorphic-fetch "^2.2.1"
 
 graphql-import@^0.7.1:
   version "0.7.1"
@@ -10367,6 +10399,13 @@ jsx-ast-utils@^2.2.1, jsx-ast-utils@^2.2.3:
   dependencies:
     array-includes "^3.0.3"
     object.assign "^4.1.0"
+
+keypather@^1.10.2:
+  version "1.10.2"
+  resolved "https://registry.yarnpkg.com/keypather/-/keypather-1.10.2.tgz#e0449632d4b3e516f21cc014ce7c5644fddce614"
+  integrity sha1-4ESWMtSz5RbyHMAUznxWRP3c5hQ=
+  dependencies:
+    "101" "^1.0.0"
 
 keyv@3.0.0:
   version "3.0.0"
@@ -16474,6 +16513,11 @@ type-check@~0.3.2:
   dependencies:
     prelude-ls "~1.1.2"
 
+type-detect@0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-0.1.1.tgz#0ba5ec2a885640e470ea4e8505971900dac58822"
+  integrity sha1-C6XsKohWQORw6k6FBZcZANrFiCI=
+
 type-detect@4.0.8:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.0.8.tgz#7646fb5f18871cfbb7749e69bd39a6388eb7450c"
@@ -17036,7 +17080,7 @@ uuid@3.3.2:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.2.tgz#1b4af4955eb3077c501c23872fc6513811587131"
   integrity sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==
 
-uuid@3.4.0, uuid@^3.0.0, uuid@^3.0.1, uuid@^3.3.2, uuid@^3.3.3, uuid@^3.4.0:
+uuid@3.4.0, uuid@^3.0.0, uuid@^3.0.1, uuid@^3.1.0, uuid@^3.3.2, uuid@^3.3.3, uuid@^3.4.0:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"
   integrity sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==


### PR DESCRIPTION
- Uses `gatsby-source-github-api` to get GitHub data at build time

- Splits the GitHub Issues proxy API into one for Issues and Stars, sharing the
  query data. The new endpoint is `/api/github/stars`.

- Updates the GithubLine component to display the build-time value at first, then update
  via the proxy as soon as possible to reflect any changes. If the value hasn't 
  changed or there was an error, the component keeps the static value.

Fixes #1019 