### PR TITLE
pipeline: links and examples update for 1.x

### DIFF
--- a/content/docs/command-reference/commit.md
+++ b/content/docs/command-reference/commit.md
@@ -20,10 +20,10 @@ positional arguments:
 
 The `dvc commit` command is useful for several scenarios, when data already
 tracked by DVC changes: when a [stage](/doc/command-reference/run) or
-[pipeline](/doc/command-reference/pipeline) is in development/experimentation;
-when manually editing or generating DVC <abbr>outputs</abbr>; or to force
-DVC-file updates without reproducing stages or pipelines. These scenarios are
-further detailed below.
+[pipeline](/doc/command-reference/dag) is in development/experimentation; when
+manually editing or generating DVC <abbr>outputs</abbr>; or to force DVC-file
+updates without reproducing stages or pipelines. These scenarios are further
+detailed below.
 
 - Code or data for a stage is under active development, with multiple iterations
   (experiments) in code, configuration, or data. Use the `--no-commit` option of

--- a/content/docs/command-reference/fetch.md
+++ b/content/docs/command-reference/fetch.md
@@ -136,9 +136,6 @@ $ cd example-get-started
 
 </details>
 
-The workspace looks almost like in this
-[pipeline setup](/doc/start/data-pipelines):
-
 ```dvc
 .
 ├── data

--- a/content/docs/command-reference/fetch.md
+++ b/content/docs/command-reference/fetch.md
@@ -49,7 +49,7 @@ on DVC remotes.) These necessary data or model files are listed as
 <abbr>dependencies</abbr> or <abbr>outputs</abbr> in a target
 [stage](/doc/command-reference/run) (in `dvc.yaml`) or `.dvc` file, so they are
 required to [reproduce](/doc/tutorials/get-started/data-pipelines#reproduce) the
-corresponding [pipeline](/doc/command-reference/pipeline).
+corresponding [pipeline](/doc/command-reference/dag).
 
 `dvc fetch` ensures that the files needed for a stage or `.dvc` file to be
 [reproduced](/doc/tutorials/get-started/data-pipelines#reproduce) exist in
@@ -136,8 +136,7 @@ $ cd example-get-started
 
 </details>
 
-The workspace looks almost like in this
-[pipeline setup](/doc/tutorials/pipelines):
+The workspace looks almost like in this [pipeline setup](/doc/tutorials/dags):
 
 ```dvc
 .

--- a/content/docs/command-reference/fetch.md
+++ b/content/docs/command-reference/fetch.md
@@ -136,7 +136,8 @@ $ cd example-get-started
 
 </details>
 
-The workspace looks almost like in this [pipeline setup](/doc/tutorials/dags):
+The workspace looks almost like in this
+[pipeline setup](/doc/start/data-pipelines):
 
 ```dvc
 .

--- a/content/docs/command-reference/freeze.md
+++ b/content/docs/command-reference/freeze.md
@@ -20,7 +20,7 @@ reproduction will not regenerate <abbr>outputs</abbr> of frozen stages, even if
 their <abbr>dependencies</abbr> have changed, and even if `--force` is used.
 
 Freezing a stage is useful to avoid syncing data from the top of its
-[pipeline](/doc/command-reference/pipeline), and keep iterating on the last
+[pipeline](/doc/command-reference/dag), and keep iterating on the last
 (non-frozen) stages only.
 
 Note that <abbr>import stages</abbr> are frozen by default. Use `dvc update` to

--- a/content/docs/command-reference/import-url.md
+++ b/content/docs/command-reference/import-url.md
@@ -194,8 +194,8 @@ trying this example (especially if trying out the following one).
 
 What if that remote file is updated regularly? The project goals might include
 regenerating some results based on the updated data source.
-[Pipeline](/doc/command-reference/pipeline) reproduction can be triggered based
-on a changed external dependency.
+[Pipeline](/doc/command-reference/dag) reproduction can be triggered based on a
+changed external dependency.
 
 Let's use the [Get Started](/doc/tutorials/get-started) project again,
 simulating an updated external data source. (Remember to prepare the

--- a/content/docs/command-reference/index.md
+++ b/content/docs/command-reference/index.md
@@ -10,7 +10,7 @@ DVC is a command line tool. The typical DVC workflow goes as follows:
   `dvc run` command, along with its `--outs` option for <abbr>outputs</abbr>
   that should also be tracked by DVC after the code is executed.
 - Sharing a Git repository with the source code of your ML
-  [pipeline](/doc/command-reference/pipeline) will not include the project's
+  [pipeline](/doc/command-reference/dag) will not include the project's
   <abbr>cache</abbr>. Use [remote storage](/doc/command-reference/remote) and
   `dvc push` to share this cache (data tracked by DVC).
 - Use `dvc repro` to automatically reproduce your full pipeline, iteratively as

--- a/content/docs/command-reference/install.md
+++ b/content/docs/command-reference/install.md
@@ -33,7 +33,7 @@ This hook automates `dvc checkout` after `git checkout`.
 **Commit/Reproduce**: Before committing DVC changes with Git, it may be
 necessary using `dvc commit` to store new data files not yet in cache. Or the
 changes might require reproducing the corresponding
-[pipeline](/doc/command-reference/pipeline) (with `dvc repro`) to regenerate the
+[pipeline](/doc/command-reference/dag) (with `dvc repro`) to regenerate the
 project's results (which implicitly commits them to DVC as well).
 
 This hook automates `dvc status` before `git commit` when needed, to remind the

--- a/content/docs/command-reference/pull.md
+++ b/content/docs/command-reference/pull.md
@@ -168,12 +168,10 @@ Our [pipeline](/doc/command-reference/dag) has been setup with these
 [stages](/doc/command-reference/run):
 
 ```dvc
