### PR TITLE
docs: fix non-intuitive diff offset formatting in start/data-pipelines.md

### DIFF
--- a/content/docs/start/data-pipelines.md
+++ b/content/docs/start/data-pipelines.md
@@ -102,9 +102,9 @@ prepare:
 +      │       └── train.tsv
 +      ├── dvc.yaml
 +      ├── dvc.lock
-        ├── params.yaml
-        └── src
-            ├── ...
+       ├── params.yaml
+       └── src
+           ├── ...
   ```
 
 - The last line, `python src/prepare.py ...`, is the command to run in this

--- a/content/docs/start/data-pipelines.md
+++ b/content/docs/start/data-pipelines.md
@@ -97,11 +97,11 @@ prepare:
        ├── data
        │   ├── data.xml
        │   ├── data.xml.dvc
-  +   │   └── prepared
-  +   │       ├── test.tsv
-  +   │       └── train.tsv
-  +   ├── dvc.yaml
-  +   ├── dvc.lock
++      │   └── prepared
++      │       ├── test.tsv
++      │       └── train.tsv
++      ├── dvc.yaml
++      ├── dvc.lock
         ├── params.yaml
         └── src
             ├── ...

--- a/content/docs/start/data-pipelines.md
+++ b/content/docs/start/data-pipelines.md
@@ -93,10 +93,10 @@ prepare:
   two files in it. This is how the <abbr>workspace</abbr> should look like now:
 
   ```
-        .
-        ├── data
-        │   ├── data.xml
-        │   ├── data.xml.dvc
+       .
+       ├── data
+       │   ├── data.xml
+       │   ├── data.xml.dvc
   +   │   └── prepared
   +   │       ├── test.tsv
   +   │       └── train.tsv

--- a/content/docs/start/data-pipelines.md
+++ b/content/docs/start/data-pipelines.md
@@ -92,7 +92,7 @@ prepare:
 - `-o data/prepared` specifies an output directory for this script, which writes
   two files in it. This is how the <abbr>workspace</abbr> should look like now:
 
-  ```diff
+  ```
         .
         ├── data
         │   ├── data.xml

--- a/content/docs/start/data-pipelines.md
+++ b/content/docs/start/data-pipelines.md
@@ -93,18 +93,18 @@ prepare:
   two files in it. This is how the <abbr>workspace</abbr> should look like now:
 
   ```
-       .
-       ├── data
-       │   ├── data.xml
-       │   ├── data.xml.dvc
-  +    │   └── prepared
-  +    │       ├── test.tsv
-  +    │       └── train.tsv
-  +    ├── dvc.yaml
-  +    ├── dvc.lock
-       ├── params.yaml
-       └── src
-           ├── ...
+   .
+   ├── data
+   │   ├── data.xml
+   │   ├── data.xml.dvc
+  +│   └── prepared
+  +│       ├── test.tsv
+  +│       └── train.tsv
+  +├── dvc.yaml
+  +├── dvc.lock
+   ├── params.yaml
+   └── src
+       ├── ...
   ```
 
 - The last line, `python src/prepare.py ...`, is the command to run in this

--- a/content/docs/start/data-pipelines.md
+++ b/content/docs/start/data-pipelines.md
@@ -97,11 +97,11 @@ prepare:
        ├── data
        │   ├── data.xml
        │   ├── data.xml.dvc
-+      │   └── prepared
-+      │       ├── test.tsv
-+      │       └── train.tsv
-+      ├── dvc.yaml
-+      ├── dvc.lock
+  +    │   └── prepared
+  +    │       ├── test.tsv
+  +    │       └── train.tsv
+  +    ├── dvc.yaml
+  +    ├── dvc.lock
        ├── params.yaml
        └── src
            ├── ...

--- a/content/docs/start/data-pipelines.md
+++ b/content/docs/start/data-pipelines.md
@@ -93,18 +93,18 @@ prepare:
   two files in it. This is how the <abbr>workspace</abbr> should look like now:
 
   ```diff
-      .
-      ├── data
-      │   ├── data.xml
-      │   ├── data.xml.dvc
+        .
+        ├── data
+        │   ├── data.xml
+        │   ├── data.xml.dvc
   +   │   └── prepared
   +   │       ├── test.tsv
   +   │       └── train.tsv
   +   ├── dvc.yaml
   +   ├── dvc.lock
-      ├── params.yaml
-      └── src
-          ├── ...
+        ├── params.yaml
+        └── src
+            ├── ...
   ```
 
 - The last line, `python src/prepare.py ...`, is the command to run in this

--- a/content/docs/start/data-pipelines.md
+++ b/content/docs/start/data-pipelines.md
@@ -92,7 +92,7 @@ prepare:
 - `-o data/prepared` specifies an output directory for this script, which writes
   two files in it. This is how the <abbr>workspace</abbr> should look like now:
 
-  ```
+  ```git
    .
    ├── data
    │   ├── data.xml


### PR DESCRIPTION
The `diff` notation breaks the tree visualization in this quote block.
