### PR TITLE
Fix mismatched details tags on command-reference/get-url

### DIFF
--- a/content/docs/command-reference/get-url.md
+++ b/content/docs/command-reference/get-url.md
@@ -154,6 +154,8 @@ $ dvc get-url https://example.com/path/to/file
 
 </details>
 
+<details>
+
 ### Click and expand for a local example
 
 ```dvc
@@ -164,5 +166,3 @@ The above command will copy the `/local/path/to/data` file or directory into
 `./dir`.
 
 </details>
-
-<details>


### PR DESCRIPTION
This fixed broken builds on my local machine, and I think it'll fix #1709 