### PR TITLE
Add an alert box above the header to advertise CML

### DIFF
--- a/src/components/LayoutHeader/index.tsx
+++ b/src/components/LayoutHeader/index.tsx
@@ -29,8 +29,10 @@ const LayoutHeader: React.FC<Required<ILayoutModifiable>> = ({ modifiers }) => {
       />
       <div className={styles.header}>
         <div className={cn(styles.alert, collapsed && styles.collapsed)}>
-          <span role="img" aria-label="rocket">🚀</span>
-          Check out the newest tool, {' '}
+          <span role="img" aria-label="rocket">
+            🚀
+          </span>
+          Check out the newest tool,{' '}
           <Link href="https://cml.dev">CML</Link>!
         </div>
         <LayoutWidthContainer

--- a/src/components/LayoutHeader/index.tsx
+++ b/src/components/LayoutHeader/index.tsx
@@ -32,7 +32,7 @@ const LayoutHeader: React.FC<Required<ILayoutModifiable>> = ({ modifiers }) => {
           <span role="img" aria-label="rocket">
             🚀
           </span>
-          Check out the newest tool,{' '}
+          Check out the newest tool,
           <Link href="https://cml.dev">CML</Link>!
         </div>
         <LayoutWidthContainer

--- a/src/components/LayoutHeader/index.tsx
+++ b/src/components/LayoutHeader/index.tsx
@@ -29,7 +29,7 @@ const LayoutHeader: React.FC<Required<ILayoutModifiable>> = ({ modifiers }) => {
       />
       <div className={styles.header}>
         <div className={cn(styles.alert, collapsed && styles.collapsed)}>
-          Check out the newest tool from Iterative,{' '}
+          🚀 Check out the newest tool, {' '}
           <Link href="https://cml.dev">CML</Link>!
         </div>
         <LayoutWidthContainer

--- a/src/components/LayoutHeader/index.tsx
+++ b/src/components/LayoutHeader/index.tsx
@@ -28,6 +28,10 @@ const LayoutHeader: React.FC<Required<ILayoutModifiable>> = ({ modifiers }) => {
         )}
       />
       <div className={styles.header}>
+        <div className={cn(styles.alert, collapsed && styles.collapsed)}>
+          Check out the newest tool from Iterative,{' '}
+          <Link href="https://cml.dev">CML</Link>!
+        </div>
         <LayoutWidthContainer
           className={cn(styles.container, collapsed && styles.collapsed)}
           wide={includes(modifiers, LayoutModifiers.Wide)}

--- a/src/components/LayoutHeader/index.tsx
+++ b/src/components/LayoutHeader/index.tsx
@@ -29,7 +29,8 @@ const LayoutHeader: React.FC<Required<ILayoutModifiable>> = ({ modifiers }) => {
       />
       <div className={styles.header}>
         <div className={cn(styles.alert, collapsed && styles.collapsed)}>
-          🚀 Check out the newest tool, {' '}
+          <span role="img" aria-label="rocket">🚀</span>
+          Check out the newest tool, {' '}
           <Link href="https://cml.dev">CML</Link>!
         </div>
         <LayoutWidthContainer

--- a/src/components/LayoutHeader/styles.module.css
+++ b/src/components/LayoutHeader/styles.module.css
@@ -59,3 +59,19 @@
   display: block;
   padding-top: 2px;
 }
+
+.alert {
+  height: 30px;
+  line-height: 30px;
+  font-size: 14px;
+  text-align: center;
+  width: 100%;
+  background-color: #dee;
+  transition: 0.5s all;
+  overflow: hidden;
+
+  &.collapsed {
+    height: 0;
+    transform: translateY(-100%);
+  }
+}

--- a/src/components/LayoutHeader/styles.module.css
+++ b/src/components/LayoutHeader/styles.module.css
@@ -61,9 +61,9 @@
 }
 
 .alert {
-  height: 30px;
-  line-height: 30px;
-  font-size: 14px;
+  height: 35px;
+  line-height: 35px;
+  font-size: 18px;
   text-align: center;
   width: 100%;
   background-color: #dee;


### PR DESCRIPTION
I'm sure we'll want changes to the text and color, but here's the implementation!

The current implementation is a simple div placed above the header, which collapses to zero height whenever the header collapses. This behavior can also be changed, especially if it has problems on corner cases.