### PR TITLE
Add rules to style captions on Gatsby image wrappers in Docs CSS

### DIFF
--- a/src/components/Documentation/Markdown/styles.module.css
+++ b/src/components/Documentation/Markdown/styles.module.css
@@ -44,12 +44,17 @@
     }
 
     img + em,
+    :global(.gatsby-resp-image-wrapper) + em,
     .gatsby-highlight + p > em:only-child {
       color: #6a737d;
       font-size: 0.9em;
       display: block;
       margin-top: -6px;
       text-align: center;
+    }
+
+    :global(.gatsby-resp-image-wrapper) + em {
+      margin-top: 0;
     }
 
     a[target='_blank'] {


### PR DESCRIPTION
Fixes #1713 by adding rules for `.gatsby-responsive-image-wrapper + em` on top of the existing `img + em` rules.

This issue came up before in the blog, I just overlooked that the docs CSS had the same issue.