### PR TITLE
cmd: add parameters for configuration of WebDAV remotes

### DIFF
--- a/content/docs/command-reference/remote/add.md
+++ b/content/docs/command-reference/remote/add.md
@@ -352,6 +352,9 @@ $ dvc remote add -d myremote webdavs://example.com/public.php/webdav
 
 > See also `dvc remote modify` for a full list of WebDAV parameters.
 
+> Note that the location of the WebDAV API endpoint `/public.php/webdav` might
+> be different for your server.
+
 </details>
 
 <details>

--- a/content/docs/command-reference/remote/add.md
+++ b/content/docs/command-reference/remote/add.md
@@ -347,7 +347,7 @@ $ dvc remote add -d myremote https://example.com/path/to/dir
 ### Click for WebDAV
 
 ```dvc
-$ dvc remote add -d myremote webdavs://example.com/path/to/dir
+$ dvc remote add -d myremote webdavs://example.com/public.php/webdav
 ```
 
 > See also `dvc remote modify` for a full list of WebDAV parameters.

--- a/content/docs/command-reference/remote/add.md
+++ b/content/docs/command-reference/remote/add.md
@@ -344,6 +344,18 @@ $ dvc remote add -d myremote https://example.com/path/to/dir
 
 <details>
 
+### Click for WebDAV
+
+```dvc
+$ dvc remote add -d myremote webdavs://example.com/path/to/dir
+```
+
+> See also `dvc remote modify` for a full list of WebDAV parameters.
+
+</details>
+
+<details>
+
 ### Click for local remote
 
 A "local remote" is a directory in the machine's file system.

--- a/content/docs/command-reference/remote/modify.md
+++ b/content/docs/command-reference/remote/modify.md
@@ -620,8 +620,8 @@ more information.
 
   The order in which DVC searches for username is:
 
-  1. `user` specified in one of the DVC configs;
-  2. `user` specified in the url (e.g. `webdav://user@example.com/path`)
+  1. `user` parameter set with this command (found in `.dvc/config`);
+  2. User defined in the URL (e.g. `webdav://user@example.com/path`)
 
 - `password` - password for WebDAV server, can be empty in case of using `token`
   authentication.

--- a/content/docs/command-reference/remote/modify.md
+++ b/content/docs/command-reference/remote/modify.md
@@ -593,7 +593,7 @@ more information.
   authentication. The order in which DVC searches for username:
 
   1. `user` specified in one of the DVC configs;
-  2. `user` specified in the url(e.g. `webdav://user@example.com/path`);
+  2. `user` specified in the url (e.g. `webdav://user@example.com/path`)
 
   ```dvc
   $ dvc remote modify --local myremote user myuser

--- a/content/docs/command-reference/remote/modify.md
+++ b/content/docs/command-reference/remote/modify.md
@@ -582,6 +582,65 @@ more information.
 
 </details>
 
+<details>
+
+### Click for WebDAV
+
+- `token` - token for WebDAV server, can be empty in case of using
+  `user/password` authentication.
+
+- `user` - username for WebDAV server, can be empty in case of using `token`
+  authentication. The order in which DVC searches for username:
+
+  1. `user` specified in one of the DVC configs;
+  2. `user` specified in the url(e.g. `webdav://user@example.com/path`);
+
+  ```dvc
+  $ dvc remote modify --local myremote user myuser
+  ```
+
+- `password` - password for WebDAV server, can be empty in case of using `token`
+  authentication.
+
+  ```dvc
+  $ dvc remote modify myremote --local password mypassword
+  ```
+
+> The username and password (may) contain sensitive user info. Therefore, it's
+> safer to add them with the `--local` option, so they're written to a
+> Git-ignored config file.
+
+- `ask_password` - ask each time for the password to use for `user/password`
+  authentication.
+
+  ```dvc
+  $ dvc remote modify myremote ask_password true
+  ```
+
+  > Note that the `password` parameter takes precedence over `ask_password`. If
+  > `password` is specified, DVC will not prompt the user to enter a password
+  > for this remote.
+
+- `cert_path` - path to certificate used for WebDAV server authentication.
+
+  ```dvc
+  $ dvc remote modify myremote cert_path /path/to/cert
+  ```
+
+- `key_path` - path to private key to use to access a remote.
+
+  ```dvc
+  $ dvc remote modify myremote key_path /path/to/key
+  ```
+
+- `timeout` - connection timeout to use for WebDAV.
+
+  ```dvc
+  $ dvc remote modify myremote timeout timeoutseconds
+  ```
+
+</details>
+
 ## Example: Customize an S3 remote
 
 Let's first set up a _default_ S3 remote.

