### PR TITLE
Fix typo

### DIFF
--- a/content/docs/start/data-versioning.md
+++ b/content/docs/start/data-versioning.md
@@ -38,7 +38,7 @@ $ dvc add data/data.xml
 ```
 
 DVC stores information about the added file (or a directory) in a special `.dvc`
-file named `data/data.dvc`, a small text file with a human-readable
+file named `data/data.xml.dvc`, a small text file with a human-readable
 [format](/doc/user-guide/dvc-files-and-directories#dvc-files). This file can be
 easily versioned like source code with Git, as a placeholder for the original
 data (which gets listed in `.gitignore`):


### PR DESCRIPTION
The small text file with human-readable format is called `data/data.xml.dvc`, not `data/data.dvc`.