### PR TITLE
cmd: simplify project nesting info in init

### DIFF
--- a/content/docs/command-reference/init.md
+++ b/content/docs/command-reference/init.md
@@ -100,6 +100,54 @@ DVC sets the `core.no_scm` config option value to `true` in the DVC
 that even if the project is tracked by Git, or if Git is initialized in it
 later, DVC will keep operating detached from Git in this project.
 
+### Nested DVC projects and repositories
+
+> Note that Git-enabled <abbr>DVC repositories</abbr> nested inside parent DVC
+> repositories (for example when using Git submodules) are isolated from the
+> parent, and vice versa. This is because each one has their own Git root.
+
+If there are multiple `--subdir` projects, but not nested, e.g.:
+
+```dvc
+.           # git init
+├── .git
+├── project-A
+│   ├── .dvc    # dvc init --subdir
+│   ...
+├── project-B
+│   ├── .dvc    # dvc init --subdir
+│   ...
+```
+
+DVC considers A and B separate projects. Any DVC command run in `project-A` is
+not aware of `project-B`. However, commands that involve versioning (like
+`dvc diff`, among others) access the commit history from the Git root (`.`).
+
+> `.` is not a DVC project in this case, so most DVC commands can't be run
+> there.
+
+If there are nested `--subdir` projects e.g.:
+
+```dvc
+project-A
+├── .dvc        # git init && dvc init
+├── .git
+├── dvc.yaml
+├── ...
+├── project-B
+│   ├── .dvc        # dvc init --subdir
+│   ├── data-B.dvc
+│   ...
+```
+
+Nothing changes for the inner projects. And any DVC command run in the outer one
+actively ignores the nested project directories. For example, using `dvc pull`
+in `project-A` wouldn't download data for the `data-B.dvc` file.
+
+> Note that like with nested <abbr>repositories</abbr> and `--subdir` projects,
+> `--no-scm` projects inside regular <abbr>projects</abbr> are ignored by any
+> parent DVC projects, and vice versa.
+
 ## Options
 
 - `-f`, `--force` - remove `.dvc/` if it exists before initialization. Will

--- a/content/docs/command-reference/init.md
+++ b/content/docs/command-reference/init.md
@@ -135,16 +135,6 @@ DVC sets the `core.no_scm` config option value to `true` in the DVC
 that even if the project is tracked by Git, or if Git is initialized in it
 later, DVC will keep operating detached from Git in this project.
 
-### Nested DVC projects and repositories
-
-> Note that Git-enabled <abbr>DVC repositories</abbr> nested inside parent DVC
-> repositories (for example when using Git submodules) are isolated from the
-> parent, and vice versa. This is because each one has their own Git root.
-
-> Note that like with nested <abbr>repositories</abbr> and `--subdir` projects,
-> `--no-scm` projects inside regular <abbr>projects</abbr> are ignored by any
-> parent DVC projects, and vice versa.
-
 ## Options
 
 - `-f`, `--force` - remove `.dvc/` if it exists before initialization. Will

--- a/content/docs/command-reference/init.md
+++ b/content/docs/command-reference/init.md
@@ -72,40 +72,6 @@ With `--subdir`, the project root will be found before the Git root, making sure
 the scope of DVC commands run here is constrained to this project alone, even if
 there are more DVC-related files elsewhere in the repo.
 