--- a/content/docs/command-reference/remote/modify.md
+++ b/content/docs/command-reference/remote/modify.md
@@ -652,15 +652,15 @@ more information.
   $ dvc remote modify myremote cert_path /path/to/cert
   ```
 
-- `key_path` - path to private key to use to access a remote.
+- `key_path` - path to private key to use to access a remote. Only has an
+  effect in combination with `cert_path`.
 
   ```dvc
   $ dvc remote modify myremote key_path /path/to/key
   ```
 
-  > Note that the `key_path` option is only valid in combination with
-  > `cert_path` option. However, the certificate might already contain the
-  > private key.
+  > Note that the certificate in `cert_path` might already contain the private
+  > key.
 
 - `timeout` - connection timeout (in seconds) for WebDAV server (default: 30).
 

--- a/content/docs/command-reference/remote/modify.md
+++ b/content/docs/command-reference/remote/modify.md
@@ -608,7 +608,7 @@ more information.
   `user/password` authentication.
 
   ```dvc
-  $ dvc remote modify --local myremote token 'mytoken'
+  $ dvc remote modify --local myremote token '<mytoken>'
   ```
 
 - `user` - username for WebDAV server, can be empty in case of using `token`

--- a/content/docs/command-reference/remote/modify.md
+++ b/content/docs/command-reference/remote/modify.md
@@ -589,6 +589,10 @@ more information.
 - `token` - token for WebDAV server, can be empty in case of using
   `user/password` authentication.
 
+  ```dvc
+  $ dvc remote modify --local myremote token mytoken
+  ```
+
 - `user` - username for WebDAV server, can be empty in case of using `token`
   authentication. The order in which DVC searches for username:
 
@@ -603,11 +607,11 @@ more information.
   authentication.
 
   ```dvc
-  $ dvc remote modify myremote --local password mypassword
+  $ dvc remote modify --local myremote password mypassword
   ```
 
-> The username and password (may) contain sensitive user info. Therefore, it's
-> safer to add them with the `--local` option, so they're written to a
+> The username, password and token (may) contain sensitive user info. Therefore,
+> it's safer to add them with the `--local` option, so they're written to a
 > Git-ignored config file.
 
 - `ask_password` - ask each time for the password to use for `user/password`

--- a/content/docs/command-reference/remote/modify.md
+++ b/content/docs/command-reference/remote/modify.md
@@ -637,7 +637,7 @@ more information.
   $ dvc remote modify myremote key_path /path/to/key
   ```
 
-- `timeout` - connection timeout (in seconds) for WebDAV server.
+- `timeout` - connection timeout (in seconds) for WebDAV server (default: 30 seconds).
 
   ```dvc
   $ dvc remote modify myremote timeout 120

--- a/content/docs/command-reference/remote/modify.md
+++ b/content/docs/command-reference/remote/modify.md
@@ -614,6 +614,10 @@ more information.
 > Therefore, it's safer to add them with the `--local` option, so they're
 > written to a Git-ignored config file.
 
+> Note that `user/password` and `token` authentication are incompatible. You
+> should authenticate against yout WebDAV remote by either `user/password` or
+> `token`.
+
 - `ask_password` - ask each time for the password to use for `user/password`
   authentication.
 
@@ -624,6 +628,10 @@ more information.
   > Note that the `password` parameter takes precedence over `ask_password`. If
   > `password` is specified, DVC will not prompt the user to enter a password
   > for this remote.
+
+  > Note that `token` authentication does not require a `password`. If `token`
+  > is specified, `ask_password` is ignored and DVC will not prompt the user to
+  > enter a password for this remote.
 
 - `cert_path` - path to certificate used for WebDAV server authentication.
 

--- a/content/docs/command-reference/remote/modify.md
+++ b/content/docs/command-reference/remote/modify.md
@@ -590,7 +590,7 @@ more information.
   `user/password` authentication.
 
   ```dvc
