### PR TITLE
[hotfix] cases: fix Automating capturing section of versioning tutorial

### DIFF
--- a/content/docs/use-cases/versioning-data-and-model-files/tutorial.md
+++ b/content/docs/use-cases/versioning-data-and-model-files/tutorial.md
@@ -309,11 +309,13 @@ When you have a script that takes some data as an input and produces other data
 
 > If you tried the commands in the
 > [Switching between workspace versions](#switching-between-workspace-versions)
-> section, go back to the master branch code and data with:
+> section, go back to the master branch code and data, and remove the
+> `model.h5.dvc` file with:
 >
 > ```dvc
 > $ git checkout master
 > $ dvc checkout
+> $ dvc remove model.h5.dvc
 > ```
 
 ```dvc


### PR DESCRIPTION
Re-close #1615 

Specifically https://github.com/iterative/dvc.org/issues/1507#issuecomment-662913116:

> Removing the model.h5.dvc file and re-running the updated tutorial runs successfully! ...
Perhaps it would be clearer if the documentation re-stated this before the Automating capturing section.
