### PR TITLE
Update the place where DAGs are stored.

### DIFF
--- a/content/docs/command-reference/dag.md
+++ b/content/docs/command-reference/dag.md
@@ -1,6 +1,6 @@
 # dag
 
-Visualize the pipeline(s) in `dvc.yaml` as one or more graph(s) of connected
+Visualize the pipeline(s) in `.dvc` files as one or more graph(s) of connected
 [stages](/doc/command-reference/run).
 
 ## Synopsis
@@ -25,7 +25,7 @@ intermediate featurization and training stages, and produce a final model, as
 well as accuracy [metrics](/doc/command-reference/metrics).
 
 In DVC, pipeline stages and commands, their data I/O, interdependencies, and
-results (intermediate or final) are specified in `dvc.yaml`, which can be
+results (intermediate or final) are specified in `.dvc` files, which can be
 written manually or built using the helper command `dvc run`. This allows DVC to
 restore one or more pipelines later (see `dvc repro`).
 


### PR DESCRIPTION
The docs seemed to suggest that DAGs were stored in the root `dvc.yaml` file but it seems they are placed in separate `.dvc` files.

----

> You may disregard these recommendations if you used the **Edit on GitHub** button from dvc.org to improve a doc in place.

❗ Please read the guidelines in the [Contributing to the Documentation](https://dvc.org/doc/user-guide/contributing/docs) list if you make any substantial changes to the documentation or JS engine.

🐛 Please make sure to mention `Fix #issue` (if applicable) in the description of the PR. This causes GitHub to close it automatically when the PR is merged.

Please choose to [allow us](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to edit your branch when creating the PR.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
