### PR TITLE
Use modified Title Case for slug -> label conversion.

### DIFF
--- a/content/docs/sidebar.json
+++ b/content/docs/sidebar.json
@@ -87,10 +87,7 @@
         "slug": "what-is-dvc",
         "source": "what-is-dvc.md"
       },
-      {
-        "label": "DVC Files and Directories",
-        "slug": "dvc-files-and-directories"
-      },
+      "dvc-files-and-directories",
       "merge-conflicts",
       {
         "slug": "dvcignore",
@@ -130,10 +127,7 @@
           }
         ]
       },
-      {
-        "label": "Running DVC on Windows",
-        "slug": "running-dvc-on-windows"
-      },
+      "running-dvc-on-windows",
       "troubleshooting",
       "related-technologies",
       {

--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
     "scroll": "^3.0.1",
     "serve-handler": "^6.1.2",
     "slick-carousel": "^1.8.1",
+    "title-case": "^3.0.2",
     "unist-util-visit": "2.0.2",
     "upath": "^1.2.0"
   },

--- a/src/utils/shared/sidebar.js
+++ b/src/utils/shared/sidebar.js
@@ -20,12 +20,16 @@
   }
 */
 
-const startCase = require('lodash/startCase')
+const { titleCase } = require('title-case')
 const sidebar = require('../../../content/docs/sidebar.json')
 
 const PATH_ROOT = '/doc'
 const FILE_ROOT = '/docs/'
 const FILE_EXTENSION = '.md'
+
+function dvcTitleCase(slug) {
+  return titleCase(slug.replace(/dvc/g, 'DVC').replace(/-/g, ' '))
+}
 
 function validateRawItem({ slug, source, children, type, url }) {
   const isSourceDisabled = source === false
@@ -109,7 +113,7 @@ function normalizeItem({ rawItem, parentPath, resultRef, prevRef }) {
       return {
         path: relativePath ? `${PATH_ROOT}/${relativePath}` : PATH_ROOT,
         source: source === false ? false : sourcePath,
-        label: label ? label : startCase(slug),
+        label: label ? label : dvcTitleCase(slug),
         tutorials: tutorials || {},
         prev,
         next: undefined,

--- a/yarn.lock
+++ b/yarn.lock
@@ -16335,6 +16335,13 @@ tinycolor2@^1.4.1:
   resolved "https://registry.yarnpkg.com/tinycolor2/-/tinycolor2-1.4.1.tgz#f4fad333447bc0b07d4dc8e9209d8f39a8ac77e8"
   integrity sha1-9PrTM0R7wLB9TcjpIJ2POaisd+g=
 
+title-case@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/title-case/-/title-case-3.0.2.tgz#9f926a0a42071366f85470572f312c4b647773ab"
+  integrity sha512-1P5hyjEhJ9Ab0AT8Xbm0z1avwPSgRR6XtFSNCdfo6B7111TTTja+456UZ2ZPkbTbzqBwIpQxp/tazh5UvpJ+fA==
+  dependencies:
+    tslib "^1.10.0"
+
 tlds@^1.203.0:
   version "1.207.0"
   resolved "https://registry.yarnpkg.com/tlds/-/tlds-1.207.0.tgz#459264e644cf63ddc0965fece3898913286b1afd"


### PR DESCRIPTION
Before, we used lodash startCase which simply made every word have its first
letter capitalized. This new function does title case (leaving 'and', 'or', etc.
uncapitalized) and also capitalizes "dvc"

Initially mentioned [here](https://github.com/iterative/dvc.org/pull/1840#discussion_r500466702)