-Similarly, DVC commands run outside this project root (if nested inside another
-DVC project, for example) will ignore this project's contents completely.
-
-### Initializing DVC without Git
-
-In rare cases, the `--no-scm` option might be desirable: to initialize DVC in a
-directory that is not part of a Git repo, or to make DVC ignore Git. Examples
-include:
-
-- SCM other than Git is being used. Even though there are DVC features that
-  require DVC to be run in the Git repo, DVC can work well with other version
-  control systems. Since DVC relies on simple `dvc.yaml` files to manage
-  <abbr>pipelines</abbr>, data, etc, they can be added into any SCM thus
-  providing large data files and directories versioning.
-
-- There is no need to keep the history at all, e.g. having a deployment
-  automation like running a data pipeline using `cron`.
-
-In this mode, DVC features related to versioning are not available. For example
-automatic creation and updating of `.gitignore` files on `dvc add` or `dvc run`,
-as well as `dvc diff` and `dvc metrics diff`, which require Git revisions to
-compare.
-
-DVC sets the `core.no_scm` config option value to `true` in the DVC
-[config](/doc/command-reference/config) when initialized this way. This means
-that even if the project is tracked by Git, or if Git is initialized in it
-later, DVC will keep operating detached from Git in this project.
-
-### Nested DVC projects and repositories
-
-> Note that Git-enabled <abbr>DVC repositories</abbr> nested inside parent DVC
-> repositories (for example when using Git submodules) are isolated from the
-> parent, and vice versa. This is because each one has their own Git root.
-
 If there are multiple `--subdir` projects, but not nested, e.g.:
 
 ```dvc
@@ -143,6 +109,37 @@ project-A
 Nothing changes for the inner projects. And any DVC command run in the outer one
 actively ignores the nested project directories. For example, using `dvc pull`
 in `project-A` wouldn't download data for the `data-B.dvc` file.
+
+### Initializing DVC without Git
+
+In rare cases, the `--no-scm` option might be desirable: to initialize DVC in a
+directory that is not part of a Git repo, or to make DVC ignore Git. Examples
+include:
+
+- SCM other than Git is being used. Even though there are DVC features that
+  require DVC to be run in the Git repo, DVC can work well with other version
+  control systems. Since DVC relies on simple `dvc.yaml` files to manage
+  <abbr>pipelines</abbr>, data, etc, they can be added into any SCM thus
+  providing large data files and directories versioning.
+
+- There is no need to keep the history at all, e.g. having a deployment
+  automation like running a data pipeline using `cron`.
+
+In this mode, DVC features related to versioning are not available. For example
+automatic creation and updating of `.gitignore` files on `dvc add` or `dvc run`,
+as well as `dvc diff` and `dvc metrics diff`, which require Git revisions to
+compare.
+
+DVC sets the `core.no_scm` config option value to `true` in the DVC
+[config](/doc/command-reference/config) when initialized this way. This means
+that even if the project is tracked by Git, or if Git is initialized in it
+later, DVC will keep operating detached from Git in this project.
+
+### Nested DVC projects and repositories
+
+> Note that Git-enabled <abbr>DVC repositories</abbr> nested inside parent DVC
+> repositories (for example when using Git submodules) are isolated from the
+> parent, and vice versa. This is because each one has their own Git root.
 
 > Note that like with nested <abbr>repositories</abbr> and `--subdir` projects,
 > `--no-scm` projects inside regular <abbr>projects</abbr> are ignored by any

--- a/content/docs/command-reference/init.md
+++ b/content/docs/command-reference/init.md
@@ -72,6 +72,40 @@ With `--subdir`, the project root will be found before the Git root, making sure
 the scope of DVC commands run here is constrained to this project alone, even if
 there are more DVC-related files elsewhere in the repo.
 
+Similarly, DVC commands run outside this project root (if nested inside another
+DVC project, for example) will ignore this project's contents completely.
+
+### Initializing DVC without Git
+
+In rare cases, the `--no-scm` option might be desirable: to initialize DVC in a
+directory that is not part of a Git repo, or to make DVC ignore Git. Examples
+include:
+
+- SCM other than Git is being used. Even though there are DVC features that
+  require DVC to be run in the Git repo, DVC can work well with other version
+  control systems. Since DVC relies on simple `dvc.yaml` files to manage
+  <abbr>pipelines</abbr>, data, etc, they can be added into any SCM thus
+  providing large data files and directories versioning.
+
+- There is no need to keep the history at all, e.g. having a deployment
+  automation like running a data pipeline using `cron`.
+
+In this mode, DVC features related to versioning are not available. For example
+automatic creation and updating of `.gitignore` files on `dvc add` or `dvc run`,
+as well as `dvc diff` and `dvc metrics diff`, which require Git revisions to
+compare.
+
+DVC sets the `core.no_scm` config option value to `true` in the DVC
+[config](/doc/command-reference/config) when initialized this way. This means
+that even if the project is tracked by Git, or if Git is initialized in it
+later, DVC will keep operating detached from Git in this project.
+
+### Nested DVC projects and repositories
+
+> Note that Git-enabled <abbr>DVC repositories</abbr> nested inside parent DVC
+> repositories (for example when using Git submodules) are isolated from the
+> parent, and vice versa. This is because each one has their own Git root.
+
 If there are multiple `--subdir` projects, but not nested, e.g.:
 
 ```dvc
