### PR TITLE
Adding missing backslash in `dvc run` commands

### DIFF
--- a/content/docs/user-guide/external-dependencies.md
+++ b/content/docs/user-guide/external-dependencies.md
@@ -44,7 +44,7 @@ stage to your list of stages in dvc.yaml.
 ### Amazon S3
 
 ```dvc
-$ dvc run -n download_file
+$ dvc run -n download_file \
           -d s3://mybucket/data.txt \
           -o data.txt \
           aws s3 cp s3://mybucket/data.txt data.txt
@@ -53,7 +53,7 @@ $ dvc run -n download_file
 ### Microsoft Azure Blob Storage
 
 ```dvc
-$ dvc run -n download_file
+$ dvc run -n download_file \
           -d azure://mycontainer/data.txt \
           -o data.txt \
           az storage copy \
@@ -66,7 +66,7 @@ $ dvc run -n download_file
 ### Google Cloud Storage
 
 ```dvc
-$ dvc run -n download_file
+$ dvc run -n download_file \
           -d gs://mybucket/data.txt \
           -o data.txt \
           gsutil cp gs://mybucket/data.txt data.txt
@@ -75,7 +75,7 @@ $ dvc run -n download_file
 ### SSH
 
 ```dvc
-$ dvc run -n download_file
+$ dvc run -n download_file \
           -d ssh://user@example.com/path/to/data.txt \
           -o data.txt \
           scp user@example.com:/path/to/data.txt data.txt
@@ -90,7 +90,7 @@ Please check that you are able to connect both ways with tools like `ssh` and
 ### HDFS
 
 ```dvc
-$ dvc run -n download_file
+$ dvc run -n download_file \
           -d hdfs://user@example.com/data.txt \
           -o data.txt \
           hdfs fs -copyToLocal \
@@ -102,7 +102,7 @@ $ dvc run -n download_file
 > Including HTTPs
 
 ```dvc
-$ dvc run -n download_file
+$ dvc run -n download_file \
           -d https://example.com/data.txt \
           -o data.txt \
           wget https://example.com/data.txt -O data.txt
@@ -111,7 +111,7 @@ $ dvc run -n download_file
 ### Local file system path
 
 ```dvc
-$ dvc run -n download_file
+$ dvc run -n download_file \
           -d /home/shared/data.txt \
           -o data.txt \
           cp /home/shared/data.txt data.txt
@@ -129,7 +129,7 @@ For example, for an HTTPs remote/dependency:
 
 ```dvc
 $ dvc remote add example https://example.com
-$ dvc run -n download_file
+$ dvc run -n download_file \
           -d remote://example/data.txt \
           -o data.txt \
           wget https://example.com/data.txt -O data.txt


### PR DESCRIPTION
Copy and paste files without the addition of the backslash on first line.

> You may disregard these recommendations if you used the **Edit on GitHub** button from dvc.org to improve a doc in place.

❗ Please read the guidelines in the [Contributing to the Documentation](https://dvc.org/doc/user-guide/contributing/docs) list if you make any substantial changes to the documentation or JS engine.

🐛 Please make sure to mention `Fix #issue` (if applicable) in the description of the PR. This causes GitHub to close it automatically when the PR is merged.

Please choose to [allow us](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to edit your branch when creating the PR.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
