### PR TITLE
use gender-neutral they instead of his/her

### DIFF
--- a/content/blog/2017-07-27-data-version-control-in-analytics-devops-paradigm.md
+++ b/content/blog/2017-07-27-data-version-control-in-analytics-devops-paradigm.md
@@ -124,7 +124,7 @@ One of the ‘juicy’ features of DVC is ability to support multiple technology
 stacks. Whether you prefer R or use promising Python-based implementations for
 your industrial data products, DVC will be able to support your pipeline
 properly. You can see it in action for both
-[Python-based](https://blog.dvc.org/how-a-data-scientist-can-improve-their-productivity)
+[Python-based](https://blog.dvc.org/how-data-scientists-can-improve-their-productivity)
 and
 [R-based](https://blog.dvc.org/r-code-and-reproducible-model-development-with-dvc)
 technical stacks.

--- a/content/blog/2017-07-27-data-version-control-in-analytics-devops-paradigm.md
+++ b/content/blog/2017-07-27-data-version-control-in-analytics-devops-paradigm.md
@@ -124,7 +124,7 @@ One of the ‘juicy’ features of DVC is ability to support multiple technology
 stacks. Whether you prefer R or use promising Python-based implementations for
 your industrial data products, DVC will be able to support your pipeline
 properly. You can see it in action for both
-[Python-based](https://blog.dvc.org/how-a-data-scientist-can-improve-his-productivity)
+[Python-based](https://blog.dvc.org/how-a-data-scientist-can-improve-their-productivity)
 and
 [R-based](https://blog.dvc.org/r-code-and-reproducible-model-development-with-dvc)
 technical stacks.

--- a/content/blog/2017-08-23-ml-model-ensembling-with-fast-iterations.md
+++ b/content/blog/2017-08-23-ml-model-ensembling-with-fast-iterations.md
@@ -208,7 +208,7 @@ In this blog post, we worked through the process of building an ensemble
 prediction pipeline using DVC. The essential key features of that pipeline were
 as follows
 
-- **_reproducibility_** — everybody on a team can run it on his/her premise
+- **_reproducibility_** — everybody on a team can run it on their premise
 
 - **_separation of data and code_** — this ensured everyone always runs the
   latest versions of the pipeline jobs with the most up-to-date ‘golden copy’ of


### PR DESCRIPTION
In line with @dmpetrov's PR to make a page title gender neutral, I made a quick search on the repository and found "his/her", which should be changed to "they" to be more inclusive.

----

> You may disregard these recommendations if you used the **Edit on GitHub** button from dvc.org to improve a doc in place.

❗ Please read the guidelines in the [Contributing to the Documentation](https://dvc.org/doc/user-guide/contributing/docs) list if you make any substantial changes to the documentation or JS engine.

🐛 Please make sure to mention `Fix #issue` (if applicable) in the description of the PR. This causes GitHub to close it automatically when the PR is merged.

Please choose to [allow us](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to edit your branch when creating the PR.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
