### PR TITLE
Updated repro.md for the DVC 1.0 release

### DIFF
--- a/content/docs/command-reference/repro.md
+++ b/content/docs/command-reference/repro.md
@@ -18,12 +18,15 @@ positional arguments:
 
 ## Description
 
-`dvc repro` provides an way to regenerate data pipeline results, by restoring
-the dependency graph (a
-[DAG](https://en.wikipedia.org/wiki/Directed_acyclic_graph)) implicitly defined
-by the [stage files](/doc/command-reference/run) (DVC-files with dependencies)
-that are found in the <abbr>project</abbr>. The commands defined in these stages
-can then be executed in the correct order, reproducing pipeline results.
+`dvc repro` provides a way to regenerate data pipeline results, by restoring the
+dependency graph ( a [DAG](https://en.wikipedia.org/wiki/Directed_acyclic_graph)
+) implicitly defined by the [stage files](/doc/command-reference/run) (DVC-files
+with dependencies) that are found in the <abbr>project</abbr>. The commands
+defined in these stages can then be executed in the correct order, reproducing
+pipeline results.
+
+`dvc repro` relies on the DAG definition that it reads from `dvc.yaml` file and
+uses `dvc.lock` file to determine what exactly needs to be run.
 
 > Pipeline stages are typically defined using the `dvc run` command, while
 > initial data dependencies can be registered by the `dvc add` command.


### PR DESCRIPTION
A PR as an outcome of the dicsussion at [#1445(review)](https://github.com/iterative/dvc.org/pull/1504#discussion_r448617904). 

This PR intends to completely update `dvc repro` documentation to sync with the 1.0 version of DVC.