### PR TITLE
Add a "Thank You" page for MailChimp subscribers

### DIFF
--- a/src/components/ThankYou/index.tsx
+++ b/src/components/ThankYou/index.tsx
@@ -1,0 +1,11 @@
+import React from 'react'
+import styles from './styles.module.css'
+
+const ThankYouPage: React.FC = () => (
+  <div className={styles.wrapper}>
+    <h1 className={styles.heading}>Thanks for subscribing!</h1>
+    <p className={styles.copy}>Keep an eye on your inbox</p>
+  </div>
+)
+
+export default ThankYouPage

--- a/src/components/ThankYou/styles.module.css
+++ b/src/components/ThankYou/styles.module.css
@@ -1,0 +1,29 @@
+.wrapper {
+  margin: 12rem auto;
+  text-align: center;
+
+  @media (--md-scr) {
+    margin: 10rem auto;
+  }
+
+  @media (--sm-scr) {
+    margin: 6rem auto;
+  }
+}
+
+.heading {
+  font-size: 3rem;
+  margin: 2rem 0;
+
+  @media (--sm-scr) {
+    font-size: 2rem;
+  }
+}
+
+.copy {
+  font-size: 1.75rem;
+
+  @media (--sm-scr) {
+    font-size: 1.1rem;
+  }
+}

--- a/src/pages/subscriber-thank-you.tsx
+++ b/src/pages/subscriber-thank-you.tsx
@@ -1,0 +1,2 @@
+import ThankYou from '../components/ThankYou'
+export default ThankYou


### PR DESCRIPTION
This PR adds a simple "Thank You" page for MailChimp to redirect to upon a successful subscription.

Hosting this page ourselves gives us more control over the page in general, but a specific issue brought this up:

Having one Audience for CML and DVC is easier to manage, but there can only be one embedded form per Audience. This is fine for the most part, except that the "return to website" button on the "Thank you" page "returns" to dvc.org even if you got there via cml.dev! Even worse, we can't just remove the thank you button in MailChimp's provided editor!

Thankfully, we *can* redirect to a custom page, which is where this PR comes in.

I fully expect the text to be changed, and maybe we want return links to both DVC and CML to make up for the fact that the page can't change between sources when using one Audience.

See how it looks on the [deploy preview](https://dvc-landing-mailchimp-t-nywlsi.herokuapp.com/subscriber-thank-you)