### PR TITLE
docs: move getting started link to top of examples section, make md blockquote

### DIFF
--- a/content/docs/command-reference/repro.md
+++ b/content/docs/command-reference/repro.md
@@ -31,9 +31,6 @@ results.
 > (either manually or by using `dvc run`) while initial data dependencies can be
 > registered with `dvc add`.
 
-To get hands-on experience with data science and machine learning pipelines, see
-[Get Started: Data Pipelines](/doc/start/data-pipelines).
-
 This command is similar to [Make](https://www.gnu.org/software/make/) in
 software build automation, but DVC captures build requirements
 ([dependencies and outputs](/doc/command-reference/run#dependencies-and-outputs))
@@ -179,6 +176,9 @@ up-to-date and only execute the final stage.
 - `-v`, `--verbose` - displays detailed tracing information.
 
 ## Examples
+
+> To get hands-on experience with data science and machine learning pipelines,
+> see [Get Started: Data Pipelines](/doc/start/data-pipelines).
 
 Let's build and reproduce a simple pipeline. It takes this `text.txt` file:
 


### PR DESCRIPTION
Fixes link position and formatting left over from #1915.