### PR TITLE
Handle non-JSON non-ok responses from CloudFlare cache clear

### DIFF
--- a/scripts/clear-cloudflare-cache.js
+++ b/scripts/clear-cloudflare-cache.js
@@ -48,19 +48,24 @@ module.exports = async function () {
     }
   )
 
+  if (!res.ok) {
+    throw new Error(
+      `CloudFlare cache clear request returned non-ok status ${res.status}: ${res.statusText}`
+    )
+  }
+
   const body = await res.json()
 
-  if (!res.ok || !body.success) {
+  if (!body.success) {
     throw new Error(
-      'CloudFlare cache clear failed! ' +
-        JSON.stringify(
-          {
-            status: res.status,
-            errors: body.errors
-          },
-          undefined,
-          2
-        )
+      `CloudFlare cache clear failed! ${JSON.stringify(
+        {
+          status: res.status,
+          errors: body.errors
+        },
+        undefined,
+        2
+      )}`
     )
   }
 


### PR DESCRIPTION
I noticed [this prod build](https://dashboard.heroku.com/apps/dvc-org/activity/builds/adcf40cc-7eaa-44cc-8d2e-ba8327fef2a3) that failed on the CloudFlare clear yesterday, seemingly on a non-JSON response. My hypothesis is that CloudFlare returns some errors like Auth as plain HTTP codes while others are encoded in the `errors` property of a json blob in the body.

This PR allows us to recognize and throw on the former before attempting a JSON conversion, and thus providing more info on the error.