### PR TITLE
Remove CSS line break on em in p following highlights

### DIFF
--- a/src/components/Documentation/Markdown/styles.module.css
+++ b/src/components/Documentation/Markdown/styles.module.css
@@ -44,8 +44,7 @@
     }
 
     img + em,
-    :global(.gatsby-resp-image-wrapper) + em,
-    .gatsby-highlight + p > em:only-child {
+    :global(.gatsby-resp-image-wrapper) + em {
       color: #6a737d;
       font-size: 0.9em;
       display: block;


### PR DESCRIPTION
This fixes #1910, but I'm not sure what this rule was created for so it may have caused an issue with something else. That said, we have a selector specifically for images so we can be sure that isn't the case.