### PR TITLE
Make image caption styling apply to plain `img`s

### DIFF
--- a/src/components/Blog/Post/Markdown/styles.module.css
+++ b/src/components/Blog/Post/Markdown/styles.module.css
@@ -58,6 +58,10 @@
     color: var(--color-gray);
   }
 
+  img + em {
+    margin-top: 5px;
+  }
+
   :global(.gatsby-resp-image-wrapper) + em {
     @media (--md-scr) {
       margin-top: -30px;

--- a/src/components/Blog/Post/Markdown/styles.module.css
+++ b/src/components/Blog/Post/Markdown/styles.module.css
@@ -49,13 +49,16 @@
     }
   }
 
-  :global(.gatsby-resp-image-wrapper) + em {
+  :global(.gatsby-resp-image-wrapper) + em,
+  img + em {
     @mixin text-secondary;
 
     display: block;
     text-align: center;
     color: var(--color-gray);
+  }
 
+  :global(.gatsby-resp-image-wrapper) + em {
     @media (--md-scr) {
       margin-top: -30px;
     }


### PR DESCRIPTION
This PR makes it so that plain `img` elements with captions are properly styled, as the previous rules only applied to images wrapped with `gatsby-image`, which are divs with a specific class.

I just took the relevant bits from the current selector and moved them into a new one that selects both `img` and the `gatsby-image` divs.

Example of the issue in the last few images of [this post](https://dvc.org/blog/shtab-completion-release).

[Here's the same blog post, but on this PR's preview](https://dvc-landing-img-caption-zfazra.herokuapp.com/blog/shtab-completion-release)