-$ dvc dag evaluate.dvc
-data/data.xml.dvc
-prepare.dvc
-featurize.dvc
-train.dvc
-evaluate.dvc
+$ dvc dag src/evaluate.py.dvc
++---------------------+
+| src/evaluate.py.dvc |
++---------------------+
 ```
 
 Imagine the [remote storage](/doc/command-reference/remote) has been modified

--- a/content/docs/command-reference/pull.md
+++ b/content/docs/command-reference/pull.md
@@ -184,7 +184,7 @@ One could do a simple `dvc pull` to get all the data, but what if you only want
 to retrieve part of the data?
 
 ```dvc
-$ dvc pull --with-deps featurize.dvc
+$ dvc pull --with-deps featurize
 
 ... Use the partial update, then pull the remaining data:
 

--- a/content/docs/command-reference/pull.md
+++ b/content/docs/command-reference/pull.md
@@ -165,12 +165,8 @@ $ dvc pull train.dvc
 > follow this example if you tried the previous ones.
 
 Our [pipeline](/doc/command-reference/dag) has been setup with these
-[stages](/doc/command-reference/run):
-
-> prepare  
-> featurize  
-> train  
-> evaluate
+[stages](/doc/command-reference/run): `prepare`, `featurize`, `train`,
+`evaluate`.
 
 Imagine the [remote storage](/doc/command-reference/remote) has been modified
 such that the data in some of these stages should be updated in the

--- a/content/docs/command-reference/pull.md
+++ b/content/docs/command-reference/pull.md
@@ -168,10 +168,28 @@ Our [pipeline](/doc/command-reference/dag) has been setup with these
 [stages](/doc/command-reference/run):
 
 ```dvc
-$ dvc dag src/evaluate.py.dvc
-+---------------------+
-| src/evaluate.py.dvc |
-+---------------------+
+$ dvc dag evaluate
+         +---------+
+         | prepare |
+         +---------+
+              *
+              *
+              *
+        +-----------+
+        | featurize |
+        +-----------+
+         **        **
+       **            *
+      *               **
++-------+               *
+| train |             **
++-------+            *
+         **        **
+           **    **
+             *  *
+        +----------+
+        | evaluate |
+        +----------+
 ```
 
 Imagine the [remote storage](/doc/command-reference/remote) has been modified

--- a/content/docs/command-reference/pull.md
+++ b/content/docs/command-reference/pull.md
@@ -165,7 +165,12 @@ $ dvc pull train.dvc
 > follow this example if you tried the previous ones.
 
 Our [pipeline](/doc/command-reference/dag) has been setup with these
