### PR TITLE
remove: updated to match with core repo

### DIFF
--- a/content/docs/command-reference/remove.md
+++ b/content/docs/command-reference/remove.md
@@ -13,9 +13,11 @@ positional arguments:
 
 ## Description
 
-This command safely removes stages from [dvc.yaml](/doc/user-guide/dvc-files-and-directories#dvcyaml-file), their `.gitignore` entries, and optionally
-removes from the <abbr>workspace</abbr> files or directories that are tracked by
-DVC. It takes one or more stage names (see `-n` option of `dvc run`) or
+This command safely removes stages from
+[dvc.yaml](/doc/user-guide/dvc-files-and-directories#dvcyaml-file), their
+`.gitignore` entries, and optionally removes from the <abbr>workspace</abbr>
+files or directories that are tracked by DVC. It takes one or more stage names
+(see `-n` option of `dvc run`) or
 [`.dvc` files](/doc/user-guide/dvc-files-and-directories#dvc-files) as target,
 removes it, and optionally removes all of its outputs (`outs` field).
 
@@ -39,7 +41,8 @@ how it can be used to replace or modify files that are tracked by DVC.
 
 ## Examples
 
-Let's imagine we have a `data.csv` file t is that already [tracked](link to dvc add cmd ref please) with DVC:
+Let's imagine we have a `data.csv` file t is that already [tracked](link to dvc
+add cmd ref please) with DVC:
 
 ```dvc
 $ dvc add data.csv
@@ -50,7 +53,8 @@ $ cat .gitignore
 /data.csv
 ```
 
-Remove the `data.csv.dvc` file, and check that the data file is gone from `.gitignore`:
+Remove the `data.csv.dvc` file, and check that the data file is gone from
+`.gitignore`:
 
 ```dvc
 $ dvc remove data.csv.dvc

--- a/content/docs/command-reference/remove.md
+++ b/content/docs/command-reference/remove.md
@@ -13,13 +13,11 @@ positional arguments:
 
 ## Description
 
-This command safely removes stage entries, `.gitignore` entries and optionally
+This command safely removes stages from [dvc.yaml](/doc/user-guide/dvc-files-and-directories#dvcyaml-file), their `.gitignore` entries, and optionally
 removes from the <abbr>workspace</abbr> files or directories that are tracked by
 DVC. It takes one or more stage names (see `-n` option of `dvc run`) or
 [`.dvc` files](/doc/user-guide/dvc-files-and-directories#dvc-files) as target,
-removes the stage entry from
-[dvc.yaml](/doc/user-guide/dvc-files-and-directories#dvcyaml-file) or the `.dvc`
-file itself, and optionally removes all of its outputs (outs field).
+removes it, and optionally removes all of its outputs (`outs` field).
 
 Note that it does not remove files from the DVC cache or remote storage (see
 `dvc gc`). However, remember to run `dvc push` to save the files you actually
@@ -41,29 +39,24 @@ how it can be used to replace or modify files that are tracked by DVC.
 
 ## Examples
 
-Let's imagine we have a `data.csv` data file, and track it with DVC:
+Let's imagine we have a `data.csv` file t is that already [tracked](link to dvc add cmd ref please) with DVC:
 
 ```dvc
 $ dvc add data.csv
 $ ls data.csv*
-
-    data.csv
-    data.csv.dvc
-
+data.csv
+data.csv.dvc
 $ cat .gitignore
-
-    /data.csv
+/data.csv
 ```
 
-Remove `data.csv` data file:
+Remove the `data.csv.dvc` file, and check that the data file is gone from `.gitignore`:
 
 ```dvc
 $ dvc remove data.csv.dvc
 $ ls data.csv*
-
-     data.csv
-
+data.csv
 $ cat .gitignore | wc -l
 
-    0
+0
 ```

--- a/content/docs/command-reference/remove.md
+++ b/content/docs/command-reference/remove.md
@@ -1,11 +1,11 @@
 # remove
 
-Remove DVC-tracked files or directories from the <abbr>workspace</abbr>.
+Remove stage entry, remove `.gitignore` entry and unprotect outputs.
 
 ## Synopsis
 
 ```usage
-usage: dvc remove [-h] [-q | -v] [-o | -p] [-f] targets [targets ...]
+usage: dvc remove [-h] [-q | -v] [--outs] targets [targets ...]
 
 positional arguments:
   targets        stages (found in dvc.yaml) or .dvc files to remove.
@@ -13,13 +13,13 @@ positional arguments:
 
 ## Description
 
-This command safely removes data files or directories that are tracked by DVC
-from the <abbr>workspace</abbr>. It takes one or more stage names (see `-n`
-option of `dvc run`) or
+This command safely removes stage entries, `.gitignore` entries and optionally
+removes from the <abbr>workspace</abbr> files or directories that are tracked by
+DVC. It takes one or more stage names (see `-n` option of `dvc run`) or
 [`.dvc` files](/doc/user-guide/dvc-files-and-directories#dvc-files) as target,
-removes all of its outputs (outs field), and optionally removes the stage entry
-from [dvc.yaml](/doc/user-guide/dvc-files-and-directories#dvcyaml-file) or the
-`.dvc` file itself.
+removes the stage entry from
+[dvc.yaml](/doc/user-guide/dvc-files-and-directories#dvcyaml-file) or the `.dvc`
+file itself, and optionally removes all of its outputs (outs field).
 
 Note that it does not remove files from the DVC cache or remote storage (see
 `dvc gc`). However, remember to run `dvc push` to save the files you actually
@@ -30,12 +30,7 @@ how it can be used to replace or modify files that are tracked by DVC.
 
 ## Options
 
-- `-o`, `--outs` - remove the outputs described in the given `targets`, keep the
-  `.dvc` files themselves. **This is the default behavior.**
-
-- `-p`, `--purge` - remove outputs and `.dvc` files.
-
-- `-f`, `--force` - force purge. Skip confirmation prompt.
+- `--outs` - remove outputs as well.
 
 - `-h`, `--help` - prints the usage/help message, and exit.
 
@@ -46,7 +41,7 @@ how it can be used to replace or modify files that are tracked by DVC.
 
 ## Examples
 
-Let's imagine have a `data.csv` data file, and track it with DVC:
+Let's imagine we have a `data.csv` data file, and track it with DVC:
 
 ```dvc
 $ dvc add data.csv
@@ -54,6 +49,10 @@ $ ls data.csv*
 
     data.csv
     data.csv.dvc
+
+$ cat .gitignore
+
+    /data.csv
 ```
 
 Remove `data.csv` data file:
@@ -62,12 +61,9 @@ Remove `data.csv` data file:
 $ dvc remove data.csv.dvc
 $ ls data.csv*
 
-     data.csv.dvc
-```
+     data.csv
 
-Purge `.dvc` files:
+$ cat .gitignore | wc -l
 
-```dvc
-$ dvc remove data.csv.dvc -p
-$ ls data.csv*
+    0
 ```

--- a/content/docs/command-reference/remove.md
+++ b/content/docs/command-reference/remove.md
@@ -60,7 +60,7 @@ Remove the `foo.csv.dvc` file, and check that the data file is gone from
 
 ```dvc
 $ dvc remove foo.csv.dvc
-$ ls *.csv*
+$ ls
 bar.csv
 bar.csv.dvc
 foo.csv

--- a/content/docs/command-reference/remove.md
+++ b/content/docs/command-reference/remove.md
@@ -1,6 +1,6 @@
 # remove
 
-Remove stage entry, remove `.gitignore` entry and unprotect outputs.
+Remove stage, `.gitignore` entry, and unprotect outputs.
 
 ## Synopsis
 

--- a/content/docs/command-reference/remove.md
+++ b/content/docs/command-reference/remove.md
@@ -41,8 +41,8 @@ how it can be used to replace or modify files that are tracked by DVC.
 
 ## Examples
 
-Let's imagine we have `foo.csv` and `bar.csv` files that are already [tracked](/doc/command-reference/add)
-with DVC:
+Let's imagine we have `foo.csv` and `bar.csv` files that are already
+[tracked](/doc/command-reference/add) with DVC:
 
 ```dvc
 $ ls *.csv*

--- a/content/docs/command-reference/remove.md
+++ b/content/docs/command-reference/remove.md
@@ -41,26 +41,29 @@ how it can be used to replace or modify files that are tracked by DVC.
 
 ## Examples
 
-Let's imagine we have a `data.csv` file t is that already [tracked](link to dvc
-add cmd ref please) with DVC:
+Let's imagine we have `foo.csv` and `bar.csv` files that are already [tracked](/doc/command-reference/add)
+with DVC:
 
 ```dvc
-$ dvc add data.csv
-$ ls data.csv*
-data.csv
-data.csv.dvc
+$ ls *.csv*
+bar.csv
+bar.csv.dvc
+foo.csv
+foo.csv.dvc
 $ cat .gitignore
-/data.csv
+/bar.csv
+/foo.csv
 ```
 
-Remove the `data.csv.dvc` file, and check that the data file is gone from
+Remove the `foo.csv.dvc` file, and check that the data file is gone from
 `.gitignore`:
 
 ```dvc
-$ dvc remove data.csv.dvc
-$ ls data.csv*
-data.csv
-$ cat .gitignore | wc -l
-
-0
+$ dvc remove foo.csv.dvc
+$ ls *.csv*
+bar.csv
+bar.csv.dvc
+foo.csv
+$ cat .gitignore
+/bar.csv
 ```

--- a/content/docs/command-reference/remove.md
+++ b/content/docs/command-reference/remove.md
@@ -30,7 +30,7 @@ how it can be used to replace or modify files that are tracked by DVC.
 
 ## Options
 
-- `--outs` - remove outputs as well.
+- `--outs` - remove the outputs described in the given `targets` as well.
 
 - `-h`, `--help` - prints the usage/help message, and exit.
 


### PR DESCRIPTION
Fixes #1490 

* `dvc remove` description updated according to implementation (see https://github.com/iterative/dvc/issues/4094 for context)

* `--outs` description updated according to implementation.

* `.gitignore` described in examples.

* Removed extra params: `-p`, `-f`.

* Removed shorthand for `--outs` (i.e. `-o`).

* Updated command description.
