### PR TITLE
Rule change for ESLint to error on unused variables.

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -28,7 +28,8 @@
       { "prefixWithI": "always" }
     ],
     "no-tabs": "error",
-    "react/prop-types": "off"
+    "react/prop-types": "off",
+    "@typescript-eslint/no-unused-vars": "error"
   },
   "overrides": [
     {


### PR DESCRIPTION
This effectively makes commits with an unused variable blocked, fixes #1291 