### PR TITLE
docs: missed adjustments for size/nfiles fields

### DIFF
--- a/content/docs/user-guide/dvc-files-and-directories.md
+++ b/content/docs/user-guide/dvc-files-and-directories.md
@@ -70,9 +70,8 @@ An _output entry_ (`outs`) consists of these fields:
   [ETag](https://en.wikipedia.org/wiki/HTTP_ETag#Strong_and_weak_validation) for
   HTTP, S3, or Azure [external outputs](/doc/user-guide/managing-external-data);
   and a special _checksum_ for HDFS.
-- `size` (optional): Size of the file or directory (sum of all files in the
-  directory).
-- `nfiles` (optional): Number of files in the directory.
+- `size`: Size of the file or directory (sum of all files).
+- `nfiles`: If a directory, number of files inside.
 - `cache`: Whether or not this file or directory is <abbr>cached</abbr> (`true`
   by default, if not present). See the `--no-commit` option of `dvc add`.
 
@@ -85,9 +84,8 @@ A _dependency entry_ (`deps`) consists of these fields:
   [ETag](https://en.wikipedia.org/wiki/HTTP_ETag#Strong_and_weak_validation) for
   HTTP, S3, or Azure <abbr>external dependencies</abbr>; and a special
   _checksum_ for HDFS. See `dvc import-url` for more information.
-- `size` (optional): Size of the file or directory (sum of all files in the
-  directory).
-- `nfiles` (optional): Number of files in the directory.
+- `size`: Size of the file or directory (sum of all files).
+- `nfiles`: If a directory, number of files inside.
 - `repo`: This entry is only for external dependencies created with
   `dvc import`, and can contains the following fields:
 


### PR DESCRIPTION
From https://github.com/iterative/dvc.org/pull/1907

> You may disregard these recommendations if you used the **Edit on GitHub** button from dvc.org to improve a doc in place.

❗ Please read the guidelines in the [Contributing to the Documentation](https://dvc.org/doc/user-guide/contributing/docs) list if you make any substantial changes to the documentation or JS engine.

🐛 Please make sure to mention `Fix #issue` (if applicable) in the description of the PR. This causes GitHub to close it automatically when the PR is merged.

Please choose to [allow us](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to edit your branch when creating the PR.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
