### PR TITLE
docs: create data folder before running "dvc get" command

### DIFF
--- a/content/docs/start/data-versioning.md
+++ b/content/docs/start/data-versioning.md
@@ -18,6 +18,7 @@ Having initialized a project in the previous section, get the data file we will
 be using later like this:
 
 ```dvc
+$ mkdir data
 $ dvc get https://github.com/iterative/dataset-registry \
           get-started/data.xml -o data/data.xml
 ```


### PR DESCRIPTION
Create "data" folder, otherwise `dvc get` throws an error