@@ -110,30 +144,9 @@ Nothing changes for the inner projects. And any DVC command run in the outer one
 actively ignores the nested project directories. For example, using `dvc pull`
 in `project-A` wouldn't download data for the `data-B.dvc` file.
 
-### Initializing DVC without Git
-
-In rare cases, the `--no-scm` option might be desirable: to initialize DVC in a
-directory that is not part of a Git repo, or to make DVC ignore Git. Examples
-include:
-
-- SCM other than Git is being used. Even though there are DVC features that
-  require DVC to be run in the Git repo, DVC can work well with other version
-  control systems. Since DVC relies on simple `dvc.yaml` files to manage
-  <abbr>pipelines</abbr>, data, etc, they can be added into any SCM thus
-  providing large data files and directories versioning.
-
-- There is no need to keep the history at all, e.g. having a deployment
-  automation like running a data pipeline using `cron`.
-
-In this mode, DVC features related to versioning are not available. For example
-automatic creation and updating of `.gitignore` files on `dvc add` or `dvc run`,
-as well as `dvc diff` and `dvc metrics diff`, which require Git revisions to
-compare.
-
-DVC sets the `core.no_scm` config option value to `true` in the DVC
-[config](/doc/command-reference/config) when initialized this way. This means
-that even if the project is tracked by Git, or if Git is initialized in it
-later, DVC will keep operating detached from Git in this project.
+> Note that like with nested <abbr>repositories</abbr> and `--subdir` projects,
+> `--no-scm` projects inside regular <abbr>projects</abbr> are ignored by any
+> parent DVC projects, and vice versa.
 
 ## Options
 

--- a/content/docs/command-reference/init.md
+++ b/content/docs/command-reference/init.md
@@ -76,7 +76,7 @@ outside this project root (if nested inside another DVC project) will ignore
 this project's contents completely.
 
 The only thing shared among nested `--subdir` projects and parent repository is
-the Git history itself.
+the Git history.
 
 > Note that nested DVC projects are always isolated from their parents, and vice
 > versa, whether using `--subdir` or not.

--- a/content/docs/command-reference/remote/add.md
+++ b/content/docs/command-reference/remote/add.md
@@ -131,7 +131,8 @@ For example:
 
 ```dvc
 $ dvc remote add -d myremote s3://mybucket/path/to/dir
-$ dvc remote modify myremote endpointurl https://object-storage.example.com
+$ dvc remote modify myremote endpointurl \
+                    https://object-storage.example.com
 ```
 
 > See `dvc remote modify` for a full list of S3 API parameters.

--- a/content/docs/command-reference/remote/modify.md
+++ b/content/docs/command-reference/remote/modify.md
@@ -90,19 +90,19 @@ these settings, you could use the following options:
   $ dvc remote modify myremote region us-east-2
   ```
 
-- `profile` - credentials profile name to use to access S3:
+- `profile` - credentials profile name to access S3:
 
   ```dvc
   $ dvc remote modify myremote profile myprofile
   ```
 
-- `credentialpath` - credentials path to use to access S3:
+- `credentialpath` - credentials path to access S3:
 
   ```dvc
   $ dvc remote modify myremote credentialpath /path/to/my/creds
   ```
 
-- `endpointurl` - endpoint URL to use to access S3:
+- `endpointurl` - endpoint URL to access S3:
 
   ```dvc
   $ dvc remote modify myremote endpointurl https://myendpoint.com
