### PR TITLE
External link icon fixes

### DIFF
--- a/src/components/Documentation/Markdown/styles.module.css
+++ b/src/components/Documentation/Markdown/styles.module.css
@@ -62,6 +62,10 @@
       content: url(/img/external-link.svg);
     }
 
+    :global(a.gatsby-resp-image-link)::after {
+      content: unset;
+    }
+
     .anchor {
       margin-left: -24px;
     }

--- a/src/components/Documentation/Markdown/styles.module.css
+++ b/src/components/Documentation/Markdown/styles.module.css
@@ -52,14 +52,18 @@
       text-align: center;
     }
 
-    a[target='_blank']::after {
-      position: relative;
-      top: 1px;
-      right: 0;
-      width: 12px;
-      height: 12px;
-      margin-left: 1px;
-      content: url(/img/external-link.svg);
+    a[target='_blank'] {
+      white-space: nowrap;
+
+      &::after {
+        position: relative;
+        top: 1px;
+        right: 0;
+        width: 12px;
+        height: 12px;
+        margin-left: 1px;
+        content: url(/img/external-link.svg);
+      }
     }
 
     :global(a.gatsby-resp-image-link)::after {


### PR DESCRIPTION
In this PR, external links (ones with `_target="blank"` specifically) have `white-space: nowrap` applied to them such that the link itself will not break on a line, including the external link icon. This fixes #1593.

Also, image links in docs no longer display the external link icon to fix #1594.