### PR TITLE
Add ability to override SEO description in docs pages

### DIFF
--- a/content/docs/start/index.md
+++ b/content/docs/start/index.md
@@ -1,4 +1,5 @@
 ---
+title: 'Get Started | DVC'
 description: 'Get started with DVC!'
 ---
 

--- a/content/docs/start/index.md
+++ b/content/docs/start/index.md
@@ -1,8 +1,3 @@
----
-title: 'Get Started | DVC'
-description: 'Get started with DVC!'
----
-
 # Get Started
 
 Assuming DVC is already [installed](/doc/install), let's initialize it by

--- a/content/docs/start/index.md
+++ b/content/docs/start/index.md
@@ -1,3 +1,7 @@
+---
+description: 'Get started with DVC!'
+---
+
 # Get Started
 
 Assuming DVC is already [installed](/doc/install), let's initialize it by

--- a/src/gatsby/models/docs/createSchemaCustomization.js
+++ b/src/gatsby/models/docs/createSchemaCustomization.js
@@ -11,7 +11,9 @@ async function createSchemaCustomization(api) {
       interfaces: ['Node'],
       fields: {
         ...markdownParentFields,
-        template: 'String'
+        template: 'String',
+        title: 'String',
+        description: 'String'
       }
     })
   ]

--- a/src/gatsby/models/docs/onCreateMarkdownContentNode.js
+++ b/src/gatsby/models/docs/onCreateMarkdownContentNode.js
@@ -18,7 +18,9 @@ async function createMarkdownDocsNode(api, { parentNode, createChildNode }) {
     slug,
     rawMarkdownBody: node.rawMarkdownBody,
     sourcePath: relativePath,
-    template: node.frontmatter.template
+    template: node.frontmatter.template,
+    title: node.frontmatter.title === '' ? null : node.frontmatter.title,
+    description: node.frontmatter.description
   }
 
   const docNode = {

--- a/src/templates/doc.tsx
+++ b/src/templates/doc.tsx
@@ -31,8 +31,6 @@ const DocPage: React.FC<IDocPageProps> = ({
 
   const { label } = getItemByPath(slug)
 
-  console.log({ title, description })
-
   return (
     <>
       <SEO title={title || label} description={description} />

--- a/src/templates/doc.tsx
+++ b/src/templates/doc.tsx
@@ -11,6 +11,8 @@ interface IDocPageProps {
   data: {
     page: {
       htmlAst: Node
+      title?: string
+      description?: string
     }
   }
   pageContext: {
@@ -24,14 +26,16 @@ const DocPage: React.FC<IDocPageProps> = ({
   pageContext: { slug, headings }
 }) => {
   const {
-    page: { htmlAst }
+    page: { htmlAst, title, description }
   } = data
 
   const { label } = getItemByPath(slug)
 
+  console.log({ title, description })
+
   return (
     <>
-      <SEO title={label} />
+      <SEO title={title || label} description={description} />
       <Documentation htmlAst={htmlAst} path={slug} headings={headings} />
     </>
   )
@@ -42,6 +46,8 @@ export default DocPage
 export const pageQuery = graphql`
   query DocPage($id: String!) {
     page: docsPage(id: { eq: $id }) {
+      title
+      description
       htmlAst
     }
   }


### PR DESCRIPTION
This PR adds the ability to use `description` and `title` frontmatter fields to override the SEO description and title of any docs page, in the same way as the Blog pages.

Since the Blog and Docs use the same SEO component, all the same SEO tags are used. If either is not provided, the page will fall back on the same SEO title and description it had before.

Fixes #1785 

Can be verified on the deploy preview with test data [here](https://dvc-landing-docs-descri-ytzq28.herokuapp.com/doc/start). I'll remove it before merge.