### PR TITLE
Fix details triggers that contain markup

### DIFF
--- a/content/docs/user-guide/external-dependencies.md
+++ b/content/docs/user-guide/external-dependencies.md
@@ -154,7 +154,7 @@ The command above creates the <abbr>import stage</abbr> (DVC-file)
 
 <details>
 
-### Expand to see resulting DVC-file
+### Expand to see resulting `.dvc` file
 
 ```yaml
 # ...
@@ -193,7 +193,7 @@ specified (with the `repo` field).
 
 <details>
 
-### Expand to see resulting DVC-file
+### Expand to see resulting `.dvc` file
 
 ```yaml
 # ...

--- a/plugins/gatsby-remark-dvc-linker/simpleLinker.js
+++ b/plugins/gatsby-remark-dvc-linker/simpleLinker.js
@@ -4,6 +4,8 @@ const { createLinkNode } = require('./helpers')
 
 const entries = require('../../content/linked-terms')
 
+const excludedParentTypes = ['link', 'heading']
+
 const useMatcher = (matcher, item) => {
   switch (typeof matcher) {
     case 'string':
@@ -21,7 +23,7 @@ module.exports = astNode => {
   const node = astNode[0]
   const parent = astNode[2]
 
-  if (parent.type !== 'link') {
+  if (!excludedParentTypes.includes(parent.type)) {
     const entry = entries.find(({ matches }) => useMatcher(matches, node.value))
     if (entry) {
       createLinkNode(entry.url, astNode)

--- a/src/components/Documentation/Markdown/index.tsx
+++ b/src/components/Documentation/Markdown/index.tsx
@@ -1,4 +1,10 @@
-import React, { useCallback, useEffect, useRef } from 'react'
+import React, {
+  useCallback,
+  useEffect,
+  useRef,
+  ReactNode,
+  ReactElement
+} from 'react'
 import cn from 'classnames'
 import { navigate } from '@reach/router'
 import rehypeReact from 'rehype-react'
@@ -12,6 +18,8 @@ import { getPathWithSource } from '../../../utils/shared/sidebar'
 import 'github-markdown-css/github-markdown.css'
 import sharedStyles from '../styles.module.css'
 import styles from './styles.module.css'
+
+import util from 'util'
 
 const isInsideCodeBlock = (node: Element): boolean => {
   while (node?.parentNode) {
@@ -30,17 +38,31 @@ const isInsideCodeBlock = (node: Element): boolean => {
 }
 
 const Details: React.FC<{
-  children: Array<{ props: { children: Array<string> } } | string>
+  children: Array<{ props: { children: ReactNode } } | string>
 }> = ({ children }) => {
   const filteredChildren = children.filter(child => child !== '\n')
 
   if (!filteredChildren.length) return null
   if (typeof filteredChildren[0] === 'string') return null
 
-  const text = filteredChildren[0].props.children[0]
+  const headingChildren: ReactNode[] = filteredChildren[0].props
+    .children as ReactNode[]
+
+  // Remove header auto-link if present
+  const finalHeadingChild = headingChildren[headingChildren.length - 1]! as {
+    props: {
+      className: string
+    }
+  }
+
+  const triggerChildren: unknown =
+    finalHeadingChild.props !== undefined &&
+    finalHeadingChild.props.className === 'anchor after'
+      ? headingChildren.slice(0, headingChildren.length - 1)
+      : headingChildren
 
   return (
-    <Collapsible trigger={text} transitionTime={200}>
+    <Collapsible trigger={triggerChildren as ReactElement} transitionTime={200}>
       {filteredChildren.slice(1)}
     </Collapsible>
   )

--- a/src/components/Documentation/Markdown/index.tsx
+++ b/src/components/Documentation/Markdown/index.tsx
@@ -51,8 +51,8 @@ const Details: React.FC<{
      which we currently have as an external package.
    */
   const triggerChildren: ReactNode[] = firstChild.props.children.slice(
-    1,
-    firstChild.props.children.length
+    0,
+    firstChild.props.children.length - 1
   ) as ReactNode[]
 
   /*

--- a/src/components/Documentation/Markdown/index.tsx
+++ b/src/components/Documentation/Markdown/index.tsx
@@ -19,8 +19,6 @@ import 'github-markdown-css/github-markdown.css'
 import sharedStyles from '../styles.module.css'
 import styles from './styles.module.css'
 
-import util from 'util'
-
 const isInsideCodeBlock = (node: Element): boolean => {
   while (node?.parentNode) {
     if (node.tagName === 'PRE') {
@@ -49,7 +47,7 @@ const Details: React.FC<{
     .children as ReactNode[]
 
   // Remove header auto-link if present
-  const finalHeadingChild = headingChildren[headingChildren.length - 1]! as {
+  const finalHeadingChild = headingChildren[headingChildren.length - 1] as {
     props: {
       className: string
     }

--- a/src/components/Documentation/Markdown/index.tsx
+++ b/src/components/Documentation/Markdown/index.tsx
@@ -41,16 +41,19 @@ const Details: React.FC<{
   const filteredChildren: ReactNode[] = children.filter(child => child !== '\n')
   const firstChild = filteredChildren[0] as JSX.Element
 
-  const triggerChildren: ReactNode[] = firstChild.props.children as ReactNode[]
+  if (!/^h.$/.test(firstChild.type)) {
+    throw new Error('The first child of a details element must be a heading!')
+  }
 
   /*
-     To work around auto-linked headings, the last child of any heading node
+     To work around auto-linked headings, the last child of the heading node
      must be removed. The only way around this is the change the autolinker,
      which we currently have as an external package.
    */
-  if (/^h.$/.test(firstChild.type)) {
-    triggerChildren.pop()
-  }
+  const triggerChildren: ReactNode[] = firstChild.props.children.slice(
+    1,
+    firstChild.props.children.length
+  ) as ReactNode[]
 
   /*
      Collapsible's trigger type wants ReactElement, so we force a TS cast from

--- a/src/components/Documentation/Markdown/index.tsx
+++ b/src/components/Documentation/Markdown/index.tsx
@@ -53,14 +53,17 @@ const Details: React.FC<{
     }
   }
 
-  const triggerChildren: unknown =
+  const triggerChildren: ReactNode =
     finalHeadingChild.props !== undefined &&
     finalHeadingChild.props.className === 'anchor after'
       ? headingChildren.slice(0, headingChildren.length - 1)
       : headingChildren
 
   return (
-    <Collapsible trigger={triggerChildren as ReactElement} transitionTime={200}>
+    <Collapsible
+      trigger={(triggerChildren as unknown) as ReactElement}
+      transitionTime={200}
+    >
       {filteredChildren.slice(1)}
     </Collapsible>
   )

--- a/src/components/Documentation/Markdown/index.tsx
+++ b/src/components/Documentation/Markdown/index.tsx
@@ -39,25 +39,18 @@ const Details: React.FC<{
   children: Array<{ props: { children: ReactNode } } | string>
 }> = ({ children }) => {
   const filteredChildren = children.filter(child => child !== '\n')
+  const firstChild = filteredChildren[0]
 
-  if (!filteredChildren.length) return null
-  if (typeof filteredChildren[0] === 'string') return null
+  const triggerChildren: ReactNode[] = firstChild.props.children as ReactNode[]
 
-  const headingChildren: ReactNode[] = filteredChildren[0].props
-    .children as ReactNode[]
-
-  // Remove header auto-link if present
-  const finalHeadingChild = headingChildren[headingChildren.length - 1] as {
-    props: {
-      className: string
-    }
+  /*
+     As an adaptation to auto-linked headings, the last child of any heading
+     nodes must be removed. The only way around this is the change the
+     autolinker, which we currently have as an external package
+   */
+  if (/h./.test(firstChild.type)) {
+    triggerChildren.pop()
   }
-
-  const triggerChildren: ReactNode =
-    finalHeadingChild.props !== undefined &&
-    finalHeadingChild.props.className === 'anchor after'
-      ? headingChildren.slice(0, headingChildren.length - 1)
-      : headingChildren
 
   return (
     <Collapsible

--- a/src/components/Documentation/Markdown/index.tsx
+++ b/src/components/Documentation/Markdown/index.tsx
@@ -44,14 +44,18 @@ const Details: React.FC<{
   const triggerChildren: ReactNode[] = firstChild.props.children as ReactNode[]
 
   /*
-     As an adaptation to auto-linked headings, the last child of any heading
-     nodes must be removed. The only way around this is the change the
-     autolinker, which we currently have as an external package
+     To work around auto-linked headings, the last child of any heading node
+     must be removed. The only way around this is the change the autolinker,
+     which we currently have as an external package.
    */
-  if (/h./.test(firstChild.type)) {
+  if (/^h.$/.test(firstChild.type)) {
     triggerChildren.pop()
   }
 
+  /*
+     Collapsible's trigger type wants ReactElement, so we force a TS cast from
+     ReactNode here.
+   */
   return (
     <Collapsible
       trigger={(triggerChildren as unknown) as ReactElement}

--- a/src/components/Documentation/Markdown/index.tsx
+++ b/src/components/Documentation/Markdown/index.tsx
@@ -38,8 +38,8 @@ const isInsideCodeBlock = (node: Element): boolean => {
 const Details: React.FC<{
   children: Array<{ props: { children: ReactNode } } | string>
 }> = ({ children }) => {
-  const filteredChildren = children.filter(child => child !== '\n')
-  const firstChild = filteredChildren[0]
+  const filteredChildren: ReactNode[] = children.filter(child => child !== '\n')
+  const firstChild = filteredChildren[0] as JSX.Element
 
   const triggerChildren: ReactNode[] = firstChild.props.children as ReactNode[]
 

--- a/src/gatsby/models/github/index.js
+++ b/src/gatsby/models/github/index.js
@@ -7,34 +7,6 @@
    alone does.
  */
 
-async function createStaticGithubDataNode(api, fieldData = {}) {
-  const {
-    actions: { createNode },
-    createNodeId,
-    createContentDigest
-  } = api
-
-  const fields = {
-    stars: 8888,
-    parent: null,
-    ...fieldData
-  }
-
-  const node = {
-    id: createNodeId('DVCGithubStaticData'),
-    children: [],
-    ...fields,
-    internal: {
-      type: 'StaticGithubData',
-      contentDigest: createContentDigest(fields)
-    }
-  }
-
-  await createNode(node)
-
-  return node
-}
-
 module.exports = {
   async createSchemaCustomization({ actions: { createTypes }, schema }) {
     createTypes(


### PR DESCRIPTION
Before, as pointed out [here](https://github.com/iterative/dvc.org/pull/1735#discussion_r479549491) by @jorgeorpinel, any markup like code quotes would break a header as only the first child
had its text extracted. Now, the `Collapsible` uses the whole `children` value of the
header it's made from as the `trigger` text, so anything that can go in a heading can go in a `details` `trigger`.

`simpleLinker` is also changed to not apply to code quotes within headings, partially because of this and also because auto-links in headers feels like it clutters the UX a bit since the same contents will very likely be linked in the following paragraph. I can re-enable this behavior if we find it desirable.