### PR TITLE
docs: skipping hidden sidebar items

### DIFF
--- a/src/components/Community/Section/index.tsx
+++ b/src/components/Community/Section/index.tsx
@@ -89,7 +89,9 @@ const Section: React.FC<ICommunitySection> = ({
       {background && <img className={styles.picture} src={background} alt="" />}
 
       {isTablet ? (
-        <Collapse isOpened={isContentVisible}>{children}</Collapse>
+        <span hidden={!isContentVisible}>
+          <Collapse isOpened={isContentVisible}>{children}</Collapse>
+        </span>
       ) : (
         children
       )}

--- a/src/components/Documentation/Layout/SidebarMenu/index.tsx
+++ b/src/components/Documentation/Layout/SidebarMenu/index.tsx
@@ -99,16 +99,18 @@ const SidebarMenuItem: React.FC<ISidebarMenuItemProps> = ({
     <>
       {parentElement}
       {children && (
-        <Collapse isOpened={!!isActive}>
-          {children.map(item => (
-            <SidebarMenuItem
-              key={item.path}
-              activePaths={activePaths}
-              onClick={onClick}
-              {...item}
-            />
-          ))}
-        </Collapse>
+        <span hidden={!isActive}>
+          <Collapse isOpened={!!isActive}>
+            {children.map(item => (
+              <SidebarMenuItem
+                key={item.path}
+                activePaths={activePaths}
+                onClick={onClick}
+                {...item}
+              />
+            ))}
+          </Collapse>
+        </span>
       )}
     </>
   )

--- a/src/components/Home/UseCases/CollapsibleText/index.tsx
+++ b/src/components/Home/UseCases/CollapsibleText/index.tsx
@@ -31,7 +31,9 @@ const CollapsibleText: React.FC<ICollapsibleTextProps> = ({
       tabIndex={0}
     >
       {header}
-      <Collapse isOpened={isOpened}>{children}</Collapse>
+      <span hidden={!isOpened}>
+        <Collapse isOpened={isOpened}>{children}</Collapse>
+      </span>
       {!isOpened && <div className={styles.moreText}>More...</div>}
     </div>
   )


### PR DESCRIPTION
Fix #1240 

Currently, there is no way to implement it efficiently without a wrapper (https://github.com/nkbt/react-collapse/issues/255). There is an ancient pending PR (https://github.com/nkbt/react-collapse/pull/262) that tries to fix it, but it is about the `aria-hidden` attribute, so the tab navigation would be still broken even (if?) after the merge. I suggest living with this wrapper approach.