### PR TITLE
Document checkout after dvc pull --run-cache

### DIFF
--- a/content/docs/command-reference/pull.md
+++ b/content/docs/command-reference/pull.md
@@ -96,7 +96,9 @@ reflinks or hardlinks to put it in the workspace without copying. See
   `dvc remote list`).
 
 - `--run-cache` - downloads all available history of stage runs from the remote
-  repository.
+  repository into the local run cache. A `dvc repro <stage_name>` is necessary 
+  to checkout these files into the workspace and update the `dvc.lock`
+  file.
 
 - `-j <number>`, `--jobs <number>` - number of threads to run simultaneously to
   handle the downloading of files from the remote. The default value is


### PR DESCRIPTION
The header of this page implies that a `dvc pull` command is analogous to `dvc fetch && dvc checkout`.   
The fact that my working directory didn't change confused me, maybe this edit will make it clear to other users.

See https://discuss.dvc.org/t/best-practice-for-ci-with-run-cache/427/2
