### PR TITLE
Add Link Check status badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![Maintainability](https://api.codeclimate.com/v1/badges/5872e0a572ec8b74bd8d/maintainability)](https://codeclimate.com/github/iterative/dvc.org/maintainability)
 [![CircleCI](https://circleci.com/gh/iterative/dvc.org.svg?style=svg)](https://circleci.com/gh/iterative/dvc.org)
+![Link Check](https://github.com/iterative/dvc.org/workflows/Check%20all%20links%20in%20the%20repository/badge.svg)
 
 [DVC](https://github.com/iterative/dvc) project website's source code.
 [Documentation](https://dvc.org/doc) and [blog](https://dvc.org/blog) content.


### PR DESCRIPTION
I didn't think the long workflow name would also reflect in the badge. We may want to rename the workflow to make the badge look better, as it doesn't seem to be configurable otherwise.

We can also use this branch for fixes for existing links, as adding the badge while failing may not be a good look.

Check out how it looks [on this branch's README](https://github.com/iterative/dvc.org/tree/link-check-status-badge#readme)