### PR TITLE
external outs: remove azure support

### DIFF
--- a/content/docs/command-reference/config.md
+++ b/content/docs/command-reference/config.md
@@ -184,9 +184,6 @@ for more details.) This section contains the following options:
 - `cache.s3` - name of an Amazon S3 remote to use as
   [external cache](/doc/user-guide/managing-external-data#examples).
 
-- `cache.azure` - name of a Microsoft Azure Blob Storage remote to use as
-  [external cache](/doc/user-guide/managing-external-data).
-
 - `cache.gs` - name of a Google Cloud Storage remote to use as
   [external cache](/doc/user-guide/managing-external-data#examples).
 

--- a/content/docs/user-guide/managing-external-data.md
+++ b/content/docs/user-guide/managing-external-data.md
@@ -27,7 +27,6 @@ Currently, the following types (protocols) of external outputs (and
 <abbr>cache</abbr>) are supported:
 
 - Amazon S3
-- Microsoft Azure Blob Storage
 - Google Cloud Storage
 - SSH
 - HDFS
@@ -67,24 +66,6 @@ $ dvc run -d data.txt \
           --external \
           -o s3://mybucket/data.txt \
           aws s3 cp data.txt s3://mybucket/data.txt
-```
-
-</details>
-
-<details>
-
-### Click for Microsoft Azure Blob Storage
-
-```dvc
-$ dvc remote add azurecache azure://mycontainer/cache
-$ dvc config cache.azure azurecache
-
-$ dvc add --external azure://mycontainer/existing-data
-
-$ dvc run -d data.txt \
-          --external \
-          -o azure://mycontainer/data.txt \
-          az storage blob upload -f data.txt -c mycontainer -n data.txt
 ```
 
 </details>


### PR DESCRIPTION
~~Related to iterative/dvc#4878~~
Closes #1934 - We never supported external outputs for Azure.
The supported remotes can be derived from current state of [outs](https://github.com/iterative/dvc/tree/1.9.1/dvc/output).