-  $ dvc remote modify --local myremote token mytoken
+  $ dvc remote modify --local myremote token 'mytoken'
   ```
 
 - `user` - username for WebDAV server, can be empty in case of using `token`

--- a/content/docs/command-reference/remote/modify.md
+++ b/content/docs/command-reference/remote/modify.md
@@ -639,7 +639,7 @@ more information.
 > `token`.
 
 - `ask_password` - ask each time for the password to use for `user/password`
-  authentication.
+  authentication. This has no effect if `password` or `token` are set.
 
   ```dvc
   $ dvc remote modify myremote ask_password true

--- a/content/docs/command-reference/remote/modify.md
+++ b/content/docs/command-reference/remote/modify.md
@@ -645,14 +645,6 @@ more information.
   $ dvc remote modify myremote ask_password true
   ```
 
-  > Note that the `password` parameter takes precedence over `ask_password`. If
-  > `password` is specified, DVC will not prompt the user to enter a password
-  > for this remote.
-
-  > Note that `token` authentication does not require a `password`. If `token`
-  > is specified, `ask_password` is ignored and DVC will not prompt the user to
-  > enter a password for this remote.
-
 - `cert_path` - path to certificate used for WebDAV server authentication, if
   you need to use local client side certificates.
 

--- a/content/docs/command-reference/remote/modify.md
+++ b/content/docs/command-reference/remote/modify.md
@@ -637,7 +637,7 @@ more information.
   $ dvc remote modify myremote key_path /path/to/key
   ```
 
-- `timeout` - connection timeout to use for WebDAV.
+- `timeout` - connection timeout for WebDAV server.
 
   ```dvc
   $ dvc remote modify myremote timeout timeoutseconds

--- a/content/docs/command-reference/remote/modify.md
+++ b/content/docs/command-reference/remote/modify.md
@@ -586,6 +586,24 @@ more information.
 
 ### Click for WebDAV
 
+- `url` - remote location URL.
+
+  ```dvc
+  $ dvc remote modify myremote \
+        url webdavs://example.com/public.php/webdav
+  ```
+
+  > Note that the location of the WebDAV API endpoint `/public.php/webdav` might
+  > be different for your server.
+
+  If your remote is located in a subfolder of your WebDAV server e.g.
+  `/path/to/dir`, this may be appended to the general `url`:
+
+  ```dvc
+  $ dvc remote modify myremote \
+        url webdavs://example.com/public.php/webdav/path/to/dir
+  ```
+
 - `token` - token for WebDAV server, can be empty in case of using
   `user/password` authentication.
 

--- a/content/docs/command-reference/remote/modify.md
+++ b/content/docs/command-reference/remote/modify.md
@@ -594,14 +594,16 @@ more information.
   ```
 
 - `user` - username for WebDAV server, can be empty in case of using `token`
-  authentication. The order in which DVC searches for username is:
-
-  1. `user` specified in one of the DVC configs;
-  2. `user` specified in the url (e.g. `webdav://user@example.com/path`)
+  authentication.
 
   ```dvc
   $ dvc remote modify --local myremote user myuser
   ```
+
+  The order in which DVC searches for username is:
+
+  1. `user` specified in one of the DVC configs;
+  2. `user` specified in the url (e.g. `webdav://user@example.com/path`)
 
 - `password` - password for WebDAV server, can be empty in case of using `token`
   authentication.

