### PR TITLE
[WIP] Absorbing Core Features

### DIFF
--- a/content/docs/tutorials/get-started/agenda.md
+++ b/content/docs/tutorials/get-started/agenda.md
@@ -26,9 +26,10 @@ with `python`.
 ![](/img/example-flow-2x.png)
 
 This is a natural language processing context, but NLP isn't the only area of
-data science where DVC can help. DVC is designed to be agnostic of frameworks,
-languages, etc. If you have data files or datasets and/or you produce data
-files, models, or datasets and you want to:
+data science where DVC can help. DVC is designed to be **Programming language 
+agnostic**: Python, R, Julia, shell scripts, etc. as well as **ML library agnostic**: 
+Keras, Tensorflow, PyTorch, Scipy, etc.. If you have data files or datasets and/or 
+you produce data files, models, or datasets and you want to:
 
 - Capture and save those <abbr>data artifacts</abbr> the same way you capture
   code

--- a/content/docs/tutorials/get-started/agenda.md
+++ b/content/docs/tutorials/get-started/agenda.md
@@ -1,8 +1,9 @@
 # Agenda
 
-You'll need [Git](https://git-scm.com) to run the commands in this guide. Also,
-if DVC is not installed, please follow these [instructions](/doc/install) to do
-so.
+DVC works **on top of Git repositories** and has a similar command line interface 
+and Git workflow. You'll need [Git](https://git-scm.com) to run the commands in 
+this guide. Also, if DVC is not installed, please follow these [instructions](/doc/install) 
+to do so.
 
 In the next few sections we'll build a simple natural language processing (NLP)
 project from scratch. If you'd like to get the final result or have any issues

--- a/content/docs/tutorials/get-started/pipeline.md
+++ b/content/docs/tutorials/get-started/pipeline.md
@@ -7,6 +7,9 @@ outputs of a command (stage) as dependencies in another one, we can describe a
 sequence of commands that gets to a desired result. This is what we call a
 **data pipeline** or dependency graph.
 
+The support for pipelines is what enables DVC to makes data science projects 
+**reproducible** using implicit dependency graphs.
+
 Let's create a second stage (after `prepare.dvc`, created in the previous
 chapter) to perform feature extraction:
 

--- a/content/docs/tutorials/get-started/pipeline.md
+++ b/content/docs/tutorials/get-started/pipeline.md
@@ -7,7 +7,7 @@ outputs of a command (stage) as dependencies in another one, we can describe a
 sequence of commands that gets to a desired result. This is what we call a
 **data pipeline** or dependency graph.
 
-The support for pipelines is what enables DVC to makes data science projects 
+This support for pipelines is what enables DVC to makes data science projects 
 **reproducible** using implicit dependency graphs.
 
 Let's create a second stage (after `prepare.dvc`, created in the previous

--- a/content/docs/user-guide/index.md
+++ b/content/docs/user-guide/index.md
@@ -4,9 +4,11 @@ Our guides describe the main DVC concepts and features comprehensively,
 explaining when and how to use them, as well as connections between them. These
 guides don't focus on specific scenarios, but have a general scope – like a user
 manual. Their topics range from more technical foundations, impacting more parts
-of DVC, to more advanced and specific things you can do. We also include a few
-guides related to contributing to
-[this open-source project](https://github.com/iterative/dvc).
+of DVC, to more advanced and specific things you can do. 
+
+Being an open-source and a self-serve projects, we would appreciate it if you 
+consider contributing to [the project](https://github.com/iterative/dvc). We also 
+have a few guides to help you get started with the same. 
 
 Please choose from the navigation sidebar to the left, or click the `Next`
 button below ↘


### PR DESCRIPTION
#425
I have worked out how we could absorb the core features section into the rest of the documentation especially into more introsuctory docs. 

I understand that I was specifically asked to work on deleting redundant data from the understanding DVC section. However, I think I now understand what you meant by absorbing. I have worked out the case for absorbing core features. I am only facing a little difficulty in the following bullet. 

> Large data file versioning works by creating special files in your Git repository that point to the cache, typically stored on a local hard drive.

I was told that https://dvc.org/doc/user-guide/large-dataset-optimization, couldn't be considered as an introductory doc. But if my idea is right I still think I can merge the above bullet into the beginning of the User Guide or Get Started. 

> You may disregard these recommendations if you used the **Edit on GitHub** button from dvc.org to improve a doc in place.

❗ Please read the guidelines in the [Contributing to the Documentation](https://dvc.org/doc/user-guide/contributing/docs) list if you make any substantial changes to the documentation or JS engine.

🐛 Please make sure to mention `Fix #issue` (if applicable) in the description of the PR. This causes GitHub to close it automatically when the PR is merged.

Please choose to [allow us](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to edit your branch when creating the PR.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
