### PR TITLE
docs: replace stage file example in /install/completion, fix typos found in review

### DIFF
--- a/content/docs/command-reference/dag.md
+++ b/content/docs/command-reference/dag.md
@@ -37,7 +37,7 @@ restore one or more pipelines later (see `dvc repro`).
 
 ## Options
 
-- `--full` - show full DAG that the `target` stage belongs too, instead of
+- `--full` - show full DAG that the `target` stage belongs to, instead of
   showing only its ancestors.
 
 - `--dot` - show DAG in

--- a/content/docs/command-reference/freeze.md
+++ b/content/docs/command-reference/freeze.md
@@ -74,7 +74,7 @@ foo.dvc:
 ```
 
 DVC notices that `foo` changed due to the `foo.dvc` file that tracks this file
-(as `outs`), but the `make_copy` stage no longer records the change among it's
+(as `outs`), but the `make_copy` stage no longer records the change among its
 `deps`.
 
 > You can use `dvc unfreeze` to go back to the regular project status.

--- a/content/docs/command-reference/install.md
+++ b/content/docs/command-reference/install.md
@@ -178,7 +178,7 @@ $ git tag
 
 These tags are used to mark points in the development of the project, and to
 document specific experiments conducted in it. To take a look at one, we
-checkout the `6-featurization` tag:
+checkout the `7-ml-pipeline` tag:
 
 ```dvc
 $ git checkout 7-ml-pipeline

--- a/content/docs/command-reference/unfreeze.md
+++ b/content/docs/command-reference/unfreeze.md
@@ -49,7 +49,7 @@ $ dvc run -n make_copy -d foo -o bar cp foo bar
 > See `dvc run` for more details.
 
 Then, let's change the file `foo` that the stage `make_copy` depends on, and
-freeze stage as well, to see what's the project status after that:
+freeze the stage as well, to see what's the project status after that:
 
 ```dvc
 $ echo zoo > foo
@@ -61,7 +61,7 @@ foo.dvc:
 ```
 
 DVC notices that `foo` changed due to the `foo.dvc` file that tracks this file
-(as `outs`), but the `make_copy` stage doesn't records the change among it's
+(as `outs`), but the `make_copy` stage no longer records the change among its
 dependencies. Run `dvc unfreeze` to get the regular/full project status:
 
 ```dvc

--- a/content/docs/command-reference/unfreeze.md
+++ b/content/docs/command-reference/unfreeze.md
@@ -61,7 +61,7 @@ foo.dvc:
 ```
 
 DVC notices that `foo` changed due to the `foo.dvc` file that tracks this file
-(as `outs`), but the `make_copy` stage no longer records the change among its
+(as `outs`), but the `make_copy` stage doesn't record the change among its
 dependencies. Run `dvc unfreeze` to get the regular/full project status:
 
 ```dvc

--- a/content/docs/install/completion.md
+++ b/content/docs/install/completion.md
@@ -27,12 +27,13 @@ run     -- Generate a stage file from a command and execute the command.
 
 Depending on what you typed on the command line so far, it completes:
 
-- Available DVC commands.
+- Available DVC commands and subcommands. For example, `dvc plots` completes
+  with `diff`, `modify`, and `show`.
 - Options (flags) that are available for a particular command.
 - File names that make sense in a given context, such as using them as a target
   for some commands.
-- Values for certain command arguments and subcommands. For example, `dvc plots`
-  completes with `diff`, `modify`, and `show`.
+- Values for certain command arguments. For example, `dvc repro` completes with
+  stages or `.dvc` files to reproduce.
 
 ## What shell do you have?
 

--- a/content/docs/install/completion.md
+++ b/content/docs/install/completion.md
@@ -31,8 +31,8 @@ Depending on what you typed on the command line so far, it completes:
 - Options (flags) that are available for a particular command.
 - File names that make sense in a given context, such as using them as a target
   for some commands.
-- Values for certain command arguments. For example, `dvc repro` completes with
-  stage files to reproduce.
+- Values for certain command arguments. For example, `dvc metrics` completes
+  with `diff`, `modify`, and `show`.
 
 ## What shell do you have?
 

--- a/content/docs/install/completion.md
+++ b/content/docs/install/completion.md
@@ -33,7 +33,7 @@ Depending on what you typed on the command line so far, it completes:
 - File names that make sense in a given context, such as using them as a target
   for some commands.
 - Values for certain command arguments. For example, `dvc repro` completes with
-  stages or `.dvc` files to reproduce.
+  existing files to reproduce.
 
 ## What shell do you have?
 

--- a/content/docs/install/completion.md
+++ b/content/docs/install/completion.md
@@ -31,8 +31,8 @@ Depending on what you typed on the command line so far, it completes:
 - Options (flags) that are available for a particular command.
 - File names that make sense in a given context, such as using them as a target
   for some commands.
-- Values for certain command arguments. For example, `dvc metrics` completes
-  with `diff`, `modify`, and `show`.
+- Values for certain command arguments. For example, `dvc plots` completes with
+  `diff`, `modify`, and `show`.
 
 ## What shell do you have?
 

--- a/content/docs/install/completion.md
+++ b/content/docs/install/completion.md
@@ -33,7 +33,7 @@ Depending on what you typed on the command line so far, it completes:
 - File names that make sense in a given context, such as using them as a target
   for some commands.
 - Values for certain command arguments. For example, `dvc repro` completes with
-  existing files to reproduce.
+  existing files to use as targets.
 
 ## What shell do you have?
 

--- a/content/docs/install/completion.md
+++ b/content/docs/install/completion.md
@@ -31,8 +31,8 @@ Depending on what you typed on the command line so far, it completes:
 - Options (flags) that are available for a particular command.
 - File names that make sense in a given context, such as using them as a target
   for some commands.
-- Values for certain command arguments. For example, `dvc plots` completes with
-  `diff`, `modify`, and `show`.
+- Values for certain command arguments and subcommands. For example, `dvc plots`
+  completes with `diff`, `modify`, and `show`.
 
 ## What shell do you have?
 


### PR DESCRIPTION
Found in review for #1743. Replaced out-of-date `dvc repro` stage file example with `dvc plots` completion example.  