-[stages](/doc/command-reference/run): prepare, featurize, train, evaluate.
+[stages](/doc/command-reference/run):
+
+> prepare  
+> featurize  
+> train  
+> evaluate
 
 Imagine the [remote storage](/doc/command-reference/remote) has been modified
 such that the data in some of these stages should be updated in the

--- a/content/docs/command-reference/pull.md
+++ b/content/docs/command-reference/pull.md
@@ -169,7 +169,7 @@ Our [pipeline](/doc/command-reference/dag) has been setup with these
 
 ```dvc
 $ dvc dag evaluate
-        +-------------------+
+    +-------------------+
     | data/data.xml.dvc |
     +-------------------+
               *

--- a/content/docs/command-reference/pull.md
+++ b/content/docs/command-reference/pull.md
@@ -165,38 +165,7 @@ $ dvc pull train.dvc
 > follow this example if you tried the previous ones.
 
 Our [pipeline](/doc/command-reference/dag) has been setup with these
-[stages](/doc/command-reference/run):
-
-```dvc
-$ dvc dag evaluate
-    +-------------------+
-    | data/data.xml.dvc |
-    +-------------------+
-              *
-              *
-              *
-         +---------+
-         | prepare |
-         +---------+
-              *
-              *
-              *
-        +-----------+
-        | featurize |
-        +-----------+
-         **        **
-       **            *
-      *               **
-+-------+               *
-| train |             **
-+-------+            *
-         **        **
-           **    **
-             *  *
-        +----------+
-        | evaluate |
-        +----------+
-```
+[stages](/doc/command-reference/run): prepare, featurize, train, evaluate.
 
 Imagine the [remote storage](/doc/command-reference/remote) has been modified
 such that the data in some of these stages should be updated in the

--- a/content/docs/command-reference/pull.md
+++ b/content/docs/command-reference/pull.md
@@ -129,7 +129,8 @@ $ cd example-get-started
 
 </details>
 
-The workspace looks almost like in this [pipeline setup](/doc/tutorials/dags):
+The workspace looks almost like in this
+[pipeline setup](/doc/start/data-pipelines):
 
 ```dvc
 .

--- a/content/docs/command-reference/pull.md
+++ b/content/docs/command-reference/pull.md
@@ -129,9 +129,6 @@ $ cd example-get-started
 
 </details>
 
-The workspace looks almost like in this
-[pipeline setup](/doc/start/data-pipelines):
-
 ```dvc
 .
 ├── data

--- a/content/docs/command-reference/pull.md
+++ b/content/docs/command-reference/pull.md
@@ -49,8 +49,8 @@ used to see what files `dvc pull` would download.
 If one or more `targets` are specified, DVC only considers the files associated
 with those stages or `.dvc` files. Using the `--with-deps` option, DVC tracks
 dependencies backward from the target [stage files](/doc/command-reference/run),
-through the corresponding [pipelines](/doc/command-reference/pipeline), to find
-data files to pull.
+through the corresponding [pipelines](/doc/command-reference/dag), to find data
+files to pull.
 
 After a data file is in cache, `dvc pull` can use OS-specific mechanisms like
 reflinks or hardlinks to put it in the workspace without copying. See
@@ -129,8 +129,7 @@ $ cd example-get-started
 
 </details>
 
-The workspace looks almost like in this
-[pipeline setup](/doc/tutorials/pipelines):
+The workspace looks almost like in this [pipeline setup](/doc/tutorials/dags):
 
 ```dvc
 .
@@ -167,7 +166,7 @@ $ dvc pull train.dvc
 > Please delete the `.dvc/cache` directory first (with `rm -Rf .dvc/cache`) to
 > follow this example if you tried the previous ones.
 
-Our [pipeline](/doc/command-reference/pipeline) has been setup with these
+Our [pipeline](/doc/command-reference/dag) has been setup with these
 [stages](/doc/command-reference/run):
 
 ```dvc

--- a/content/docs/command-reference/pull.md
+++ b/content/docs/command-reference/pull.md
@@ -169,6 +169,12 @@ Our [pipeline](/doc/command-reference/dag) has been setup with these
 
 ```dvc
 $ dvc dag evaluate
+        +-------------------+
+    | data/data.xml.dvc |
+    +-------------------+
+              *
+              *
+              *
          +---------+
          | prepare |
          +---------+