@@ -168,21 +168,24 @@ these settings, you could use the following options:
   for specific grantees\*\*. Grantee can read object and its metadata.
 
   ```dvc
-  $ dvc remote modify myremote grant_read id=aws-canonical-user-id,id=another-aws-canonical-user-id
+  $ dvc remote modify myremote grant_read \
+          id=aws-canonical-user-id,id=another-aws-canonical-user-id
   ```
 
 - `grant_read_acp`\* - grants `READ_ACP` permissions at object level access
   control list for specific grantees\*\*. Grantee can read the object's ACP.
 
   ```dvc
-  $ dvc remote modify myremote grant_read_acp id=aws-canonical-user-id,id=another-aws-canonical-user-id
+  $ dvc remote modify myremote grant_read_acp \
+          id=aws-canonical-user-id,id=another-aws-canonical-user-id
   ```
 
 - `grant_write_acp`\* - grants `WRITE_ACP` permissions at object level access
   control list for specific grantees\*\*. Grantee can modify the object's ACP.
 
   ```dvc
-  $ dvc remote modify myremote grant_write_acp id=aws-canonical-user-id,id=another-aws-canonical-user-id
+  $ dvc remote modify myremote grant_write_acp \
+          id=aws-canonical-user-id,id=another-aws-canonical-user-id
   ```
 
 - `grant_full_control`\* - grants `FULL_CONTROL` permissions at object level
@@ -190,7 +193,8 @@ these settings, you could use the following options:
   grant_read_acp + grant_write_acp
 
   ```dvc
-  $ dvc remote modify myremote grant_full_control id=aws-canonical-user-id,id=another-aws-canonical-user-id
+  $ dvc remote modify myremote grant_full_control \
+          id=aws-canonical-user-id,id=another-aws-canonical-user-id
   ```
 
   > \* `grant_read`, `grant_read_acp`, `grant_write_acp` and
@@ -221,7 +225,8 @@ For example:
 
 ```dvc
 $ dvc remote add myremote s3://path/to/dir
-$ dvc remote modify myremote endpointurl https://object-storage.example.com
+$ dvc remote modify myremote endpointurl \
+                    https://object-storage.example.com
 ```
 
 S3 remotes can also be configured entirely via environment variables:
@@ -250,7 +255,8 @@ For more information about the variables DVC supports, please visit
 - `connection_string` - connection string.
 
   ```dvc
-  $ dvc remote modify --local myremote connection_string "my-connection-string"
+  $ dvc remote modify --local myremote connection_string \
+                              "my-connection-string"
   ```
 
 > The connection string contains sensitive user info. Therefore, it's safer to
