### PR TITLE
cases: add custom meta title and meta description to (data versioning tutorial) [SEO]

### DIFF
--- a/content/docs/use-cases/versioning-data-and-model-files/tutorial.md
+++ b/content/docs/use-cases/versioning-data-and-model-files/tutorial.md
@@ -1,15 +1,15 @@
 ---
 title: 'Tutorial: Data & Model Versioning'
-description: 'Get experience with data versioning in a basic machine learning
-version control scenario: managing multiple datasets and ML model versions using
-DVC commands.'
+description: 'Get hands-on experience with data versioning in a basic machine
+learning version control scenario: managing multiple datasets and ML models
+using DVC.'
 ---
 
 # Tutorial: Data & Model Versioning
 
 The goal of this example is to give you some hands-on experience with a basic
 machine learning version control scenario: managing multiple datasets and ML
-model versions using DVC commands. We'll work with a
+models using DVC. We'll work with a
 [tutorial](https://blog.keras.io/building-powerful-image-classification-models-using-very-little-data.html)
 that [François Chollet](https://twitter.com/fchollet) put together to show how
 to build a powerful image classifier using a pretty small dataset.

--- a/content/docs/use-cases/versioning-data-and-model-files/tutorial.md
+++ b/content/docs/use-cases/versioning-data-and-model-files/tutorial.md
@@ -1,7 +1,8 @@
 ---
 title: 'Tutorial: Data & Model Versioning'
-description: |
-  Get experience with data versioning in a basic machine learning version control scenario: managing multiple datasets and ML model versions using DVC commands.
+description: 'Get experience with data versioning in a basic machine learning
+version control scenario: managing multiple datasets and ML model versions using
+DVC commands.'
 ---
 
 # Tutorial: Data & Model Versioning

--- a/content/docs/use-cases/versioning-data-and-model-files/tutorial.md
+++ b/content/docs/use-cases/versioning-data-and-model-files/tutorial.md
@@ -1,5 +1,5 @@
 ---
-title: 'Tutorial: Data & Model Versioning'
+title: 'Data and Model Versioning Tutorial'
 description: 'Get hands-on experience with data versioning in a basic machine
 learning version control scenario: managing multiple datasets and ML models
 using DVC.'

--- a/content/docs/use-cases/versioning-data-and-model-files/tutorial.md
+++ b/content/docs/use-cases/versioning-data-and-model-files/tutorial.md
@@ -1,3 +1,9 @@
+---
+title: 'Tutorial: Data & Model Versioning'
+description: |
+  Get experience with data versioning in a basic machine learning version control scenario: managing multiple datasets and ML model versions using DVC commands.
+---
+
 # Tutorial: Data & Model Versioning
 
 The goal of this example is to give you some hands-on experience with a basic

--- a/content/docs/use-cases/versioning-data-and-model-files/tutorial.md
+++ b/content/docs/use-cases/versioning-data-and-model-files/tutorial.md
@@ -5,7 +5,7 @@ learning version control scenario: managing multiple datasets and ML models
 using DVC.'
 ---
 
-# Tutorial: Data & Model Versioning
+# Data and Model Versioning Tutorial
 
 The goal of this example is to give you some hands-on experience with a basic
 machine learning version control scenario: managing multiple datasets and ML


### PR DESCRIPTION
The data versioning tutorial has good placement in [search results](https://www.google.com/search?q=dataset+versioning) for key terms like "versioning data" and "dataset versioning". The results for this page typically show the default dvc.org meta description, and the title is limited to "Tutorial".
<img width="660" alt="image" src="https://user-images.githubusercontent.com/18587991/95728226-ef4d4600-0c83-11eb-8451-c8f98cb88c21.png">

A unique description that matches the page content can increase clickthrough and reduce bounce (leading to better search ranking). Pages that include the search terms in their title typically rank better on those terms.

This PR adds a custom meta description and expands the meta title to "Tutorial: Data & Model Versioning". 

