### PR TITLE
blog: 1.0 copyediting

### DIFF
--- a/content/blog/2020-06-22-dvc-1-0-release.md
+++ b/content/blog/2020-06-22-dvc-1-0-release.md
@@ -24,8 +24,8 @@ tags:
 ## Introduction
 
 3 years ago, I was concerned about good engineering standards in data science:
-data versioning, reproducibility, workflow automation like continuous
-integration and continuous delivery (CI/CD) but for machine learning. I wanted
+data versioning, reproducibility, workflow automation - like continuous
+integration and continuous delivery (CI/CD) - but for machine learning. I wanted
 there to be Git for data to make this possible. So I made DVC (Data Version
 Control), which works as version control for data projects.
 
@@ -39,11 +39,11 @@ of data scientists, ML engineers, developers and software engineers.
 
 ## DVC 1.0
 
-The new DVC 1.0. is inspired by discussions and contributions from our
+The new DVC 1.0 is inspired by discussions and contributions from our
 community - both fresh ideas and bug reports 😅. All these contributions, big
-and small, have a collective impact on DVC's development- I'm confident 1.0
+and small, have a collective impact on DVC's development - I'm confident 1.0
 wouldn't be possible without our community. They tell us what features matter
-most, what approaches work and (and what don't!), and what they need from DVC to
+most, what approaches work (and what don't!), and what they need from DVC to
 support their ML projects.
 
 A few weeks ago we announced the 1.0 prerelease. After lots of helpful feedback
@@ -56,18 +56,17 @@ for more details.
 
 It took us 3 years to finalize the requirements for DVC 1.0 and stabilize the
 commands (API) and DVC file formats. Below are the major lessons that we have
-learned in 3 years of this journey and how the lessons are reflected to the new
-DVC.
+learned in 3 years of this journey and how these are reflected in the new DVC.
 
 ### [Multi-stage DVC files](https://github.com/iterative/dvc/issues/1871)
 
 Our users taught us that ML pipelines evolve much faster than data engineering
 pipelines with data processing steps. People need to change the commands of the
-pipeline often and it was not easy to do in the old DVC files.
+pipeline often and it was not easy to do with the old DVC files.
 
-In DVC 1.0 the DVC file format was changed in three big ways. First, instead of
+In DVC 1.0, the DVC file format was changed in three big ways. First, instead of
 multiple DVC stage files (`*.dvc`), each project has a single DVC file
-`dvc.yaml`. By default, all stages go in this single .yaml file.
+`dvc.yaml`. By default, all stages go in this single `.yaml` file.
 
 Second, we made clear connections between the `dvc run` command, where pipeline
 stages are defined, and how stages appear in `dvc.yaml`. Many of the `dvc run`
@@ -76,8 +75,8 @@ to edit an existing pipeline by making `dvc.yaml` more human readable and
 writable.
 
 Third, data hash values are no longer stored in the pipeline metafile. This
-approach aligns better with GitOps paradigm and simplifies the usage of DVC
-because tremendously improves human-readability of the `dvc.yaml`:
+approach aligns better with GitOps paradigms and simplifies the usage of DVC by
+tremendously improving metafile human-readability:
 
 ```yaml
 stages:
@@ -107,58 +106,58 @@ stages:
 ```
 
 All the hashes have been moved to a special file, `dvc.lock`, which is a lot
-like the old dvc-file format. DVC uses the .lock file to define what data files
-need to be restored to the workspace from data remotes (cloud storage) and if a
-particular pipeline stage needs to be rerun. In other words, we're separating
-the human-readable parts of the pipeline into`dvc.yaml` and auto-generated
-"machine" parts into- `dvc.lock`.
+like the old DVC file format. DVC uses the `.lock` file to define what data
+files need to be restored to the workspace from data remotes (cloud storage) and
+if a particular pipeline stage needs to be rerun. In other words, we're
+separating the human-readable parts of the pipeline into `dvc.yaml` and
+auto-generated "machine" parts into `dvc.lock`.
 
 Another cool change: the auto-generated part doesn't necessarily need to be
-stored in your Git repository, the new feature run-cache that eliminates the
-need of storing the lock file in Git repositories. That brings us to our next
-big feature:
+stored in your Git repository. The new run-cache feature eliminates the need of
+storing the lock file in Git repositories. That brings us to our next big
+feature:
 
 ### [Run cache](https://github.com/iterative/dvc/issues/1234)
 
 We built DVC with a workflow in mind: one experiment to one commit. Some users
-love it, but this approach gets clunky fast for others (like, folks who are
+love it, but this approach gets clunky fast for others (like folks who are
 grid-searching hyperparameter space). Forcing users to make Git commits for each
-ML experiment was a requirement for old DVC, if you wanted to snapshot your
+ML experiment was a requirement for the old DVC, if you wanted to snapshot your
 project or pipelines on each experiment. Moving forward, we want to give users
 more flexibility to decide how often they want to commit.
 
 We had an insight that data remotes (S3, Azure Blob, SSH etc) can be used
 instead of Git for storing the codified meta information, not only data. In DVC
-1.0 a special structure is implemented - run-cache - that preserves the state in
-cluding all the hashes. Basically, all the information that is stored in the new
-`dvc.lock` file is replicated in the run cache.
+1.0 a special structure is implemented - run-cache - that preserves the state
+including all the hashes. Basically, all the information that is stored in the
+new `dvc.lock` file is replicated in the run-cache.
 
 The advantage of the run-cache is that pipeline runs (and output file versions)
 are not directly connected to Git commits anymore. New DVC can store all the
-runs in run-cache- even if they were never committed to Git.
+runs in run-cache - even if they were never committed to Git.
 
 This approach gives DVC a "long memory" of DVC stages runs. If a user runs a
-command that was run before (Git committed or not), then DVC can return the
-result of the command from the cache without rerunning it. It is a useful
-feature for hyperparameter optimization stage when users return to the previous
-sets of the parameters and don't want to wait for ML retraining.
+command that was run before (whether Git committed or not), then DVC can return
+the result of the command from the cache without rerunning it. It is a useful
+feature for a hyperparameter optimization stage - when users return to the
+previous sets of the parameters and don't want to wait for ML retraining.
 
-Another benefit of the run-cache is related to CI/CD systems for ML which is a
+Another benefit of the run-cache is related to CI/CD systems for ML, which is a
 holy grail of MLOps. The long memory means users don't have to make auto-commits
 in their CI/CD system side - see
 [this stackowerflow question](https://stackoverflow.com/questions/61245284/will-you-automate-git-commit-into-ci-cd-pipline-to-save-dvc-run-experiments).
 
 ### [Plots](https://github.com/iterative/dvc/issues/3409)
 
-Countless users have asked when we'd support metrics visualizations. It become
-clear that metrics, metrics visualization is an essential part of _DataOps_
+Countless users have asked when we'd support metrics visualizations. It became
+clear that metrics and their visualization are an essential part of _DataOps_,
 especially when it comes down to navigation around ML models, datasets and
 experiments. Now it's here: DVC 1.0 introduces metrics file visualization
-commands, `dvc plots diff` and `dvc plots show`. This is a brand new
-functionality in DVC and it's _in experimentation mode_ now.
+commands, `dvc plots diff` and `dvc plots show`. This is brand-new functionality
+in DVC and it's _in experimental mode_ now.
 
 This function is designed not only for visualizing the current state of your
-project, but it also for comparing plots across your Git history. Users can
+project, but also for comparing plots across your Git history. Users can
 visualize how, for example, their model accuracy in the latest commit differs
 from another commit (or even multiple commits).
 
@@ -188,32 +187,32 @@ confusion matrices, so you can just point DVC plots to your metrics and go.
 
 ### [Data transfer optimizations](https://github.com/iterative/dvc/issues/3488)
 
-In _DataOps_, data transfer speed is huge. We've done substantial work to
-optimize data management commands, like `dvc pull / push / status -c / gc -c`.
-Now, based on the amount of data to move, DVC can choose the optimal strategy
-for traversing your data remote.
+In _DataOps_, data transfer speed is hugely important. We've done substantial
+work to optimize data management commands, like
+`dvc pull / push / status -c / gc -c`. Now, based on the amount of data to move,
+DVC can choose the optimal strategy for traversing your data remote.
 
 [Mini-indexes](https://github.com/iterative/dvc/issues/2147) help DVC instantly
 check data directories instead of iterating over millions of files. This also
-speeds adding/removing files to large directories.
+speeds up adding/removing files to/from large directories.
 
-More optimizations are included in the release based on performance bottlenecks
-we profiled. More detailed
-[benchmark report](https://gist.github.com/pmrowla/338d9645bd05df966f8aba8366cab308)
-that shows how many second it takes to run a specific commands on 2M images
-directory.
+More optimizations are included in the release based on our profiling of
+performance bottlenecks. More detailed
+[benchmark reports](https://gist.github.com/pmrowla/338d9645bd05df966f8aba8366cab308)
+show how many seconds it takes to run specific commands on a directory
+containing 2 million images.
 
 ![](/uploads/images/2020-05-04/benchmarks.svg)
 
 ### [Hyperparameter tracking](https://github.com/iterative/dvc/issues/3393)
 
-This feature was actually released in the last DVC 0.93 version (see
+This feature was actually released in the last DVC 0.93 version (see the
 [params docs](https://dvc.org/doc/command-reference/params). However, it is an
 important step to support configuration files and ML experiments in a more
 holistic way.
 
-The parametes is a special type of dependencies in the pipelines. This is the
-way of talling DVC that a command depends not on a file (`params.yaml`) but on a
+The parameters are a special type of dependency in the pipelines. This is the
+way of telling DVC that a command depends not on a file (`params.yaml`) but on a
 particular set of values in the file:
 
 ```dvc
@@ -222,7 +221,7 @@ $ dvc run -d users.csv -o model.pkl \
         python train.py
 ```
 
-The params.yaml is the place where the parameters are stored:
+The `params.yaml` file is the place where the parameters are stored:
 
 ```yaml
 lr: 0.0041
@@ -238,24 +237,24 @@ process:
 
 ### Stable releases cycles
 
-Today many teams use DVC in their daily job for modeling and as part of their
-production MLOps automation systems. Stability plays more and more important
+Today, many teams use DVC in their daily job for modeling and as part of their
+production MLOps automation systems. Stability plays an increasingly important
 role.
 
 We've always prioritized agility and speed in our development process. There
 have been weeks with two DVC releases! This approach had a ton of benefits in
-terms of learning speed and fast feedback from users.
+terms of learning speed and rapid feedback from users.
 
 Now we're seeing signs that it's time to shift gears. Our API is stabilized and
-version 1.0 is built with our long-term vision in mind. Our user base has grown
-and we have footing with mature teams - teams that are using DVC in mission
-critical systems. That's why we're intentionally going to spend more time on
-release testing in the future - it might increase the time between releases, but
-the quality of the tool will be more predictable.
+version 1.0 is built with our long-term vision in mind. Our user-base has grown
+and we have footing with mature teams - teams that are using DVC in
+mission-critical systems. That's why we're intentionally going to spend more
+time on release testing in the future. It might increase the time between
+releases, but the quality of the tool will be more predictable.
 
 Additionally, we've already implemented a benchmark testing framework to track
 performance across potential releases: https://iterative.github.io/dvc-bench/ In
-this web site, anyone can see the performance improvements and degradations for
+this website, anyone can see the performance improvements and degradations for
 every release candidate:
 
 ![](/uploads/images/2020-06-22/dvc-benchmark.png)
@@ -267,7 +266,7 @@ that's what we'll be doing. We'll be posting more soon.
 [Peter Rowlands](https://github.com/pmrowla) will be writing a blog post about
 the performance optimization in DVC 1.0,
 [Paweł Redzyński](https://github.com/pared) about versioning and visualizing
-plots, [Saugat Pachhai](https://github.com/skshetry) about the new dvc file
+plots, [Saugat Pachhai](https://github.com/skshetry) about the new DVC file
 formats and pipelines, and [Ruslan Kuprieiev](https://github.com/efiop) about
 run-cache.
 
@@ -278,7 +277,7 @@ Please stay in touch and subscribe to our newsletter in http://dvc.org.
 It's quite a journey to build an open source project in the ML/AI space. We're
 fortunate to have a community of DVC users, contributors and cheerleaders. All
 these folks tremendously help us to define, test and develop the project. We've
-reached this significant milestone of 1.0 version together and I hope we'll
+reached this significant milestone of version 1.0 together and I hope we'll
 continue working on DVC and bringing the best practices of DataOps and MLOps to
 the ML/AI space.
 


### PR DESCRIPTION
Reading through and noticed a few minor typos in the 1.0 blog post.

[Diff ignoring whitespace](https://github.com/iterative/dvc.org/pull/1477/files?w=1)