--- a/content/docs/command-reference/pull.md
+++ b/content/docs/command-reference/pull.md
@@ -168,7 +168,7 @@ Our [pipeline](/doc/command-reference/dag) has been setup with these
 [stages](/doc/command-reference/run):
 
 ```dvc
-$ dvc pipeline show evaluate.dvc
+$ dvc dag evaluate.dvc
 data/data.xml.dvc
 prepare.dvc
 featurize.dvc

--- a/content/docs/command-reference/push.md
+++ b/content/docs/command-reference/push.md
@@ -152,8 +152,12 @@ $ dvc push data.zip.dvc
 
 Demonstrating the `--with-deps` option requires a larger example. First, assume
 a [pipeline](/doc/command-reference/dag) has been setup with these
-[stages](/doc/command-reference/run): model-posts, post-features, test-posts,
-matrix-train
+[stages](/doc/command-reference/run):
+
+> model-posts  
+> post-features  
+> test-posts  
+> matrix-train
 
 Imagine the <abbr>project</abbr> has been modified such that the
 <abbr>outputs</abbr> of some of these stages need to be uploaded to

--- a/content/docs/command-reference/push.md
+++ b/content/docs/command-reference/push.md
@@ -152,9 +152,8 @@ $ dvc push data.zip.dvc
 
 Demonstrating the `--with-deps` option requires a larger example. First, assume
 a [pipeline](/doc/command-reference/dag) has been setup with these
-[stages](/doc/command-reference/run):
-
-model-posts post-features test-posts matrix-train
+[stages](/doc/command-reference/run): model-posts, post-features, test-posts,
+matrix-train
 
 Imagine the <abbr>project</abbr> has been modified such that the
 <abbr>outputs</abbr> of some of these stages need to be uploaded to

--- a/content/docs/command-reference/push.md
+++ b/content/docs/command-reference/push.md
@@ -67,7 +67,7 @@ cache (compared to the default remote.) It can be used to see what files
 If one or more `targets` are specified, DVC only considers the files associated
 with them. Using the `--with-deps` option, DVC tracks dependencies backward from
 the target [stage files](/doc/command-reference/run), through the corresponding
-[pipelines](/doc/command-reference/pipeline), to find data files to push.
+[pipelines](/doc/command-reference/dag), to find data files to push.
 
 ## Options
 
@@ -151,7 +151,7 @@ $ dvc push data.zip.dvc
 ## Example: With dependencies
 
 Demonstrating the `--with-deps` option requires a larger example. First, assume
-a [pipeline](/doc/command-reference/pipeline) has been setup with these
+a [pipeline](/doc/command-reference/dag) has been setup with these
 [stages](/doc/command-reference/run):
 
 ```dvc

--- a/content/docs/command-reference/push.md
+++ b/content/docs/command-reference/push.md
@@ -152,12 +152,8 @@ $ dvc push data.zip.dvc
 
 Demonstrating the `--with-deps` option requires a larger example. First, assume
 a [pipeline](/doc/command-reference/dag) has been setup with these
-[stages](/doc/command-reference/run):
-
-> model-posts  
-> post-features  
-> test-posts  
-> matrix-train
+[stages](/doc/command-reference/run): `clean-posts`, `featurize`, `test-posts`,
+`matrix-train`
 
 Imagine the <abbr>project</abbr> has been modified such that the
 <abbr>outputs</abbr> of some of these stages need to be uploaded to

--- a/content/docs/command-reference/push.md
+++ b/content/docs/command-reference/push.md
@@ -179,7 +179,7 @@ $ dvc push --with-deps model.p.dvc
 ... Push the rest of the data
 
 $ dvc status --cloud
-
+Data and pipelines are up to date.
 ```
 
 We specified a stage in the middle of this pipeline (`matrix-train.p.dvc`) with

--- a/content/docs/command-reference/push.md
+++ b/content/docs/command-reference/push.md
@@ -154,10 +154,7 @@ Demonstrating the `--with-deps` option requires a larger example. First, assume
 a [pipeline](/doc/command-reference/dag) has been setup with these
 [stages](/doc/command-reference/run):
 
-```dvc
-test-posts
-matrix-train
-```
+model-posts post-features test-posts matrix-train
 
 Imagine the <abbr>project</abbr> has been modified such that the
 <abbr>outputs</abbr> of some of these stages need to be uploaded to
@@ -165,7 +162,6 @@ Imagine the <abbr>project</abbr> has been modified such that the
 
 ```dvc
 $ dvc status --cloud
