### PR TITLE
Remove UrlNotDvcRepoError from exc for dvc.api

### DIFF
--- a/content/docs/api-reference/get_url.md
+++ b/content/docs/api-reference/get_url.md
@@ -68,8 +68,6 @@ or
 
 ## Exceptions
 
-- `dvc.api.UrlNotDvcRepoError` - `repo` is not a DVC project.
-
 - `dvc.exceptions.NoRemoteError` - no `remote` is found.
 
 ## Example: Getting the URL to a DVC-tracked file

--- a/content/docs/api-reference/open.md
+++ b/content/docs/api-reference/open.md
@@ -84,8 +84,6 @@ streamed, which optimizes memory usage.
 
 - `dvc.exceptions.PathMissingError` - `path` cannot be found in `repo`.
 
-- `dvc.api.UrlNotDvcRepoError` - `repo` is not a DVC project.
-
 - `dvc.exceptions.NoRemoteError` - no `remote` is found.
 
 ## Example: Use data or models from DVC repos

--- a/content/docs/api-reference/read.md
+++ b/content/docs/api-reference/read.md
@@ -75,8 +75,6 @@ These are loaded to memory directly (without using any disc space).
 
 - `dvc.exceptions.PathMissingError` - `path` cannot be found in `repo`.
 
-- `dvc.api.UrlNotDvcRepoError` - `repo` is not a DVC project.
-
 - `dvc.exceptions.NoRemoteError` - no `remote` is found.
 
 ## Example: Load data from a DVC repository


### PR DESCRIPTION
We added support for subrepos in https://github.com/iterative/dvc/pull/4465, due to which it made `UrlNotDvcRepoError` invalid and imprecise. So, we made a _breaking change_ for the exceptions raised.

There's a lot of things that are wrong with exceptions for `dvc.api`, which I don't want to fix them here but on the core side (raise `ApiError` everywhere, perhaps?).

> You may disregard these recommendations if you used the **Edit on GitHub** button from dvc.org to improve a doc in place.

❗ Please read the guidelines in the [Contributing to the Documentation](https://dvc.org/doc/user-guide/contributing/docs) list if you make any substantial changes to the documentation or JS engine.

🐛 Please make sure to mention `Fix #issue` (if applicable) in the description of the PR. This causes GitHub to close it automatically when the PR is merged.

Please choose to [allow us](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to edit your branch when creating the PR.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
