### PR TITLE
Use upgraded link-check to fix checks on forked repos

### DIFF
--- a/.github/workflows/link-check-all.yml
+++ b/.github/workflows/link-check-all.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Run Link Check
-        uses: 'iterative/link-check.action@v0.6'
+        uses: 'iterative/link-check.action@v0.7'
         with:
           configFile: 'config/link-check/config.yml'
           output: consoleLog

--- a/.github/workflows/link-check-deploy.yml
+++ b/.github/workflows/link-check-deploy.yml
@@ -23,11 +23,12 @@ jobs:
 
       - name: Run Link Check
         id: check
-        uses: 'iterative/link-check.action@v0.6'
+        uses: 'iterative/link-check.action@v0.7'
         with:
           diff: true
           configFile: 'config/link-check/config.yml'
           rootURL: '${{ github.event.deployment.payload.web_url }}'
+          origin: 'https://github.com/iterative/dvc.org'
           output: checksAction
 
       - uses: LouisBrunner/checks-action@v1.0.0


### PR DESCRIPTION
While GHA is running on forked repos, `origin` points to the forked repo which breaks the script.

The new version of link-check adds an `origin` option to the GitHub Action, which will cause the action to attempt to remove the `origin` remote and point it to the provided input.

This PR is initiated from a forked repo to test the behavior.

EDIT: While required to have the script run on forked PRs, it seems this stems from a different issue.