### PR TITLE
Fix cache pruning

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -13,6 +13,7 @@ exports.createSchemaCustomization = api =>
 exports.sourceNodes = api => callOnModels(models, 'sourceNodes', api)
 exports.onCreateNode = api => callOnModels(models, 'onCreateNode', api)
 exports.createPages = api => callOnModels(models, 'createPages', api)
+exports.onPostBuild = api => callOnModels(models, 'onPostBuild', api)
 
 exports.onCreatePage = ({ page, actions }) => {
   setPageContext(page, actions)
@@ -42,5 +43,3 @@ exports.onCreateWebpackConfig = ({ stage, actions, getConfig }) => {
     actions.replaceWebpackConfig(config)
   }
 }
-
-exports.onPostBuild = api => callOnModels(models, 'onPostBuild', api)

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -1,5 +1,4 @@
 require('dotenv').config()
-const pruneCache = require('./src/gatsby/prune-cache')
 
 const {
   setPageContext,
@@ -44,6 +43,4 @@ exports.onCreateWebpackConfig = ({ stage, actions, getConfig }) => {
   }
 }
 
-exports.onPostBuild = api => {
-  return Promise.all([callOnModels(models, 'onPostBuild', api), pruneCache])
-}
+exports.onPostBuild = api => callOnModels(models, 'onPostBuild', api)

--- a/src/gatsby/models.js
+++ b/src/gatsby/models.js
@@ -7,6 +7,7 @@ const jsonFiles = require('./models/json-files')
 const communityPage = require('./models/community')
 const glossary = require('./models/glossary')
 const github = require('./models/github')
+const pruneCache = require('./models/prune-cache')
 
 const models = [
   markdownContent,
@@ -17,7 +18,8 @@ const models = [
   jsonFiles,
   communityPage,
   glossary,
-  github
+  github,
+  pruneCache
 ]
 
 module.exports = models

--- a/src/gatsby/models/prune-cache/index.js
+++ b/src/gatsby/models/prune-cache/index.js
@@ -1,5 +1,5 @@
 const fs = require('fs')
-const crawlPageData = require('../utils/shared/crawlPageData')
+const crawlPageData = require('../../../utils/shared/crawlPageData.js')
 
 async function removeFile(filePath) {
   return new Promise((resolve, reject) =>
@@ -15,7 +15,7 @@ async function removeFile(filePath) {
   )
 }
 
-module.exports = async function pruneStalePageCache({ graphql }) {
+exports.onPostBuild = async function pruneStalePageCache({ graphql }) {
   // Remove stale page-data from cache in production
 
   // Bail out early if we're in dev mode.


### PR DESCRIPTION
Fixes #1405, which I've confirmed is a cache issue with local testing.

We totally have a tool that prunes cache to solve that, I must have accidentally broken the invocation earlier before starting work on the CML site.

This PR turns the weird function-but-not-model pruner into a model like the other pieces of `gatsby-node` logic we use, both cleaning it up and fixing the invocation.