### PR TITLE
import: clarify -o behavior for subdirectories

### DIFF
--- a/content/docs/command-reference/import.md
+++ b/content/docs/command-reference/import.md
@@ -78,7 +78,8 @@ from the source repo.
 - `-o <path>`, `--out <path>` - specify a path (directory and/or file name) to
   the desired location to place the imported file in (instead of using the
   current working directory). If an existing directory is specified, the target
-  data will be placed inside.
+  data will be placed inside. If `path` contains a parent directory which does
+  not exist, this command will fail.
 
 - `--rev <commit>` - commit hash, branch or tag name, etc. (any
   [Git revision](https://git-scm.com/docs/revisions)) of the repository to


### PR DESCRIPTION
> You may disregard these recommendations if you used the **Edit on GitHub** button from dvc.org to improve a doc in place.

❗ Please read the guidelines in the [Contributing to the Documentation](https://dvc.org/doc/user-guide/contributing/docs) list if you make any substantial changes to the documentation or JS engine.

🐛 Please make sure to mention `Fix #issue` (if applicable) in the description of the PR. This causes GitHub to close it automatically when the PR is merged.

Please choose to [allow us](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to edit your branch when creating the PR.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

* Clarify `dvc import -o` behavior when output path contains subdirectories.
* See https://github.com/iterative/dvc/pull/4340