### PR TITLE
start: add meta title, description and key term (data pipelines) [SEO]

### DIFF
--- a/content/docs/start/data-pipelines.md
+++ b/content/docs/start/data-pipelines.md
@@ -1,9 +1,11 @@
 ---
-description: 'Learn how DVC data pipelines can help you organize, version, and
-efficiently reproduce your data science or machine learning project.'
+title: 'Get Started: Data Pipelines'
+description: 'Get started with pipelines in DVC. Learn how to build data
+pipelines to organize, version, and reproduce your data science and machine
+learning processes.'
 ---
 
-# Data Pipelines
+# Get Started: Data Pipelines
 
 Versioning large data files and directories for data science is great, but not
 enough. How is data filtered, transformed, or used to train ML models? DVC

--- a/content/docs/start/data-pipelines.md
+++ b/content/docs/start/data-pipelines.md
@@ -13,8 +13,8 @@ that produce a final result.
 
 DVC pipelines and their data can also be easily versioned (using Git). This
 allows you to better organize your project, and reproduce your workflow and
-results later exactly as they were built originally! This allows you to
-capture simple ETL workflows, better organize data science projects, or build detailed
+results later exactly as they were built originally! This allows you to capture
+simple ETL workflows, better organize data science projects, or build detailed
 machine learning pipelines (to name a few uses).
 
 ## Pipeline stages

--- a/content/docs/start/data-pipelines.md
+++ b/content/docs/start/data-pipelines.md
@@ -312,7 +312,7 @@ important problems:
   and which commands will generate the pipeline results (such as an ML model).
   Storing these files in Git makes it easy to version and share.
 - _Continuous Delivery and Continuous Integration (CI/CD) for ML_ - describing
-  projects in way that it can be reproduced (built) is the fist necessary step
+  projects in way that it can be reproduced (built) is the first necessary step
   before introducing CI/CD systems. See our sister project,
   [CML](https://cml.dev/) for some examples.
 

--- a/content/docs/start/data-pipelines.md
+++ b/content/docs/start/data-pipelines.md
@@ -1,8 +1,7 @@
 ---
 title: 'Get Started: Data Pipelines'
-description: 'Get started with pipelines in DVC. Learn how to build data
-pipelines to organize, version, and reproduce your data science and machine
-learning processes.'
+description: 'Get started with pipelines in DVC. Learn how to capture, organize,
+version, and reproduce your data science and machine learning workflows.'
 ---
 
 # Get Started: Data Pipelines

--- a/content/docs/start/data-pipelines.md
+++ b/content/docs/start/data-pipelines.md
@@ -11,14 +11,11 @@ enough. How is data filtered, transformed, or used to train ML models? DVC
 introduces a mechanism to capture _data pipelines_ — series of data processes
 that produce a final result.
 
-A DVC pipeline uses stages to describe how models and other data artifacts are
-built, and provides an efficient way to reproduce them. This allows you to
-capture simple data workflows, organize data science projects, or build detailed
-machine learning pipelines (to name a few use cases).
-
-You can easily version DVC pipelines and their data (using Git). This allows you
-to better organize your project and reproduce your workflow and results later —
-exactly as they were built originally!
+DVC pipelines and their data can also be easily versioned (using Git). This
+allows you to better organize your project, and reproduce your workflow and
+results later exactly as they were built originally! This allows you to
+capture simple ETL workflows, better organize data science projects, or build detailed
+machine learning pipelines (to name a few uses).
 
 ## Pipeline stages
 

--- a/content/docs/start/data-pipelines.md
+++ b/content/docs/start/data-pipelines.md
@@ -1,6 +1,6 @@
 ---
 title: 'Get Started: Data Pipelines'
-description: 'Get started with pipelines in DVC. Learn how to capture, organize,
+description: 'Learn how to build and use DVC pipelines to capture, organize,
 version, and reproduce your data science and machine learning workflows.'
 ---
 
@@ -12,10 +12,10 @@ introduces a mechanism to capture _data pipelines_ — series of data processes
 that produce a final result.
 
 DVC pipelines and their data can also be easily versioned (using Git). This
-allows you to better organize your project, and reproduce your workflow and
-results later exactly as they were built originally! This allows you to capture
-simple ETL workflows, better organize data science projects, or build detailed
-machine learning pipelines (to name a few uses).
+allows you to better organize projects, and reproduce your workflow and results
+later — exactly as they were built originally! For example, you could capture a
+simple ETL workflow, organize a data science project, or build a detailed
+machine learning pipeline.
 
 ## Pipeline stages
 

--- a/content/docs/start/data-pipelines.md
+++ b/content/docs/start/data-pipelines.md
@@ -1,6 +1,6 @@
 ---
-description: |
-  Learn how DVC data pipelines can help you organize, version, and efficiently reproduce your data science or machine learning project.
+description: 'Learn how DVC data pipelines can help you organize, version, and
+efficiently reproduce your data science or machine learning project.'
 ---
 
 # Data Pipelines

--- a/content/docs/start/data-pipelines.md
+++ b/content/docs/start/data-pipelines.md
@@ -1,3 +1,8 @@
+---
+description: |
+  Learn how DVC data pipelines can help you organize, version, and efficiently reproduce your data science or machine learning project.
+---
+
 # Data Pipelines
 
 Versioning large data files and directories for data science is great, but not
@@ -5,9 +10,14 @@ enough. How is data filtered, transformed, or used to train ML models? DVC
 introduces a mechanism to capture _data pipelines_ — series of data processes
 that produce a final result.
 
-DVC pipelines and their data can also be easily versioned (using Git). This
-allows you to better organize your project, and reproduce your workflow and
-results later exactly as they were built originally!
+A DVC pipeline uses stages to describe how models and other data artifacts are
+built, and provides an efficient way to reproduce them. This allows you to
+capture simple data workflows, organize data science projects, or build detailed
+machine learning pipelines (to name a few use cases).
+
+You can easily version DVC pipelines and their data (using Git). This allows you
+to better organize your project and reproduce your workflow and results later —
+exactly as they were built originally!
 
 ## Pipeline stages
 


### PR DESCRIPTION
**Meta title**
Added a custom title to prefix title with "Get Started:" in search result. Edited page H1 to match. Suggest using this pattern for all Get Started items and Tutorial. Adding prefixes like this should improve clickthrough and reduce bounce by clearly showing the result is a "Get Started" article (or Tutorial, in that case) as opposed to command reference, etc. 

**Meta description**
Added a custom meta description to the front matter with overview and key terms. 

**Key term**
Added second paragraph to expand on use cases and add "machine learning pipelines".

This page doesn't rank on the first page for either "data pipelines" or "machine learning pipelines". The intent of these changes is to improve placement for "machine learning pipelines". Current results for that term align well with the DVC use cases.