### PR TITLE
hotfix: fix commit desc (broken tooltip)

### DIFF
--- a/content/docs/command-reference/commit.md
+++ b/content/docs/command-reference/commit.md
@@ -1,7 +1,7 @@
 # commit
 
 Record changes to DVC-tracked files in the <abbr>project</abbr>, by updating
-[DVC-files](/doc/user-guide/dvc-file-format) and saving <abbr>outputs<abbr> to
+[DVC-files](/doc/user-guide/dvc-file-format) and saving <abbr>outputs</abbr> to
 the <abbr>cache</abbr>.
 
 ## Synopsis
@@ -20,7 +20,7 @@ positional arguments:
 The `dvc commit` command is useful for several scenarios, when data already
 tracked by DVC changes: when a [stage](/doc/command-reference/run) or
 [pipeline](/doc/command-reference/pipeline) is in development/experimentation;
-when manually editing or generating DVC <abbr>outputs<abbr>; or to force
+when manually editing or generating DVC <abbr>outputs</abbr>; or to force
 DVC-file updates without reproducing stages or pipelines. These scenarios are
 further detailed below.
 


### PR DESCRIPTION
Fixes this:

![image](https://user-images.githubusercontent.com/1477535/83939492-101c0100-a7a3-11ea-9d73-f5c65a9fec94.png)
> From https://dvc.org/doc/command-reference/commit

> You may disregard these recommendations if you used the **Edit on GitHub** button from dvc.org to improve a doc in place.

❗ Please read the guidelines in the [Contributing to the Documentation](https://dvc.org/doc/user-guide/contributing/docs) list if you make any substantial changes to the documentation or JS engine.

🐛 Please make sure to mention `Fix #issue` (if applicable) in the description of the PR. This causes GitHub to close it automatically when the PR is merged.

Please choose to [allow us](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to edit your branch when creating the PR.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