--- a/content/docs/command-reference/remote/modify.md
+++ b/content/docs/command-reference/remote/modify.md
@@ -637,7 +637,7 @@ more information.
   $ dvc remote modify myremote key_path /path/to/key
   ```
 
-- `timeout` - connection timeout (in seconds) for WebDAV server (default: 30 seconds).
+- `timeout` - connection timeout (in seconds) for WebDAV server (default: 30).
 
   ```dvc
   $ dvc remote modify myremote timeout 120

--- a/content/docs/command-reference/remote/modify.md
+++ b/content/docs/command-reference/remote/modify.md
@@ -640,7 +640,7 @@ more information.
 - `timeout` - connection timeout (in seconds) for WebDAV server.
 
   ```dvc
-  $ dvc remote modify myremote timeout timeoutseconds
+  $ dvc remote modify myremote timeout 120
   ```
 
 </details>

--- a/content/docs/command-reference/remote/modify.md
+++ b/content/docs/command-reference/remote/modify.md
@@ -594,7 +594,7 @@ more information.
   ```
 
 - `user` - username for WebDAV server, can be empty in case of using `token`
-  authentication. The order in which DVC searches for username:
+  authentication. The order in which DVC searches for username is:
 
   1. `user` specified in one of the DVC configs;
   2. `user` specified in the url (e.g. `webdav://user@example.com/path`)

--- a/content/docs/command-reference/remote/modify.md
+++ b/content/docs/command-reference/remote/modify.md
@@ -610,9 +610,9 @@ more information.
   $ dvc remote modify --local myremote password mypassword
   ```
 
-> The username, password and token (may) contain sensitive user info. Therefore,
-> it's safer to add them with the `--local` option, so they're written to a
-> Git-ignored config file.
+> The username, password, and token (may) contain sensitive user info.
+> Therefore, it's safer to add them with the `--local` option, so they're
+> written to a Git-ignored config file.
 
 - `ask_password` - ask each time for the password to use for `user/password`
   authentication.

--- a/content/docs/command-reference/remote/modify.md
+++ b/content/docs/command-reference/remote/modify.md
@@ -635,7 +635,8 @@ more information.
   > is specified, `ask_password` is ignored and DVC will not prompt the user to
   > enter a password for this remote.
 
-- `cert_path` - path to certificate used for WebDAV server authentication.
+- `cert_path` - path to certificate used for WebDAV server authentication, if
+  you need to use local client side certificates.
 
   ```dvc
   $ dvc remote modify myremote cert_path /path/to/cert
@@ -646,6 +647,10 @@ more information.
   ```dvc
   $ dvc remote modify myremote key_path /path/to/key
   ```
+
+  > Note that the `key_path` option is only valid in combination with
+  > `cert_path` option. However, the certificate might already contain the
+  > private key.
 
 - `timeout` - connection timeout (in seconds) for WebDAV server (default: 30).
 

--- a/content/docs/command-reference/remote/modify.md
+++ b/content/docs/command-reference/remote/modify.md
@@ -637,7 +637,7 @@ more information.
   $ dvc remote modify myremote key_path /path/to/key
   ```
 
-- `timeout` - connection timeout for WebDAV server.
+- `timeout` - connection timeout (in seconds) for WebDAV server.
 
   ```dvc
   $ dvc remote modify myremote timeout timeoutseconds


### PR DESCRIPTION
This adds the documentation of configuration parameters for my proposed addition of WebDAV remotes.

Relates to iterative/dvc#1153, https://github.com/iterative/dvc/pull/4256


> You may disregard these recommendations if you used the **Edit on GitHub** button from dvc.org to improve a doc in place.

❗ Please read the guidelines in the [Contributing to the Documentation](https://dvc.org/doc/user-guide/contributing/docs) list if you make any substantial changes to the documentation or JS engine.

🐛 Please make sure to mention `Fix #issue` (if applicable) in the description of the PR. This causes GitHub to close it automatically when the PR is merged.

Please choose to [allow us](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to edit your branch when creating the PR.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