-
   new:            data/model.p
   new:            data/matrix-test.p
   new:            data/matrix-train.p
@@ -185,7 +181,6 @@ $ dvc push --with-deps model.p.dvc
 
 $ dvc status --cloud
 
-Data and pipelines are up to date.
 ```
 
 We specified a stage in the middle of this pipeline (`matrix-train.p.dvc`) with

--- a/content/docs/command-reference/push.md
+++ b/content/docs/command-reference/push.md
@@ -155,17 +155,11 @@ a [pipeline](/doc/command-reference/dag) has been setup with these
 [stages](/doc/command-reference/run):
 
 ```dvc
-$ dvc dag
-data/Posts.xml.zip.dvc
-Posts.xml.dvc
-Posts.tsv.dvc
-Posts-test.tsv.dvc
-matrix-train.p.dvc
-model.p.dvc
-Dvcfile
+test-posts
+matrix-train
 ```
 
-Imagine the <abbr>projects</abbr> has been modified such that the
+Imagine the <abbr>project</abbr> has been modified such that the
 <abbr>outputs</abbr> of some of these stages need to be uploaded to
 [remote storage](/doc/command-reference/remote).
 

--- a/content/docs/command-reference/push.md
+++ b/content/docs/command-reference/push.md
@@ -155,7 +155,7 @@ a [pipeline](/doc/command-reference/dag) has been setup with these
 [stages](/doc/command-reference/run):
 
 ```dvc
-$ dvc pipeline show
+$ dvc dag
 data/Posts.xml.zip.dvc
 Posts.xml.dvc
 Posts.tsv.dvc

--- a/content/docs/command-reference/repro.md
+++ b/content/docs/command-reference/repro.md
@@ -166,7 +166,7 @@ only execute the final stage.
 
 For simplicity, let's build a pipeline defined below. (If you want get your
 hands-on something more real, see this short
-[pipeline tutorial](/doc/tutorials/dags)). It takes this `text.txt` file:
+[pipeline tutorial](/doc/start/data-pipelines)). It takes this `text.txt` file:
 
 ```
 dvc

--- a/content/docs/command-reference/repro.md
+++ b/content/docs/command-reference/repro.md
@@ -1,6 +1,6 @@
 # repro
 
-Reproduce complete or partial [pipelines](/doc/command-reference/pipeline) by
+Reproduce complete or partial [pipelines](/doc/command-reference/dag) by
 executing commands defined in their [stages](/doc/command-reference/run) in the
 correct order. The commands to be executed are determined by recursively
 analyzing dependencies and <abbr>outputs</abbr> of the target stages.
@@ -166,7 +166,7 @@ only execute the final stage.
 
 For simplicity, let's build a pipeline defined below. (If you want get your
 hands-on something more real, see this short
-[pipeline tutorial](/doc/tutorials/pipelines)). It takes this `text.txt` file:
+[pipeline tutorial](/doc/tutorials/dags)). It takes this `text.txt` file:
 
 ```
 dvc

--- a/content/docs/command-reference/run.md
+++ b/content/docs/command-reference/run.md
@@ -22,8 +22,8 @@ positional arguments:
 ## Description
 
 `dvc run` is a helper for creating or updating
-[pipeline](/doc/command-reference/pipeline) stages in a `dvc.yaml` file (located
-in the current working directory). _Stages_ represent individual data processes,
+[pipeline](/doc/command-reference/dag) stages in a `dvc.yaml` file (located in
+the current working directory). _Stages_ represent individual data processes,
 including their input and resulting outputs.
 
 A stage name is required and can be provided using the `-n` (`--name`) option.
@@ -112,8 +112,8 @@ run directly, for example a shell built-in, expression, or binary found in
 by the command itself, not by `dvc run`.
 
 ⚠️ Note that while DVC is platform-agnostic, the commands defined in your
