### PR TITLE
docs: add redirect for How To: Update Tracked Files

### DIFF
--- a/redirects-list.json
+++ b/redirects-list.json
@@ -29,6 +29,7 @@
 
   "^/doc/use-cases/data-and-model-files-versioning/?$                                     /doc/use-cases/versioning-data-and-model-files",
   "^/doc/user-guide/dvc-file-format$                                                      /doc/user-guide/dvc-files-and-directories",
+  "^/doc/user-guide/updating-tracked-files$                                               /doc/user-guide/how-to/update-tracked-files",
   "^/doc/understanding-dvc(/.*)?$                                                         /doc/user-guide/what-is-dvc",
   "^/doc/commands-reference(/.*)?$                                                        /doc/command-reference$1",
   "^/doc/command-reference/plot$                                                          /doc/command-reference/plots",


### PR DESCRIPTION
As discussed with @jorgeorpinel to address the redirect problem in #1823 and #1705.

If this redirect is applied soon, the existing index ranking for the old URL should be transferred to the new one, even though the change was made some time ago. This is the [existing index listing for the old URL](https://www.google.com/search?client=safari&rls=en&sxsrf=ALeKk01Bsc_mAQ8KJircq8gRouuCtIqMFg%3A1602146894471&ei=TtJ-X4uaHKqorgTdxqiQCA&q=info%3Ahttps%3A%2F%2Fdvc.org%2Fdoc%2Fuser-guide%2Fupdating-tracked-files&oq=info%3Ahttps%3A%2F%2Fdvc.org%2Fdoc%2Fuser-guide%2Fupdating-tracked-files&gs_lcp=CgZwc3ktYWIQAzoECAAQR1DhEVjaEmDXFWgAcAJ4AIABlgGIAYcCkgEDMC4ymAEAoAEBqgEHZ3dzLXdpesgBCMABAQ&sclient=psy-ab&ved=0ahUKEwiL-ZakzqTsAhUqlIsKHV0jCoIQ4dUDCAw&uact=5).

When this PR is merged, I'll reindex the old URL on Search Console.