### PR TITLE
guide: split DVC Files/Internals (prep for dvc.yaml 2.0 updates)

### DIFF
--- a/content/blog/2019-04-23-dvc-project-ideas-for-google-summer-of-docs-2019.md
+++ b/content/blog/2019-04-23-dvc-project-ideas-for-google-summer-of-docs-2019.md
@@ -81,10 +81,10 @@ there is need for improving the overall structure and making some parts more
 friendly from a new user perspective. We have mostly complete
 [reference documentation](/doc/commands-reference) for each command, although
 some functions are missing good actionable examples. We also have a
-[User Guide](/doc/user-guide/dvc-files-and-directories), however it is not in
-very good shape. We strive for making our documentation clear and comprehensive
-for users of various backgrounds and proficiency levels and this is where we do
-need some fresh perspective.
+[User Guide](/doc/user-guide), however it is not in very good shape. We strive
+for making our documentation clear and comprehensive for users of various
+backgrounds and proficiency levels and this is where we do need some fresh
+perspective.
 
 ### How DVC documentation is built
 

--- a/content/blog/2019-11-05-october-19-dvc-heartbeat.md
+++ b/content/blog/2019-11-05-october-19-dvc-heartbeat.md
@@ -193,9 +193,9 @@ move should be instant. Please, find more information
 ### Q: My repo’s DVC is “busy and locked” and I’m not sure how it got that way and how to remove/diagnose the lock. [Any suggestions?](https://discordapp.com/channels/485586884165107732/485596304961962003/608392956679815168)
 
 DVC uses a lock file to prevent running two commands at the same time. The lock
