### PR TITLE
start: add meta description, 'machine learning' term (index) [SEO]

### DIFF
--- a/content/docs/start/index.md
+++ b/content/docs/start/index.md
@@ -1,7 +1,7 @@
 ---
-description: 'A step-by-step introduction: Learn how to use DVC to organize,
-version, and efficiently reproduce your data science or machine learning
-project.'
+description: 'Learn how you can use DVC to manage data science and machine
+learning projects: version data, manage data access, build data pipelines, and
+capture experiments.'
 ---
 
 # Get Started
@@ -53,14 +53,14 @@ DVC features can be grouped into layers. We'll explore them one by one in the
 next few sections:
 
 - [**Data versioning**](/doc/start/data-versioning) is the core part of DVC for
-  large files, datasets, ML models versioning and efficient sharing. We'll show
-  how to use a regular Git workflow, without storing large files with Git. Think
-  "Git for data".
+  large files, datasets, machine learning models versioning and efficient
+  sharing. We'll show how to use a regular Git workflow, without storing large
+  files with Git. Think "Git for data".
 
 - [**Data access**](/doc/start/data-access) shows how to use data artifacts from
   outside of the project and how to import data artifacts from another DVC
-  project. This can help to download a specific version of a machine learning
-  model to a deployment server or import a model to another project.
+  project. This can help to download a specific version of an ML model to a
+  deployment server or import a model to another project.
 
 - [**Data pipelines**](/doc/start/data-pipelines) describe how models and other
   data artifacts are built, and provide an efficient way to reproduce them.

--- a/content/docs/start/index.md
+++ b/content/docs/start/index.md
@@ -1,3 +1,9 @@
+---
+description: 'A step-by-step introduction: Learn how to use DVC to organize,
+version, and efficiently reproduce your data science or machine learning
+project.'
+---
+
 # Get Started
 
 Assuming DVC is already [installed](/doc/install), let's initialize it by
@@ -11,7 +17,7 @@ In expandable sections that start with the ⚙️ emoji, we'll be providing more
 information for those trying to run the commands. It's up to you to pick the
 best way to read the material - read the text (skip sections like this, and it
 should be enough to understand the idea of DVC), or try to run them and get the
-fist hand experience.
+first hand experience.
 
 We'll be building an NLP project from scratch together. The end result is
 published on [GitHub](https://github.com/iterative/example-get-started).
@@ -53,12 +59,13 @@ next few sections:
 
 - [**Data access**](/doc/start/data-access) shows how to use data artifacts from
   outside of the project and how to import data artifacts from another DVC
-  project. This can help to download a specific version of an ML model to a
-  deployment server or import a model to another project.
+  project. This can help to download a specific version of a machine learning
+  model to a deployment server or import a model to another project.
 
 - [**Data pipelines**](/doc/start/data-pipelines) describe how models and other
   data artifacts are built, and provide an efficient way to reproduce them.
   Think "Makefiles for data and ML projects" done right.
 
 - [**Experiments**](/doc/start/experiments) attach parameters, metrics, plots.
-  You can capture and navigate experiments not leaving Git. Think "Git for ML".
+  You can capture and navigate experiments without leaving Git. Think "Git for
+  machine learning".

--- a/content/docs/start/index.md
+++ b/content/docs/start/index.md
@@ -1,7 +1,7 @@
 ---
 description: 'Learn how you can use DVC to manage data science and machine
-learning projects: version data, manage data access, build data pipelines, and
-capture experiments.'
+learning projects: version data, access it anywhere, capture data pipelines, and
+manage experiments.'
 ---
 
 # Get Started


### PR DESCRIPTION
**Meta description**
Added a custom meta description to the front matter. This doc commonly appears in results next to the Tutorial (shown below in results for "dvc tutorial"). In addition to normal benefits, a custom description will help users differentiate between the two (hopefully reducing bounces for both).

**Key term**
Added "machine learning" in two usages: one as "machine learning model" and another as "git for machine learning".

**Typos**
Fixed two typos that I came across incidentally.

<img width="595" alt="image" src="https://user-images.githubusercontent.com/18587991/96011158-42252a00-0e4b-11eb-85d7-ade570eacc4c.png">
