### PR TITLE
Link check upgrade

### DIFF
--- a/.github/workflows/link-check-all.yml
+++ b/.github/workflows/link-check-all.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Run Link Check
-        uses: 'iterative/link-check.action@v0.6'
+        uses: 'iterative/link-check.action@v0.7'
         with:
           configFile: 'config/link-check/config.yml'
           output: consoleLog

--- a/.github/workflows/link-check-deploy.yml
+++ b/.github/workflows/link-check-deploy.yml
@@ -23,7 +23,7 @@ jobs:
 
       - name: Run Link Check
         id: check
-        uses: 'iterative/link-check.action@v0.6'
+        uses: 'iterative/link-check.action@v0.7'
         with:
           diff: true
           configFile: 'config/link-check/config.yml'

--- a/config/link-check/config.yml
+++ b/config/link-check/config.yml
@@ -7,6 +7,6 @@ linkOptions:
     minTime: 2000
     maxConcurrent: 1
 
-  '*.github.com':
+  '(*.)?github.com':
     minTime: 1000
     maxConcurrent: 1

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "react-slick": "^0.25.2",
     "react-use": "^14.0.0",
     "rehype-react": "^5.0.1",
-    "repo-link-check": "^0.6.0",
+    "repo-link-check": "^0.7.1",
     "reset-css": "^5.0.1",
     "s3-client": "^4.4.2",
     "scroll": "^3.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -14403,10 +14403,10 @@ replace-ext@^1.0.0:
   resolved "https://registry.yarnpkg.com/replace-ext/-/replace-ext-1.0.1.tgz#2d6d996d04a15855d967443631dd5f77825b016a"
   integrity sha512-yD5BHCe7quCgBph4rMQ+0KkIRKwWCrHDOX1p1Gp6HwjPM5kVoCdKGNhN7ydqqsX6lJEnQDKZ/tFMiEdQ1dvPEw==
 
-repo-link-check@^0.6.0:
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/repo-link-check/-/repo-link-check-0.6.0.tgz#2ae67c44d725658beeaa3acf7d7de5e71175bbd1"
-  integrity sha512-7y05N70Nju6AQBWiYv/pXubn56dklS/Jfc5MDX4rED74DPMeqilKfBtjkV4kAg9cCfTwsnePPuuWgQGbN6cfRw==
+repo-link-check@^0.7.1:
+  version "0.7.1"
+  resolved "https://registry.yarnpkg.com/repo-link-check/-/repo-link-check-0.7.1.tgz#3a717d8cf30ee1b71bfbde8d2019dde0f53a24b8"
+  integrity sha512-vcKvgqgVbC1BawU9kUCIR8tWc2nDvKipGca9oraGj1Qe5X/GeMLrOlKlrT4BAVxFIxI24eEnh1b5RYK7GzI7Kg==
   dependencies:
     bottleneck "^2.19.5"
     commander "^6.1.0"


### PR DESCRIPTION
Bump link check version to 0.7, with changes to the GET->HEAD retry system such that any failure on HEAD is retried with GET (previously this only happened on 405)

Also, this PR changes the GitHub link settings pattern to include the apex domain (github.com as opposed to www.github.com or api.github.com).