### PR TITLE
Skip running deploy check on master.

### DIFF
--- a/.github/workflows/link-check-deploy.yml
+++ b/.github/workflows/link-check-deploy.yml
@@ -2,14 +2,18 @@ name: Check new links against deployment
 # This workflow "triggers" and skips on deployment because GitHub Actions /
 # Checks refuses to show the check on deployment_status
 on:
-  - deployment
-  - deployment_status
+  deployment:
+    branches-ignore:
+      - master
+  deployment_status:
+    branches-ignore:
+      - master
 
 jobs:
   run:
     name: Initialize
     runs-on: ubuntu-latest
-    if: github.ref != 'master' && github.event.deployment_status.state == 'success'
+    if: github.event.deployment_status.state == 'success'
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/link-check-deploy.yml
+++ b/.github/workflows/link-check-deploy.yml
@@ -9,7 +9,7 @@ jobs:
   run:
     name: Initialize
     runs-on: ubuntu-latest
-    if: github.ref != 'master' && github.event.deployment_status.state == 'success' 
+    if: github.ref != 'master' && github.event.deployment_status.state == 'success'
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/link-check-deploy.yml
+++ b/.github/workflows/link-check-deploy.yml
@@ -9,7 +9,7 @@ jobs:
   run:
     name: Initialize
     runs-on: ubuntu-latest
-    if: github.event.deployment_status.state == 'success'
+    if: github.ref != 'master' && github.event.deployment_status.state == 'success' 
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
It will never check any links because we're comparing to master.

Also, this change provides a convenient excuse to test the deploy check on a new PR!