### PR TITLE
Add style for descriptionLong code blocks.

### DIFF
--- a/src/components/Blog/Post/styles.module.css
+++ b/src/components/Blog/Post/styles.module.css
@@ -74,6 +74,14 @@
   & a {
     color: var(--color-black);
   }
+
+  & code {
+    font-family: monospace;
+    font-size: 0.75em;
+    padding: 0.2em 0.3em;
+    border-radius: 3px;
+    background-color: rgba(27, 31, 35, 0.05);
+  }
 }
 
 .share {


### PR DESCRIPTION
Most noticeable in [this blog post](https://dvc.org/blog/shtab-completion-release), `descriptionLong` doesn't have any styles for `code` blocks. However, the `code` blocks are still present, so we just need to style them.

This PR does that. See how it looks in the [deploy preview](https://dvc-landing-description-ae1pr8.herokuapp.com/blog/shtab-completion-release)!

I don't know if we already have an issue for this, feel free to let me know and I'll link it.

Since the style is a simple CSS rule, it can be changed to anything if we think another style would look better here. Currently, I just copy the rule used in docs.