### PR TITLE
s/open/read in dvc.api.read reference

### DIFF
--- a/content/docs/api-reference/read.md
+++ b/content/docs/api-reference/read.md
@@ -3,7 +3,7 @@
 Returns the contents of a tracked file.
 
 ```py
-def open(path: str,
+def read(path: str,
          repo: str = None,
          rev: str = None,
          remote: str = None,


### PR DESCRIPTION
(rant starts)
Feels like the `dvc.api` could be better overall (it's written in a man-page style instead of easy to use, gets-out-of-way reference.
The block that tries to show the function signature is split into multiple lines and has a `def` in front of them.
Formatting is also broken in many places and seems that there's too much information than there should be for what's it meant to be very simple APIs.

Another issue, I noticed is that we have too many exceptions for `dvc.api`. Not a documentation issue, but docs do reflect the issue on the core side.
(rant ends)

Just fixing a typo/mistake on `dvc.api.read()`. :slightly_smiling_face: 