### PR TITLE
Updated doc for 'dvc cache dir' according to pull request #4613

### DIFF
--- a/content/docs/command-reference/cache/dir.md
+++ b/content/docs/command-reference/cache/dir.md
@@ -79,6 +79,6 @@ Absolute path `/path/to/dir` saved as is.
 ## Example: Getting current cache directory
 
 ```dvc
-$dvc cache dir
+$ dvc cache dir
 /home/user/dvc/.dvc/cache
 ```

--- a/content/docs/command-reference/cache/dir.md
+++ b/content/docs/command-reference/cache/dir.md
@@ -11,7 +11,8 @@ usage: dvc cache dir [-h] [--global | --system | --local] [-u] value
 positional arguments:
   value        Path to cache directory. Relative paths are resolved
                relative to the current directory and saved to config
-               relative to the config file location.
+               relative to the config file location. If no path is
+               provided, it returns the current cache directory.
 ```
 
 ## Description
@@ -21,7 +22,8 @@ Helper to set the `cache.dir` configuration option. (See
 Unlike doing so with `dvc config cache`, this command transform paths (`value`)
 that are provided relative to the current working directory into paths
 **relative to the config file location**. However, if the `value` provided is an
-absolute path, then it's preserved as it is.
+absolute path, then it's preserved as it is. If no path is provided, it prints
+the path for current cache directory.
 
 ## Options
 
@@ -73,3 +75,10 @@ $ cat .dvc/config
 ```
 
 Absolute path `/path/to/dir` saved as is.
+
+## Example: Getting current cache directory
+
+```dvc
+$dvc cache dir
+/home/user/dvc/.dvc/cache
+```


### PR DESCRIPTION
Updated doc for 'dvc cache dir' according to pull request [#4613](https://github.com/iterative/dvc/pull/4613)

- Updated the help section of `dvc cache dir` command.
- Added an example to print the current cache directory path with `dvc cache dir` command. (This may need modification).

Signed-off-by: Girish Joshi <girish946@gmail.com>

> You may disregard these recommendations if you used the **Edit on GitHub** button from dvc.org to improve a doc in place.

❗ Please read the guidelines in the [Contributing to the Documentation](https://dvc.org/doc/user-guide/contributing/docs) list if you make any substantial changes to the documentation or JS engine.

🐛 Please make sure to mention `Fix #issue` (if applicable) in the description of the PR. This causes GitHub to close it automatically when the PR is merged.

Please choose to [allow us](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to edit your branch when creating the PR.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