-[pipeline](/doc/command-reference/pipeline) stages may only work on some
-operating systems and require certain software packages to be installed.
+[pipeline](/doc/command-reference/dag) stages may only work on some operating
+systems and require certain software packages to be installed.
 
 Wrap the command with double quotes `"` if there are special characters in it
 like `|` (pipe) or `<`, `>` (redirection), otherwise they would apply to
@@ -330,8 +330,8 @@ $ tree ..
 
 ## Example: Chaining stages
 
-DVC [pipelines](/doc/command-reference/pipeline) are constructed by connecting
-the outputs of a stage to the dependencies of the following one(s).
+DVC [pipelines](/doc/command-reference/dag) are constructed by connecting the
+outputs of a stage to the dependencies of the following one(s).
 
 Extract an XML file from an archive to the `data/` folder:
 

--- a/content/docs/command-reference/status.md
+++ b/content/docs/command-reference/status.md
@@ -1,7 +1,7 @@
 # status
 
 Show changes in the <abbr>project</abbr>
-[pipelines](/doc/command-reference/pipeline), as well as file mismatches either
+[pipelines](/doc/command-reference/dag), as well as file mismatches either
 between the <abbr>cache</abbr> and <abbr>workspace</abbr>, or between the cache
 and remote storage.
 

--- a/content/docs/use-cases/shared-development-server.md
+++ b/content/docs/use-cases/shared-development-server.md
@@ -91,7 +91,7 @@ Your colleagues can [checkout](/doc/command-reference/checkout) the
 <abbr>project</abbr> data (from the shared <abbr>cache</abbr>), and have both
 `raw` and `clean` data files appear in their workspace without moving anything
 manually. After this, they could decide to continue building this
