### PR TITLE
Add href to Link Check action results on README badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Maintainability](https://api.codeclimate.com/v1/badges/5872e0a572ec8b74bd8d/maintainability)](https://codeclimate.com/github/iterative/dvc.org/maintainability)
 [![CircleCI](https://circleci.com/gh/iterative/dvc.org.svg?style=svg)](https://circleci.com/gh/iterative/dvc.org)
-![Link Check](https://github.com/iterative/dvc.org/workflows/Check%20all%20links%20in%20the%20repository/badge.svg)
+[![Link Check](https://github.com/iterative/dvc.org/workflows/Check%20all%20links%20in%20the%20repository/badge.svg)](https://github.com/iterative/dvc.org/actions?query=workflow%3A%22Check+all+links+in+the+repository%22)
 
 [DVC](https://github.com/iterative/dvc) project website's source code.
 [Documentation](https://dvc.org/doc) and [blog](https://dvc.org/blog) content.


### PR DESCRIPTION
This PR simply adds a link around the Link Check badge in the README to the GitHub Action results of the action it's related to.