### PR TITLE
cmd: Updating description of <DVC_METRIC_Y> in plots

### DIFF
--- a/content/docs/command-reference/plots/diff.md
+++ b/content/docs/command-reference/plots/diff.md
@@ -1,7 +1,7 @@
 # plots diff
 
 Show multiple versions of [plot metrics](/doc/command-reference/plots) by
-overlaying them in a single plot. This allows to compare them easily.
+overlaying them in a single image. This allows to compare them easily.
 
 ## Synopsis
 

--- a/content/docs/command-reference/plots/index.md
+++ b/content/docs/command-reference/plots/index.md
@@ -64,8 +64,11 @@ epoch, AUC, loss
 37, 0.92302, 0.0299015
 ```
 
-Hierarchical file formats such as JSON and YAML consists of an array of objects
-where each object should contain all fields that are required for the plot.
+Hierarchical file formats such as JSON and YAML consists of an array of
+consistent objects (sharing a common structure): All objects should contain the
+fields used for the X and Y axis of the plot (see
+[DVC template anchors](#dvc-template-anchors)); Extra elements will be ignored
+silently.
 
 `dvc plots` subcommands can produce plots for a specified field or a set of
 them, from the array's objects. For example, `val_loss` is one of the field

--- a/content/docs/command-reference/plots/index.md
+++ b/content/docs/command-reference/plots/index.md
@@ -64,11 +64,8 @@ epoch, AUC, loss
 37, 0.92302, 0.0299015
 ```
 
-In hierarchical file formats (JSON or YAML), an array of consistent objects is
-expected: every object should have the same structure. However, if an object has
-extra elements, it won't affect the plot as long as
-[fields specified](#dvc-template-anchors) for X and Y axis are present in all
-the objects.
+Hierarchical file formats such as JSON and YAML consists of an array of objects
+where each object should contain all fields that are required for the plot.
 
 `dvc plots` subcommands can produce plots for a specified field or a set of
 them, from the array's objects. For example, `val_loss` is one of the field
@@ -151,8 +148,8 @@ header (first row) are equivalent to field names.
 
 - `<DVC_METRIC_Y>` (optional) - field name of the data for the Y axis. It can be
   defined with the `-y` option of the `dvc plot` subcommands. The default is the
-  last one found in the first row of the metrics file: the last column for
-  CSV/TSV, or the last field for JSON/YAML.
+  last header of the metrics file: the last column for CSV/TSV, or the last
+  field for JSON/YAML.
 
 - `<DVC_METRIC_X_TITLE>` (optional) - field name to display as the X axis label
 

--- a/content/docs/command-reference/plots/index.md
+++ b/content/docs/command-reference/plots/index.md
@@ -65,7 +65,10 @@ epoch, AUC, loss
 ```
 
 In hierarchical file formats (JSON or YAML), an array of consistent objects is
-expected: every object should have the same structure.
+expected: every object should have the same structure. However, if an object has
+extra elements, it won't effect the plot as long as
+[fields specified](#dvc-template-anchors) for X and Y axis are present in all
+the objects.
 
 `dvc plots` subcommands can produce plots for a specified field or a set of
 them, from the array's objects. For example, `val_loss` is one of the field
@@ -148,8 +151,8 @@ header (first row) are equivalent to field names.
 
 - `<DVC_METRIC_Y>` (optional) - field name of the data for the Y axis. It can be
   defined with the `-y` option of the `dvc plot` subcommands. The default is the
-  last one found in the metrics file: the last column for CSV/TSV, or the last
-  field for JSON/YAML.
+  last one found in the first row of the metrics file: the last column for
+  CSV/TSV, or the last field for JSON/YAML.
 
 - `<DVC_METRIC_X_TITLE>` (optional) - field name to display as the X axis label
 

--- a/content/docs/command-reference/plots/index.md
+++ b/content/docs/command-reference/plots/index.md
@@ -66,7 +66,7 @@ epoch, AUC, loss
 
 In hierarchical file formats (JSON or YAML), an array of consistent objects is
 expected: every object should have the same structure. However, if an object has
-extra elements, it won't effect the plot as long as
+extra elements, it won't affect the plot as long as
 [fields specified](#dvc-template-anchors) for X and Y axis are present in all
 the objects.
 


### PR DESCRIPTION
Per https://github.com/iterative/dvc.org/issues/1414#issuecomment-730093511:

> Update the description of <DVC_METRIC_Y> to specify only the first row matters
> Update the text in the plots index description 

Per https://github.com/iterative/dvc.org/issues/1414#issuecomment-731027131
> let's just double check that all other metrics and plots usage blocks correspond to the -h help output of the commands on the latest DVC version (1.9.1) 