@@ -274,8 +280,8 @@ a full guide on using Google Drive as DVC remote storage.
   [possible formats](/doc/user-guide/setup-google-drive-remote#url-format).
 
   ```dvc
-  $ dvc remote modify myremote \
-                      url gdrive://0AIac4JZqHhKmUk9PDA/dvcstore
+  $ dvc remote modify myremote url \
+                      gdrive://0AIac4JZqHhKmUk9PDA/dvcstore
   ```
 
 - `gdrive_client_id` - Client ID for authentication with OAuth 2.0 when using a
@@ -415,13 +421,13 @@ more information.
   $ dvc remote modify myremote oss_endpoint endpoint
   ```
 
-- `oss_key_id` - OSS key ID to use to access a remote.
+- `oss_key_id` - OSS key ID to access the remote.
 
   ```dvc
   $ dvc remote modify myremote --local oss_key_id my-key-id
   ```
 
-- `oss_key_secret` - OSS secret key for authorizing access into a remote.
+- `oss_key_secret` - OSS secret key for authorizing access into the remote.
 
   ```dvc
   $ dvc remote modify myremote --local oss_key_secret my-key-secret
@@ -440,41 +446,43 @@ more information.
 - `url` - remote location URL.
 
   ```dvc
-  $ dvc remote modify myremote url ssh://user@example.com:1234/path/to/remote
+  $ dvc remote modify myremote url \
+                      ssh://user@example.com:1234/absolute/path
   ```
 
-- `user` - username to use to access a remote. The order in which dvc searches
-  for username:
-
-  1. `user` specified in one of the dvc configs;
-  2. `user` specified in the url(e.g. `ssh://user@example.com/path`);
-  3. `user` specified in `~/.ssh/config` for remote host;
-  4. current user;
+- `user` - username to access the remote.
 
   ```dvc
   $ dvc remote modify --local myremote user myuser
   ```
 
-- `port` - port to use to access a remote. The order in which dvc searches for
-  port:
+  The order in which DVC picks the username:
 
-  1. `port` specified in one of the dvc configs;
-  2. `port` specified in the url(e.g. `ssh://example.com:1234/path`);
-  3. `port` specified in `~/.ssh/config` for remote host;
-  4. default ssh port 22;
+  1. `user` parameter set with this command (found in `.dvc/config`);
+  2. User defined in the URL (e.g. `ssh://user@example.com/path`);
+  3. User defined in `~/.ssh/config` for this host (URL);
+  4. Current user
+
+- `port` - port to access the remote.
 
   ```dvc
   $ dvc remote modify myremote port 2222
   ```
 
-- `keyfile` - path to private key to use to access a remote.
+  The order in which DVC decide the port number:
+
+  1. `port` parameter set with this command (found in `.dvc/config`);
+  2. Port defined in the URL (e.g. `ssh://example.com:1234/path`);
+  3. Port defined in `~/.ssh/config` for this host (URL);
+  4. Default SSH port 22
+
+- `keyfile` - path to private key to access the remote.
 
   ```dvc
   $ dvc remote modify myremote keyfile /path/to/keyfile
   ```
 
-- `password` - a private key passphrase or a password to use to use when
-  accessing a remote.
+- `password` - a private key passphrase or a password to access the remote.
 
   ```dvc
   $ dvc remote modify --local myremote password mypassword
@@ -484,8 +492,8 @@ more information.
 > safer to add them with the `--local` option, so they're written to a
 > Git-ignored config file.
 
-- `ask_password` - ask for a private key passphrase or a password to use when
-  accessing a remote.
+- `ask_password` - ask for a private key passphrase or a password to access the
+  remote.
 
   ```dvc
   $ dvc remote modify myremote ask_password true
@@ -509,7 +517,7 @@ more information.
 
 ### Click for HDFS
 
-- `user` - username to use to access a remote.
+- `user` - username to access the remote.
 
   ```dvc
   $ dvc remote modify --local myremote user myuser
@@ -524,7 +532,7 @@ more information.
 
 ### Click for HTTP
 
-- `auth` - authentication method to use when accessing a remote. The accepted
+- `auth` - authentication method to use when accessing the remote. The accepted
   values are:
 
   - `basic` -
@@ -551,14 +559,16 @@ more information.
   ```
 
 - `user` - username to use when the `auth` parameter is set to `basic` or
-  `digest`. The order in which DVC searches for username:
-
-  1. `user` specified in one of the DVC configs;
-  2. `user` specified in the url(e.g. `http://user@example.com/path`);
+  `digest`.
 
   ```dvc
   $ dvc remote modify --local myremote user myuser
   ```
+
+  The order in which DVC picks the username:
+
+  1. `user` parameter set with this command (found in `.dvc/config`);
+  2. User defined in the URL (e.g. `http://user@example.com/path`);
 
 - `password` - password to use for any `auth` method.
 


### PR DESCRIPTION
Notes extracted from #1661: 

> Ideally not but yes in the way things are structured now in this ref. This isolation and nested situation got too complicated... I should probably make a separate sub-section to cover it after explaining all the 3 kinds of projects (typical or git-enabled, --subdir, --no-scm).

> On Git submodules: "I would expect from people who use submodules have the same intuition by default - isolated in Git, isolated in DVC - nothing special or specif", "True, I can just remove it and handle them via support channel if needed" (from https://github.com/iterative/dvc.org/pull/1615#pullrequestreview-461335110)

> On block code examples for nested repos: ".git still not important here" (from https://github.com/iterative/dvc.org/pull/1615#pullrequestreview-461337818)