-[file](https://dvc.org/doc/user-guide/dvc-files-and-directories#dvc-files-and-directories)
-is under the `.dvc` directory. If no DVC commands running and you are still
-getting this error it’s safe to remove this file manually to resolve the issue.
+[file](https://dvc.org/doc/user-guide/dvc-internals) is under the `.dvc`
+directory. If no DVC commands running and you are still getting this error it’s
+safe to remove this file manually to resolve the issue.
 
 ### Q: [I’m trying to understand how does DVC remote add work in case of a local folder and what is the best workflow when data is outside of your project root?](https://discordapp.com/channels/485586884165107732/485596304961962003/611209851757920266)
 
@@ -250,7 +250,7 @@ advanced[ DVC setup with symlinks and hardlinks](https://dvc.org/doc/user-guide/
 (`cache.type` config option is not default). If `dvc gc` behavior is not
 granular enough you can manually find the by its cache from the DVC-file in
 `.dvc/cache` and remote storage. Learn
-[here](https://dvc.org/doc/user-guide/dvc-files-and-directories#structure-of-cache-directory)
+[here](https://dvc.org/doc/user-guide/dvc-internals#structure-of-cache-directory)
 how they are organized.
 
 ### Q: [I’m trying to understand if DVC is an appropriate solution for storing data under GDPR requirements.](https://discordapp.com/channels/485586884165107732/485596304961962003/621057268145848340) That means that permanent deletion of files with sensitive data needs to be fully supported.

--- a/content/blog/2020-04-16-april-20-community-gems.md
+++ b/content/blog/2020-04-16-april-20-community-gems.md
@@ -119,7 +119,7 @@ all. That's okay, easy to fix. Simply remove the `.dvc` file like any other-
 `rm <file>.dvc`. DVC will then stop tracking the file, and the associated target
 file will still be in your local workspace. Note that the file will still be in
 your
-[DVC cache](https://dvc.org/doc/user-guide/dvc-files-and-directories#structure-of-cache-directory)
+[DVC cache](https://dvc.org/doc/user-guide/dvc-internals#structure-of-cache-directory)
 unless you clear it with `dvc gc`.
 
 ### Q: [I'm trying to move a stage file with `dvc move`, but I'm getting an error. What's going on?](https://discordapp.com/channels/485586884165107732/563406153334128681/685125650901630996)

--- a/content/blog/2020-05-26-may-20-community-gems.md
+++ b/content/blog/2020-05-26-may-20-community-gems.md
@@ -57,7 +57,7 @@ find the entry corresponding to `image_1.png`. It'll give the `md5` for
 `image_1.png`. Finally, go back to `.dvc/cache`, identify the file corresponding
 to that `md5`, and delete it. For detailed instructions about `.dir` files,
 where to find them and how they're used,
-[see our docs about the structure of the cache](https://dvc.org/doc/user-guide/dvc-files-and-directories#structure-of-cache-directory).
+[see our docs about the structure of the cache](https://dvc.org/doc/user-guide/dvc-internals#structure-of-cache-directory).
 
 Having said all this... please know that in the future, we plan to support a
 function like `git rm` that will allow easier deletes from DVC!

--- a/content/blog/2020-06-29-june-20-community-gems.md
+++ b/content/blog/2020-06-29-june-20-community-gems.md
@@ -32,7 +32,7 @@ delete the old `.dvc` files. We also have a
 available, although we can't provide long-term support for it.
 
 Learn more about the `dvc.yaml` format in our
-[brand new docs](https://dvc.org/doc/user-guide/dvc-files-and-directories#dvcyaml-file)!
+[brand new docs](https://dvc.org/doc/user-guide/dvc-files#dvcyaml-file)!
 
 https://media.giphy.com/media/JYpTAnhT0EI2Q/giphy.gif
 
@@ -46,7 +46,7 @@ possible- these file names are how DVC deduplicates data (to avoid keeping
 multiple copies of the same file version) and ensures that each unique version
 of a file is immutable. If you manually overwrote those filenames you would risk
 breaking Git version control. You can
-[read more about how DVC uses this file format in our docs](https://dvc.org/doc/user-guide/dvc-files-and-directories#structure-of-cache-directory).
+[read more about how DVC uses this file format in our docs](https://dvc.org/doc/user-guide/dvc-internals#structure-of-cache-directory).
 
 It sounds like you're looking for ways to interact with DVC-tracked objects at a
 high level of abstraction, meaning that you want to interface with the original
@@ -69,7 +69,7 @@ secure and recommended ways to do this:
 If the directory you're adding is logically one unit (for example, it is the
 whole dataset in your project), we recommend using `dvc add` at the directory
 level. Otherwise, add files one-by-one. You can
-[read more about how DVC versions directories in our docs](https://dvc.org/doc/user-guide/dvc-files-and-directories#structure-of-cache-directory).
+[read more about how DVC versions directories in our docs](https://dvc.org/doc/user-guide/dvc-internals#structure-of-cache-directory).
 
 ### Q: [Do you have any examples of using DVC with MinIO?](https://discord.com/channels/485586884165107732/563406153334128681/722780202844815362)
 

--- a/content/blog/2020-11-25-november-20-community-gems.md
+++ b/content/blog/2020-11-25-november-20-community-gems.md
@@ -81,7 +81,7 @@ https://<path-to-your-remote-storage>/ab/cd123
 To better understand how DVC uses
 [content-addressable storage](https://en.wikipedia.org/wiki/Content-addressable_storage)
 in your remote,
-[read up in our docs](https://dvc.org/doc/user-guide/dvc-files-and-directories#structure-of-the-cache-directory).
+[read up in our docs](https://dvc.org/doc/user-guide/dvc-internals#structure-of-the-cache-directory).
 
 ### [Q: Can I have more than one `dvc.yaml` file in my project?](https://discord.com/channels/485586884165107732/563406153334128681/777946398250893333)
 
@@ -110,7 +110,7 @@ Alternatively, you can manually find and delete your files:
 2. Look in your remote storage and remove the file matching the hash.
 3. Look in `.dvc/cache` and remove the file as well. If you'd like to better
    understand how your cache is organized,
-   [we have docs for that](https://dvc.org/doc/user-guide/dvc-files-and-directories#structure-of-the-cache-directory).
+   [we have docs for that](https://dvc.org/doc/user-guide/dvc-internals#structure-of-the-cache-directory).
 
 Your DVC remote storage and cache are simply storage locations, so once your
 file is gone from there it's gone for good.

--- a/content/docs/api-reference/get_url.md
+++ b/content/docs/api-reference/get_url.md
@@ -36,7 +36,7 @@ URL returned depends on the
 `remote` used (see the [Parameters](#parameters) section).
 
 If the target is a directory, the returned URL will end in `.dir`. Refer to
-[Structure of cache directory](/doc/user-guide/dvc-files-and-directories#structure-of-the-cache-directory)
+[Structure of cache directory](/doc/user-guide/dvc-internals#structure-of-the-cache-directory)
 and `dvc add` to learn more about how DVC handles data directories.
 
 ⚠️ This function does not check for the actual existence of the file or

--- a/content/docs/command-reference/add.md
+++ b/content/docs/command-reference/add.md
@@ -38,7 +38,7 @@ other DVC commands), a few actions are taken under the hood:
 1. Calculate the file hash.
 2. Move the file contents to the cache (by default in `.dvc/cache`), using the
    file hash to form the cached file path. (See
-   [Structure of cache directory](/doc/user-guide/dvc-files-and-directories#structure-of-the-cache-directory)
+   [Structure of cache directory](/doc/user-guide/dvc-internals#structure-of-the-cache-directory)
    for more details.)
 3. Attempt to replace the file with a link to the cached data (more details on
    file linking further down).
@@ -82,7 +82,7 @@ entire tree. Instead, the single `.dvc` file references a special JSON file in
 the cache (with `.dir` extension), that in turn points to the added files.
 
 > Refer to
-> [Structure of cache directory](/doc/user-guide/dvc-files-and-directories#structure-of-the-cache-directory)
+> [Structure of cache directory](/doc/user-guide/dvc-internals#structure-of-the-cache-directory)
 > for more info. on `.dir` cache entries.
 
 Note that DVC commands that use tracked data support granular targeting of files

--- a/content/docs/command-reference/cache/dir.md
+++ b/content/docs/command-reference/cache/dir.md
@@ -18,7 +18,7 @@ positional arguments:
 ## Description
 
 Helper to set the `cache.dir` configuration option. (See
-[cache directory](/doc/user-guide/dvc-files-and-directories#structure-of-the-cache-directory).)
+[cache directory](/doc/user-guide/dvc-internals#structure-of-the-cache-directory).)
 Unlike doing so with `dvc config cache`, `dvc cache dir` transform paths
 (`value`) that are provided relative to the current working directory into paths
 **relative to the config file location**. However, if the `value` provided is an

--- a/content/docs/command-reference/cache/index.md
+++ b/content/docs/command-reference/cache/index.md
@@ -19,7 +19,7 @@ The DVC Cache is where your data files, models, etc. (anything you want to
 version with DVC) are actually stored. The data files and directories visible in
 the <abbr>workspace</abbr> are links\* to (or copies of) the ones in cache.
 Learn more about it's
-[structure](/doc/user-guide/dvc-files-and-directories#structure-of-the-cache-directory).
+[structure](/doc/user-guide/dvc-internals#structure-of-the-cache-directory).
 
 > \* Refer to
 > [File link types](/doc/user-guide/large-dataset-optimization#file-link-types-for-the-dvc-cache)

--- a/content/docs/command-reference/config.md
+++ b/content/docs/command-reference/config.md
@@ -130,7 +130,7 @@ remote. See `dvc remote` for more information.
 A DVC project <abbr>cache</abbr> is the hidden storage (by default located in
 the `.dvc/cache` directory) for files that are tracked by DVC, and their
 different versions. (See `dvc cache` and
-[DVC Files and Directories](/doc/user-guide/dvc-files-and-directories#structure-of-the-cache-directory)
+[DVC Files and Directories](/doc/user-guide/dvc-internals#structure-of-the-cache-directory)
 for more details.) This section contains the following options:
 
 - `cache.dir` - set/unset cache directory location. A correct value is either an
@@ -206,9 +206,8 @@ for more details.) This section contains the following options:
 
 ### state
 
-See
-[Internal directories and files](/doc/user-guide/dvc-files-and-directories#internal-directories-and-files)
-to learn more about the state file (database) that is used for optimization.
+See [Internal directories and files](/doc/user-guide/dvc-internals) to learn
+more about the state file (database) that is used for optimization.
 
 - `state.row_limit` - maximum number of entries in the state database, which
   affects the physical size of the state file itself, as well as the performance

--- a/content/docs/command-reference/fetch.md
+++ b/content/docs/command-reference/fetch.md
@@ -173,7 +173,7 @@ $ tree .dvc/cache
 > Refer to `dvc status`.
 
 Note that the
-[`.dvc/cache`](/doc/user-guide/dvc-files-and-directories#structure-of-the-cache-directory)
+[`.dvc/cache`](/doc/user-guide/dvc-internals#structure-of-the-cache-directory)
 directory was created and populated.
 
 All the data needed in this version of the project is now in your cache: File

--- a/content/docs/command-reference/gc.md
+++ b/content/docs/command-reference/gc.md
@@ -29,7 +29,7 @@ of commits (determined by reading the DVC-files in them). See the
 [Options](#options) section for more details.
 
 > Note that `dvc gc` tries to fetch any missing
-> [`.dir` files](/doc/user-guide/dvc-files-and-directories#structure-of-the-cache-directory)
+> [`.dir` files](/doc/user-guide/dvc-internals#structure-of-the-cache-directory)
 > from [remote storage](/doc/command-reference/remote) to the local
 > <abbr>cache</abbr>, in order to determine which files should exist inside
 > cached directories. These files may be missing if the cache directory was

--- a/content/docs/command-reference/init.md
+++ b/content/docs/command-reference/init.md
@@ -16,9 +16,9 @@ repository root (a `.git/` directory should be present).
 
 At DVC initialization, a new `.dvc/` directory is created for internal
 configuration and <abbr>cache</abbr>
-[files and directories](/doc/user-guide/dvc-files-and-directories#internal-directories-and-files),
-that are hidden from the user. This directory is automatically staged with
-`git add`, so it can be easily committed with Git.
+[files and directories](/doc/user-guide/dvc-internals), that are hidden from the
+user. This directory is automatically staged with `git add`, so it can be easily
+committed with Git.
 
 The command [options](#options) can be used to start an alternative workflow for
 advanced scenarios:

--- a/content/docs/command-reference/push.md
+++ b/content/docs/command-reference/push.md
@@ -188,7 +188,7 @@ Finally, we used `dvc status` to double check that all data had been uploaded.
 ## Example: What happens in the cache?
 
 Let's take a detailed look at what happens to the
-[cache directory](/doc/user-guide/dvc-files-and-directories#structure-of-the-cache-directory)
+[cache directory](/doc/user-guide/dvc-internals#structure-of-the-cache-directory)
 as you run an experiment locally and push data to remote storage. To set the
 example consider having created a <abbr>workspace</abbr> that contains some code
 and data, and having set up a remote.
@@ -236,7 +236,7 @@ the cache having more files in it than the remote – which is what the `new`
 state means.
 
 > Refer to
-> [Structure of cache directory](/doc/user-guide/dvc-files-and-directories#structure-of-the-cache-directory)
+> [Structure of cache directory](/doc/user-guide/dvc-internals#structure-of-the-cache-directory)
 > for more info.
 
 Next we can copy the remaining data from the cache to the remote using

--- a/content/docs/command-reference/run.md
+++ b/content/docs/command-reference/run.md
@@ -97,7 +97,7 @@ Relevant notes:
 
 - Entire directories produced by the stage can be tracked as outputs by DVC,
   which generates a single `.dir` entry in the cache (refer to
-  [Structure of cache directory](/doc/user-guide/dvc-files-and-directories#structure-of-the-cache-directory)
+  [Structure of cache directory](/doc/user-guide/dvc-internals#structure-of-the-cache-directory)
   for more info.)
 
 - [external dependencies](/doc/user-guide/external-dependencies) and

--- a/content/docs/sidebar.json
+++ b/content/docs/sidebar.json
@@ -92,7 +92,8 @@
         "slug": "what-is-dvc",
         "source": "what-is-dvc.md"
       },
-      "dvc-files-and-directories",
+      "dvc-files",
+      "dvc-internals",
       {
         "slug": "dvcignore",
         "tutorials": {

--- a/content/docs/start/index.md
+++ b/content/docs/start/index.md
@@ -36,9 +36,8 @@ $ git init
 $ dvc init
 ```
 
-A few
-[directories and files](/doc/user-guide/dvc-files-and-directories#internal-directories-and-files)
-are created that should be added to Git:
+A few [directories and files](/doc/user-guide/dvc-internals) are created that
+should be added to Git:
 
 ```dvc
 $ git status

--- a/content/docs/use-cases/versioning-data-and-model-files/index.md
+++ b/content/docs/use-cases/versioning-data-and-model-files/index.md
@@ -36,10 +36,10 @@ of large files. Now you can use DVC to create
 to learn how DVC looks and feels firsthand.
 
 As you use DVC, unique versions of your data files and directories are
-[cached](/doc/user-guide/dvc-files-and-directories#structure-of-the-cache-directory)
-in a systematic way (preventing file duplication). The working datastore is
-separated from your <abbr>workspace</abbr> to keep the project light, but stays
-connected via file
+[cached](/doc/user-guide/dvc-internals#structure-of-the-cache-directory) in a
+systematic way (preventing file duplication). The working datastore is separated
+from your <abbr>workspace</abbr> to keep the project light, but stays connected
+via file
 [links](/doc/user-guide/large-dataset-optimization#file-link-types-for-the-dvc-cache)
 handled automatically by DVC.
 

--- a/content/docs/user-guide/basic-concepts/dvc-cache.md
+++ b/content/docs/user-guide/basic-concepts/dvc-cache.md
@@ -6,4 +6,4 @@ match: ['DVC cache', cache, caches, cached, 'cache directory']
 The DVC cache is a hidden storage (by default located in the `.dvc/cache`
 directory) for files that are tracked by DVC, and their different versions.
 Learn more about it's
-[structure](/doc/user-guide/dvc-files-and-directories#structure-of-the-cache-directory).
+[structure](/doc/user-guide/dvc-internals#structure-of-the-cache-directory).

--- a/content/docs/user-guide/dvc-files.md
+++ b/content/docs/user-guide/dvc-files.md
@@ -1,11 +1,6 @@
-# DVC Files and Directories
+# DVC File Formats
 
-Once initialized in a <abbr>project</abbr>, DVC populates its installation
-directory (`.dvc/`) with the
-[internal directories and files](#internal-directories-and-files) needed for DVC
-operation.
-
-Additionally, there are a few metafiles that support DVC's features:
+There are a few special files that enable DVC's features:
 
 - Files ending with the `.dvc` extension are placeholders to track data files
   and directories. A <abbr>DVC project</abbr> usually has one `.dvc` file per
@@ -20,8 +15,10 @@ Both `.dvc` files and `dvc.yaml` use human-friendly YAML 1.2 schemas, described
 below. We encourage you to get familiar with them so you may create, generate,
 and edit them on your own.
 
-Both the internal directory and these metafiles should be versioned with Git (in
-Git-enabled <abbr>repositories</abbr>).
+Both the internal directory and these "metafiles" should be versioned with Git
+(in Git-enabled <abbr>repositories</abbr>).
+
+> See also [`.dvcignore`](/doc/user-guide/dvcignore).
 
 ## `.dvc` files
 
@@ -246,117 +243,3 @@ directory tracked by DVC. Specifically: `md5`, `etag`, or `checksum` (same as in
 
 Full <abbr>parameters</abbr> (key and value) are listed separately under
 `params`, grouped by parameters file.
-
-## Internal directories and files
-
-- `.dvc/config`: This is a configuration file. The config file can be edited by
-  hand or with the `dvc config` command.
-
-- `.dvc/config.local`: This is a local configuration file, that will overwrite
-  options in `.dvc/config`. This is useful when you need to specify private
-  options in your config that you don't want to track and share through Git
-  (credentials, private locations, etc). The local config file can be edited by
-  hand or with the command `dvc config --local`.
-
-- `.dvc/cache`: The <abbr>cache</abbr> directory will store your data in a
-  special [structure](#structure-of-the-cache-directory). The data files and
-  directories in the <abbr>workspace</abbr> will only contain links to the data
-  files in the cache. (Refer to
-  [Large Dataset Optimization](/doc/user-guide/large-dataset-optimization). See
-  `dvc config cache` for related configuration options.
-
-  > Note that DVC includes the cache directory in `.gitignore` during
-  > initialization. No data tracked by DVC will ever be pushed to the Git
-  > repository, only [DVC-files](/doc/user-guide/dvc-files-and-directories) that
-  > are needed to download or reproduce them.
-
-- `.dvc/plots`: Directory for
-  [plot templates](/doc/command-reference/plots#plot-templates)
-
-- `.dvc/tmp`: Directory for miscellaneous temporary files
-
-- `.dvc/tmp/index`: Directory for remote index files that are used for
-  optimizing `dvc push`, `dvc pull`, `dvc fetch` and `dvc status -c` operations
-
-- `.dvc/tmp/state`: This file is used for optimization. It is a SQLite database,
-  that contains hash values for files tracked in a DVC project, with respective
-  timestamps and inodes to avoid unnecessary file hash computations. It also
-  contains a list of links (from cache to <abbr>workspace</abbr>) created by DVC
-  and is used to cleanup your workspace when calling `dvc checkout`.
-
-- `.dvc/tmp/state-journal`: Temporary file for SQLite operations
-
-- `.dvc/tmp/state-wal`: Another SQLite temporary file
-
-- `.dvc/tmp/updater`: This file is used store the latest available version of
-  DVC. It's used to remind the user to upgrade when the installed version is
-  behind.
-
-- `.dvc/tmp/updater.lock`: Lock file for `.dvc/tmp/updater`
-
-- `.dvc/tmp/lock`: Lock file for the entire DVC project
-
-- `.dvc/tmp/rwlock`: JSON file that contains read and write locks for specific
-  dependencies and outputs, to allow safely running multiple DVC commands in
-  parallel
-
-## Structure of the cache directory
-
-The DVC cache is a
-[content-addressable storage](https://en.wikipedia.org/wiki/Content-addressable_storage)
-(by default in `.dvc/cache`), which adds a layer of indirection between code and
-data.
-
-There are two ways in which the data is <abbr>cached</abbr>: As a single file
-(eg. `data.csv`), or as a directory.
-
-### Files
-
-DVC calculates the file hash, a 32 characters long string (usually MD5). The
-first two characters are used to name the directory inside the cache, and the
-rest become the file name of the cached file. For example, if a data file has a
-hash value of `ec1d2935f811b77cc49b031b999cbf17`, its path in the cache will be
-`.dvc/cache/ec/1d2935f811b77cc49b031b999cbf17`.
-
-> Note that file hashes are calculated from file contents only. 2 or more files
-> with different names but the same contents can exist in the workspace and be
-> tracked by DVC, but only one copy is stored in the cache. This helps avoid
-> data duplication.
-
-### Directories
-
-Let's imagine [adding](/doc/command-reference/add) a directory with 2 images:
-
-```dvc
-$ tree data/images/
-data/images/
-├── cat.jpeg
-└── index.jpeg
-
-$ dvc add data/images
-```
-
-The directory is cached as a JSON file with `.dir` extension. The files it
-contains are stored in the cache regularly, as explained earlier. It looks like
-this:
-
-```dvc
-.dvc/cache/
-├── 19
-│   └── 6a322c107c2572335158503c64bfba.dir
-├── d4
-│   └── 1d8cd98f00b204e9800998ecf8427e
-└── 20
-    └── 0b40427ee0998e9802335d98f08cd98f
-```
-
-The `.dir` file contains the mapping of files in `data/images` (as a JSON
-array), including their hash values:
-
-```dvc
-$ cat .dvc/cache/19/6a322c107c2572335158503c64bfba.dir
-[{"md5": "dff70c0392d7d386c39a23c64fcc0376", "relpath": "cat.jpeg"},
-{"md5": "29a6c8271c0c8fbf75d3b97aecee589f", "relpath": "index.jpeg"}]
-```
-
-That's how DVC knows that the other two cached files belong in the directory.

--- a/content/docs/user-guide/dvc-files.md
+++ b/content/docs/user-guide/dvc-files.md
@@ -44,12 +44,12 @@ meta:
 
 `.dvc` files can contain the following fields:
 
-- `outs` (always present): List of _output entries_ (details below) that
-  represent files or directories tracked by DVC. Normally there is only one (but
-  several can be added or combined manually).
-- `deps`: List of _dependency entries_ (details below). Only present in import
-  `.dvc` files (see `dvc import` and `dvc import-url`). Normally there is only
-  one (but several can be added manually).
+- `outs` (always present): List of [output entries](#output-entries) (details
+  below) that represent the files or directories tracked with DVC. Typically
+  there is only one (but several can be added or combined manually).
+- `deps`: List of [dependency entries](#dependency-entries) (details below).
+  Only present when `dvc import` or `dvc import-url` are used to generate this
+  `.dvc` file. Typically there is only one (but several can be added manually).
 - `wdir`: Working directory for the `outs` and `deps` paths (relative to the
   `.dvc` file's location). If this field is not present explicitly, it defaults
   to `.` (the `.dvc` file's location).
@@ -59,7 +59,14 @@ meta:
   Any YAML contents is supported. `meta` contents are ignored by DVC, but they
   can be meaningful for user processes that read `.dvc` files.
 
-An _output entry_ (`outs`) can have these fields:
+Note that comments can be added to `.dvc` files using the `# comment` syntax.
+`meta` fields and `#` comments are preserved among executions of the `dvc repro`
+and `dvc commit` commands, but not when a `.dvc` file is overwritten by
+`dvc add`, `dvc move`, `dvc import`, or `dvc import-url`.
+
+### Output entries
+
+`outs` fields can contain these subfields:
 
 - `path`: Path to the file or directory (relative to `wdir` which defaults to
   the file's location)
@@ -81,7 +88,9 @@ An _output entry_ (`outs`) can have these fields:
 - `desc`: User description for this output. This doesn't affect any DVC
   operations.
 
-A _dependency entry_ (`deps`) can have these fields:
+### Dependency entries
+
+`deps` fields can contain these subfields:
 
 - `path`: Path to the dependency (relative to `wdir` which defaults to the
   file's location)
@@ -102,11 +111,6 @@ A _dependency entry_ (`deps`) can have these fields:
     dependency from.
   - `rev_lock`: Git commit hash of the external <abbr>DVC repository</abbr> at
     the time of importing or updating the dependency (with `dvc update`)
-
-Note that comments can be added to `.dvc` files using the `# comment` syntax.
-`meta` fields and `#` comments are preserved among executions of the `dvc repro`
-and `dvc commit` commands, but not when a `.dvc` file is overwritten by
-`dvc add`, `dvc move`, `dvc import`, or `dvc import-url`.
 
 ## `dvc.yaml` file
 
@@ -164,14 +168,13 @@ the following fields:
   file's location). If this field is not present explicitly, it defaults to `.`
   (the file's location).
 - `deps`: List of <abbr>dependency</abbr> file or directory paths of this stage
-  (relative to `wdir` which defaults to the file's location)
+  (relative to `wdir` which defaults to the file's location). See
+  [Dependency entries](#dependency-entries) above for more details.
 - `params`: List of <abbr>parameter</abbr> dependency keys (field names) that
-  are read from a YAML, JSON, TOML, or Python file (`params.yaml` by default).
+  are read from a YAML, JSON, TOML, or Python file (`params.yaml` by default)
 - `outs`: List of <abbr>output</abbr> file or directory paths of this stage
-  (relative to `wdir` which defaults to the file's location), and optionally,
-  whether or not this file or directory is <abbr>cached</abbr> (`true` by
-  default, if not present). See the `--no-commit` option of `dvc run` and
-  `dvc repro`.
+  (relative to `wdir` which defaults to the file's location). See
+  [Output entries](#output-entries) above for more details.
 - `metrics`: List of [metrics files](/doc/command-reference/metrics), and
   optionally, whether or not this metrics file is <abbr>cached</abbr> (`true` by
   default, if not present). See the `--metrics-no-cache` (`-M`) option of

--- a/content/docs/user-guide/dvc-files.md
+++ b/content/docs/user-guide/dvc-files.md
@@ -2,9 +2,9 @@
 
 There are a few special DVC file formats that enable its features:
 
-- Files ending with the `.dvc` extension are placeholders to track data files
-  and directories. A <abbr>DVC project</abbr> usually has one `.dvc` file per
-  large data file or directory being tracked.
+- Files ending with the `.dvc` extension ("dot DVC files") are placeholders to
+  track data files and directories. A <abbr>DVC project</abbr> usually has one
+  `.dvc` file per large data file or directory being tracked.
 - `dvc.yaml` files (or _pipelines files_) specify stages that form the
   pipeline(s) of a project, and how they connect (_dependency graph_ or DAG).
 
@@ -17,6 +17,9 @@ and edit them on your own.
 
 These metafiles should be versioned with Git (in Git-enabled
 <abbr>repositories</abbr>).
+
+See the [internals guide](/doc/user-guide/dvc-internals) for the contents of the
+`.dvc/` directory.
 
 > See also [`.dvcignore`](/doc/user-guide/dvcignore).
 

--- a/content/docs/user-guide/dvc-internals.md
+++ b/content/docs/user-guide/dvc-internals.md
@@ -4,6 +4,8 @@ Once initialized in a <abbr>project</abbr>, DVC populates its installation
 directory (`.dvc/`) with the internal directories and files needed for DVC
 operation.
 
+> See also [DVC Files](/doc/user-guide/dvc-files).
+
 - `.dvc/config`: This is a configuration file. The config file can be edited by
   hand or with the `dvc config` command.
 

--- a/content/docs/user-guide/dvc-internals.md
+++ b/content/docs/user-guide/dvc-internals.md
@@ -1,0 +1,117 @@
+# DVC Internal Directories and Files
+
+Once initialized in a <abbr>project</abbr>, DVC populates its installation
+directory (`.dvc/`) with the internal directories and files needed for DVC
+operation.
+
+- `.dvc/config`: This is a configuration file. The config file can be edited by
+  hand or with the `dvc config` command.
+
+- `.dvc/config.local`: This is a local configuration file, that will overwrite
+  options in `.dvc/config`. This is useful when you need to specify private
+  options in your config that you don't want to track and share through Git
+  (credentials, private locations, etc). The local config file can be edited by
+  hand or with the command `dvc config --local`.
+
+- `.dvc/cache`: The <abbr>cache</abbr> directory will store your data in a
+  special [structure](#structure-of-the-cache-directory). The data files and
+  directories in the <abbr>workspace</abbr> will only contain links to the data
+  files in the cache. (Refer to
+  [Large Dataset Optimization](/doc/user-guide/large-dataset-optimization). See
+  `dvc config cache` for related configuration options.
+
+  > Note that DVC includes the cache directory in `.gitignore` during
+  > initialization. No data tracked by DVC will ever be pushed to the Git
+  > repository, only [DVC-files](/doc/user-guide/dvc-files-and-directories) that
+  > are needed to download or reproduce them.
+
+- `.dvc/plots`: Directory for
+  [plot templates](/doc/command-reference/plots#plot-templates)
+
+- `.dvc/tmp`: Directory for miscellaneous temporary files
+
+- `.dvc/tmp/index`: Directory for remote index files that are used for
+  optimizing `dvc push`, `dvc pull`, `dvc fetch` and `dvc status -c` operations
+
+- `.dvc/tmp/state`: This file is used for optimization. It is a SQLite database,
+  that contains hash values for files tracked in a DVC project, with respective
+  timestamps and inodes to avoid unnecessary file hash computations. It also
+  contains a list of links (from cache to <abbr>workspace</abbr>) created by DVC
+  and is used to cleanup your workspace when calling `dvc checkout`.
+
+- `.dvc/tmp/state-journal`: Temporary file for SQLite operations
+
+- `.dvc/tmp/state-wal`: Another SQLite temporary file
+
+- `.dvc/tmp/updater`: This file is used store the latest available version of
+  DVC. It's used to remind the user to upgrade when the installed version is
+  behind.
+
+- `.dvc/tmp/updater.lock`: Lock file for `.dvc/tmp/updater`
+
+- `.dvc/tmp/lock`: Lock file for the entire DVC project
+
+- `.dvc/tmp/rwlock`: JSON file that contains read and write locks for specific
+  dependencies and outputs, to allow safely running multiple DVC commands in
+  parallel
+
+## Structure of the cache directory
+
+The DVC cache is a
+[content-addressable storage](https://en.wikipedia.org/wiki/Content-addressable_storage)
+(by default in `.dvc/cache`), which adds a layer of indirection between code and
+data.
+
+There are two ways in which the data is <abbr>cached</abbr>: As a single file
+(eg. `data.csv`), or as a directory.
+
+### Files
+
+DVC calculates the file hash, a 32 characters long string (usually MD5). The
+first two characters are used to name the directory inside the cache, and the
+rest become the file name of the cached file. For example, if a data file has a
+hash value of `ec1d2935f811b77cc49b031b999cbf17`, its path in the cache will be
+`.dvc/cache/ec/1d2935f811b77cc49b031b999cbf17`.
+
+> Note that file hashes are calculated from file contents only. 2 or more files
+> with different names but the same contents can exist in the workspace and be
+> tracked by DVC, but only one copy is stored in the cache. This helps avoid
+> data duplication.
+
+### Directories
+
+Let's imagine [adding](/doc/command-reference/add) a directory with 2 images:
+
+```dvc
+$ tree data/images/
+data/images/
+├── cat.jpeg
+└── index.jpeg
+
+$ dvc add data/images
+```
+
+The directory is cached as a JSON file with `.dir` extension. The files it
+contains are stored in the cache regularly, as explained earlier. It looks like
+this:
+
+```dvc
+.dvc/cache/
+├── 19
+│   └── 6a322c107c2572335158503c64bfba.dir
+├── d4
+│   └── 1d8cd98f00b204e9800998ecf8427e
+└── 20
+    └── 0b40427ee0998e9802335d98f08cd98f
+```
+
+The `.dir` file contains the mapping of files in `data/images` (as a JSON
+array), including their hash values:
+
+```dvc
+$ cat .dvc/cache/19/6a322c107c2572335158503c64bfba.dir
+[{"md5": "dff70c0392d7d386c39a23c64fcc0376", "relpath": "cat.jpeg"},
+{"md5": "29a6c8271c0c8fbf75d3b97aecee589f", "relpath": "index.jpeg"}]
+```
+
+That's how DVC knows that the other two cached files belong in the directory.

--- a/content/docs/user-guide/dvcignore.md
+++ b/content/docs/user-guide/dvcignore.md
@@ -96,7 +96,7 @@ stored. Checking the hash value of the data files manually, we can see that
 `data2` was cached. This means that `dvc add` did ignore `data1`.
 
 > Refer to
-> [Structure of cache directory](/doc/user-guide/dvc-files-and-directories#structure-of-the-cache-directory)
+> [Structure of cache directory](/doc/user-guide/dvc-internals#structure-of-the-cache-directory)
 > for more info.
 
 ## Example: Ignore file state changes

--- a/content/linked-terms.js
+++ b/content/linked-terms.js
@@ -1,14 +1,14 @@
 module.exports = [
   {
     matches: '.dvc',
-    url: '/doc/user-guide/dvc-files-and-directories#dvc-files'
+    url: '/doc/user-guide/dvc-files#dvc-files'
   },
   {
     matches: 'dvc.yaml',
-    url: '/doc/user-guide/dvc-files-and-directories#dvcyaml-file'
+    url: '/doc/user-guide/dvc-files#dvcyaml-file'
   },
   {
     matches: 'dvc.lock',
-    url: '/doc/user-guide/dvc-files-and-directories#dvclock-file'
+    url: '/doc/user-guide/dvc-files#dvclock-file'
   }
 ]

--- a/redirects-list.json
+++ b/redirects-list.json
@@ -29,6 +29,7 @@
 
   "^/doc/use-cases/data-and-model-files-versioning/?$                                     /doc/use-cases/versioning-data-and-model-files",
   "^/doc/user-guide/dvc-file-format$                                                      /doc/user-guide/dvc-files-and-directories",
+  "^/doc/user-guide/dvc-files-and-directories$                                            /doc/user-guide/dvc-files",
   "^/doc/user-guide/updating-tracked-files$                                               /doc/user-guide/how-to/update-tracked-data",
   "^/doc/user-guide/how-to/update-tracked-files$                                          /doc/user-guide/how-to/update-tracked-data",
   "^/doc/user-guide/merge-conflicts$                                                      /doc/user-guide/how-to/merge-conflicts",


### PR DESCRIPTION
Also includes

- Separate **Outputs** and **Dependencies** sections in **DVC Files** guide

Next up:

- Review "metafile" terminology.
- Introduce basics from https://github.com/iterative/dvc/wiki/Parametrization to the **DVC Files** guide
- Further split **DVC Files** into separate pages?