-[pipeline](/doc/command-reference/pipeline) and process the clean data:
+[pipeline](/doc/command-reference/dag) and process the clean data:
 
 ```dvc
 $ git pull

--- a/content/docs/use-cases/versioning-data-and-model-files/tutorial.md
+++ b/content/docs/use-cases/versioning-data-and-model-files/tutorial.md
@@ -354,7 +354,7 @@ a monolithic way. It uses the `save_bottleneck_feature` function to
 pre-calculate the bottom, "frozen" part of the net every time it is run.
 Features are written into files. The intention was probably that the
 `save_bottleneck_feature` can be commented out after the first run, but it's not
-very convenient having to remember to do si it every time the dataset changes.
+very convenient having to remember to do it every time the dataset changes.
 
 Here's where the [pipelines](/doc/command-reference/dag) feature of DVC comes in
 handy. We touched on it briefly when we described `dvc run` and `dvc repro`. The

--- a/content/docs/use-cases/versioning-data-and-model-files/tutorial.md
+++ b/content/docs/use-cases/versioning-data-and-model-files/tutorial.md
@@ -356,12 +356,12 @@ Features are written into files. The intention was probably that the
 `save_bottleneck_feature` can be commented out after the first run, but it's not
 very convenient having to remember to do si it every time the dataset changes.
 
-Here's where the [pipelines](/doc/command-reference/pipeline) feature of DVC
-comes in handy. We touched on it briefly when we described `dvc run` and
-`dvc repro`. The next step would be splitting the script into two parts and
-utilizing pipelines. See [this example](/doc/tutorials/pipelines) to get
-hands-on experience with pipelines, and try to apply it here. Don't hesitate to
-join our [community](/chat) and ask any questions!
+Here's where the [pipelines](/doc/command-reference/dag) feature of DVC comes in
+handy. We touched on it briefly when we described `dvc run` and `dvc repro`. The
+next step would be splitting the script into two parts and utilizing pipelines.
+See [this example](/doc/start/data-pipelines) to get hands-on experience with
+pipelines, and try to apply it here. Don't hesitate to join our
+[community](/chat) and ask any questions!
 
 Another detail we only brushed upon here is the way we captured the
 `metrics.csv` metric file with the `-M` option of `dvc run`. Marking this

--- a/content/docs/use-cases/versioning-data-and-model-files/tutorial.md
+++ b/content/docs/use-cases/versioning-data-and-model-files/tutorial.md
@@ -359,7 +359,7 @@ very convenient having to remember to do so every time the dataset changes.
 Here's where the [pipelines](/doc/command-reference/dag) feature of DVC comes in
 handy. We touched on it briefly when we described `dvc run` and `dvc repro`. The
 next step would be splitting the script into two parts and utilizing pipelines.
-See [this example](/doc/start/data-pipelines) to get hands-on experience with
+See [Data Pipelines](/doc/start/data-pipelines) to get hands-on experience with
 pipelines, and try to apply it here. Don't hesitate to join our
 [community](/chat) and ask any questions!
 

--- a/content/docs/user-guide/dvcignore.md
+++ b/content/docs/user-guide/dvcignore.md
@@ -29,8 +29,8 @@ DVC-handled directories.
 
 **It is crucial to understand, that DVC might remove ignored files upon
 `dvc run` or `dvc repro`. If they are not produced by a
-[pipeline](/doc/command-reference/pipeline) [stage](/doc/command-reference/run),
-they can be deleted permanently.**
+[pipeline](/doc/command-reference/dag) [stage](/doc/command-reference/run), they
+can be deleted permanently.**
 
 Keep in mind, that when you add to `.dvcignore` entries that affect one of the
 existing <abbr>outputs</abbr>, its status will change and DVC will behave as if

--- a/content/docs/user-guide/what-is-dvc/collaboration-issues.md
+++ b/content/docs/user-guide/what-is-dvc/collaboration-issues.md
@@ -48,6 +48,6 @@ formalized. Common questions need to be answered in an unified, principled way.
   sources, intermediate data files, and models?
 
 Some of these questions are easy to answer individually. Data scientists,
-engineers, or managers may already know or can easily find answers to some of
+engineers, or managers may already knows or can easily find answers to some of
 them. However, the variety of answers and approaches makes data science
 collaboration a nightmare. **A systematic approach is required.**

--- a/content/docs/user-guide/what-is-dvc/collaboration-issues.md
+++ b/content/docs/user-guide/what-is-dvc/collaboration-issues.md
@@ -48,6 +48,6 @@ formalized. Common questions need to be answered in an unified, principled way.
   sources, intermediate data files, and models?
 
 Some of these questions are easy to answer individually. Data scientists,
-engineers, or managers may already knows or can easily find answers to some of
+engineers, or managers may already know or can easily find answers to some of
 them. However, the variety of answers and approaches makes data science
 collaboration a nightmare. **A systematic approach is required.**

--- a/content/docs/user-guide/what-is-dvc/core-features.md
+++ b/content/docs/user-guide/what-is-dvc/core-features.md
@@ -4,7 +4,7 @@
   interface and Git workflow.
 
 - It makes data science projects **reproducible** by creating lightweight
-  [pipelines](/doc/command-reference/pipeline) using implicit dependency graphs.
+  [pipelines](/doc/command-reference/dag) using implicit dependency graphs.
 
 - **Large data file versioning** works by creating special files in your Git
   repository that point to the <abbr>cache</abbr>, typically stored on a local

--- a/content/docs/user-guide/what-is-dvc/index.md
+++ b/content/docs/user-guide/what-is-dvc/index.md
@@ -43,7 +43,7 @@ DVC uses a few core concepts:
   (<abbr>dependencies</abbr>) and <abbr>outputs</abbr>. Pipelines are defined by
   special [stage files](/doc/command-reference/run) (similar to
   [Makefiles](https://www.gnu.org/software/make/manual/make.html#Introduction)).
-  Refer to [pipeline](/doc/command-reference/pipeline) for more information.
+  Refer to [pipeline](/doc/command-reference/dag) for more information.
 
 - **Workflow**: Set of experiments and relationships among them. Workflow
   corresponds to the entire Git repository.


### PR DESCRIPTION
- [ ] UPDATE: Merge https://github.com/iterative/dvc.org/pull/1591#pullrequestreview-453804426 after this one.

---
- Continuation of https://github.com/iterative/dvc.org/pull/1383#issuecomment-648363086

- One of the *Next Priorities* in DVC 1.x discrepancies #1255:
  - [x] dvc pipeline -> dvc dag #1383 Need to update pipeline links, for now they just redirect to dag. Also push/pull examples.

~~Line 169 in `repro.md` links to `/doc/tutorial/dags` and previously linked to `/doc/tutorial/pipelines`. Both these links just redirect to `doc/start`. Maybe they should have a different link (`/doc/start/data-pipelines`)?~~