### PR TITLE
docs: add intruction to create virtualenv

### DIFF
--- a/content/docs/start/data-pipelines.md
+++ b/content/docs/start/data-pipelines.md
@@ -38,6 +38,8 @@ Now let's install the requirements:
 > first.
 
 ```dvc
+$ python3 -m venv .env
+$ source .env/bin/activate
 $ pip install -r src/requirements.txt
 ```
 

--- a/content/docs/start/data-pipelines.md
+++ b/content/docs/start/data-pipelines.md
@@ -34,12 +34,10 @@ requirements.txt  train.py
 Now let's install the requirements:
 
 > We **strongly** recommend creating a
-> [virtual environment](https://packaging.python.org/tutorials/installing-packages/#creating-virtual-environments)
+> [virtual environment](https://python.readthedocs.io/en/stable/library/venv.html)
 > first.
 
 ```dvc
-$ python3 -m venv .env
-$ source .env/bin/activate
 $ pip install -r src/requirements.txt
 ```
 


### PR DESCRIPTION
Hello!
[edited]
This pull request changes the virtual virtual environment link from [python tutorials](https://packaging.python.org/tutorials/installing-packages/#creating-virtual-environments) to [python docs](https://python.readthedocs.io/en/stable/library/venv.html). 
The tutorials page has some text before getting to the command itself, the docs page is more straightforward so the user can paste the code get back to DVC guides :)
