### PR TITLE
cli: config: add docs for --show-origin

### DIFF
--- a/content/docs/command-reference/config.md
+++ b/content/docs/command-reference/config.md
@@ -72,8 +72,8 @@ multiple projects and users, respectively:
 
 - `-l`, `--list` - lists all defined config values.
 
-- `--show-origin` - when listing or getting config values, also show the file
-  the config value is saved in.
+- `--show-origin` - when listing or getting config options, also show the
+  location of the config file where each option `value` is found.
 
 - `-h`, `--help` - prints the usage/help message, and exit.
 

--- a/content/docs/command-reference/config.md
+++ b/content/docs/command-reference/config.md
@@ -53,6 +53,9 @@ multiple projects and users, respectively:
 > \* For Linux, the global `dvc/config` may be found in `$XDG_CONFIG_HOME`, and
 > the system-wide one in `$XDG_CONFIG_DIRS[0]`, if those env vars are defined.
 
+> **Note:** The `--show-origin` flag can show you where a given config option
+> value is currently stored.
+
 ## Command options (flags)
 
 - `-u`, `--unset` - remove a specified config option from a config file.

--- a/content/docs/command-reference/config.md
+++ b/content/docs/command-reference/config.md
@@ -6,7 +6,7 @@ Get or set <abbr>project</abbr>-level (or global) DVC configuration options.
 
 ```usage
 usage: dvc config [-h] [--global | --system | --local] [-q | -v] [-u]
-                  [-l] [name] [value]
+                  [-l] [--show-origin] [name] [value]
 
 positional arguments:
   name     Option name in format: section.option or remote.name.option
@@ -71,6 +71,9 @@ multiple projects and users, respectively:
   `sudo dvc config --system ...` (Linux).
 
 - `-l`, `--list` - lists all defined config values.
+
+- `--show-origin` - when listing or getting config values, also show the file
+  the config value is saved in.
 
 - `-h`, `--help` - prints the usage/help message, and exit.
 

--- a/content/docs/command-reference/config.md
+++ b/content/docs/command-reference/config.md
@@ -53,8 +53,8 @@ multiple projects and users, respectively:
 > \* For Linux, the global `dvc/config` may be found in `$XDG_CONFIG_HOME`, and
 > the system-wide one in `$XDG_CONFIG_DIRS[0]`, if those env vars are defined.
 
-> **Note:** The `--show-origin` flag can show you where a given config option
-> value is currently stored.
+> Note that the `--show-origin` flag can show you where a given config option
+> `value` is currently stored.
 
 ## Command options (flags)
 


### PR DESCRIPTION
Support the --show-origin option for config, which, similar to git,
prefixes each config option with the source file it originated from.

Per iterative/dvc#5119
Matches iterative/dvc#5126

> You may disregard these recommendations if you used the **Edit on GitHub** button from dvc.org to improve a doc in place.

❗ Please read the guidelines in the [Contributing to the Documentation](https://dvc.org/doc/user-guide/contributing/docs) list if you make any substantial changes to the documentation or JS engine.

🐛 Please make sure to mention `Fix #issue` (if applicable) in the description of the PR. This causes GitHub to close it automatically when the PR is merged.

Please choose to [allow us](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to edit your branch when creating the PR.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
