### PR TITLE
feat: sidebar dropdown toggle with subpages #1427

### DIFF
--- a/src/components/Documentation/Layout/SidebarMenu/index.tsx
+++ b/src/components/Documentation/Layout/SidebarMenu/index.tsx
@@ -51,10 +51,14 @@ const SidebarMenuItem: React.FC<ISidebarMenuItemProps> = ({
   type
 }) => {
   const isActive = activePaths && includes(activePaths, path)
+  const [dropDownToggle, setDropDownToggle] = useState(isActive)
   const isRootParent =
     activePaths && activePaths.length > 1 && activePaths[0] === path
   const isLeafItem = children === undefined || children.length === 0
-  const currentLevelOnClick = (): void => onClick(isLeafItem)
+  const currentLevelOnClick = (): void => {
+    setDropDownToggle(!dropDownToggle)
+    onClick(isLeafItem)
+  }
 
   // Fetch a special icon if one is defined
   const IconComponent = icon && ICONS[icon]
@@ -64,7 +68,7 @@ const SidebarMenuItem: React.FC<ISidebarMenuItemProps> = ({
 
   const className = cn(
     styles.sectionLink,
-    isActive && styles.active,
+    dropDownToggle && styles.active,
     isRootParent && 'docSearch-lvl0',
     'link-with-focus',
     style ? styles[style] : styles.sidebarDefault,
@@ -101,8 +105,8 @@ const SidebarMenuItem: React.FC<ISidebarMenuItemProps> = ({
     <>
       {parentElement}
       {children && (
-        <span hidden={!isActive}>
-          <Collapse isOpened={!!isActive}>
+        <span hidden={!dropDownToggle}>
+          <Collapse isOpened={!!dropDownToggle}>
             {children.map(item => (
               <SidebarMenuItem
                 key={item.path}

--- a/src/components/Documentation/Layout/SidebarMenu/index.tsx
+++ b/src/components/Documentation/Layout/SidebarMenu/index.tsx
@@ -50,8 +50,6 @@ const SidebarMenuItem: React.FC<ISidebarMenuItemProps> = ({
   icon,
   type
 }) => {
-  const isActive = activePaths && includes(activePaths, path)
-
   const [isExpanded, setIsExpanded] = useState(
     activePaths && includes(activePaths, path)
   )
@@ -68,7 +66,7 @@ const SidebarMenuItem: React.FC<ISidebarMenuItemProps> = ({
   const currentLevelOnClick = (
     event: SyntheticEvent<HTMLAnchorElement>
   ): void => {
-    if (isActive) {
+    if (event.currentTarget.getAttribute('aria-current') === 'page') {
       event.preventDefault()
       setIsExpanded(!isExpanded)
     }
@@ -112,7 +110,11 @@ const SidebarMenuItem: React.FC<ISidebarMenuItemProps> = ({
         onClick={currentLevelOnClick}
         target="_blank"
       >
-        {iconElement}
+        {iconElement ? (
+          iconElement
+        ) : (
+          <span className={bulletIconClassName}></span>
+        )}
         {label} <ExternalLinkIcon />
       </Link>
     ) : (

--- a/src/components/Documentation/Layout/SidebarMenu/index.tsx
+++ b/src/components/Documentation/Layout/SidebarMenu/index.tsx
@@ -50,12 +50,14 @@ const SidebarMenuItem: React.FC<ISidebarMenuItemProps> = ({
   icon,
   type
 }) => {
-  const [isActive, setIsActive] = useState(
+  const isActive = activePaths && includes(activePaths, path)
+
+  const [isExpanded, setIsExpanded] = useState(
     activePaths && includes(activePaths, path)
   )
 
   useEffect(() => {
-    setIsActive(activePaths && includes(activePaths, path))
+    setIsExpanded(activePaths && includes(activePaths, path))
   }, [activePaths])
 
   const isRootParent =
@@ -64,16 +66,16 @@ const SidebarMenuItem: React.FC<ISidebarMenuItemProps> = ({
   const currentLevelOnClick = (
     event: SyntheticEvent<HTMLAnchorElement>
   ): void => {
-    if (event.currentTarget.getAttribute('aria-current') === 'page') {
+    if (isActive) {
       event.preventDefault()
-      setIsActive(!isActive)
+      setIsExpanded(!isExpanded)
     }
     onClick(isLeafItem)
   }
 
   const bulletIconClick = (event: SyntheticEvent<HTMLSpanElement>): void => {
     event.preventDefault()
-    setIsActive(!isActive)
+    setIsExpanded(!isExpanded)
   }
 
   // Fetch a special icon if one is defined
@@ -84,7 +86,7 @@ const SidebarMenuItem: React.FC<ISidebarMenuItemProps> = ({
 
   const className = cn(
     styles.sectionLink,
-    isActive && styles.active,
+    isExpanded && styles.active,
     isRootParent && 'docSearch-lvl0',
     'link-with-focus',
     style ? styles[style] : styles.sidebarDefault,
@@ -129,8 +131,8 @@ const SidebarMenuItem: React.FC<ISidebarMenuItemProps> = ({
     <>
       {parentElement}
       {children && (
-        <span hidden={!isActive}>
-          <Collapse isOpened={!!isActive}>
+        <span hidden={!isExpanded}>
+          <Collapse isOpened={!!isExpanded}>
             {children.map(item => (
               <SidebarMenuItem
                 key={item.path}

--- a/src/components/Documentation/Layout/SidebarMenu/index.tsx
+++ b/src/components/Documentation/Layout/SidebarMenu/index.tsx
@@ -71,6 +71,11 @@ const SidebarMenuItem: React.FC<ISidebarMenuItemProps> = ({
     onClick(isLeafItem)
   }
 
+  const bulletIconClick = (event: SyntheticEvent<HTMLSpanElement>): void => {
+    event.preventDefault()
+    setIsActive(false)
+  }
+
   // Fetch a special icon if one is defined
   const IconComponent = icon && ICONS[icon]
   const iconElement = IconComponent ? (
@@ -107,6 +112,13 @@ const SidebarMenuItem: React.FC<ISidebarMenuItemProps> = ({
         className={className}
         onClick={currentLevelOnClick}
       >
+        <span
+          className={styles.absBeforeIconOverlay}
+          onClick={bulletIconClick}
+          onKeyDown={bulletIconClick}
+          role="button"
+          tabIndex={-1}
+        ></span>
         {iconElement}
         {label}
       </Link>

--- a/src/components/Documentation/Layout/SidebarMenu/index.tsx
+++ b/src/components/Documentation/Layout/SidebarMenu/index.tsx
@@ -62,7 +62,9 @@ const SidebarMenuItem: React.FC<ISidebarMenuItemProps> = ({
 
   const isRootParent =
     activePaths && activePaths.length > 1 && activePaths[0] === path
+
   const isLeafItem = children === undefined || children.length === 0
+
   const currentLevelOnClick = (
     event: SyntheticEvent<HTMLAnchorElement>
   ): void => {
@@ -95,6 +97,12 @@ const SidebarMenuItem: React.FC<ISidebarMenuItemProps> = ({
     icon ? undefined : styles.withDefaultBullet
   )
 
+  const bulletIconClassName = cn(
+    styles.sidebarDefaultBullet,
+    isExpanded && styles.active,
+    isLeafItem && styles.sidebarLeafBullet
+  )
+
   const parentElement =
     type === 'external' ? (
       <Link
@@ -114,15 +122,17 @@ const SidebarMenuItem: React.FC<ISidebarMenuItemProps> = ({
         className={className}
         onClick={currentLevelOnClick}
       >
-        <span
-          className={styles.absBeforeIconOverlay}
-          onClick={bulletIconClick}
-          onKeyDown={bulletIconClick}
-          data-path={path}
-          role="button"
-          tabIndex={0}
-        ></span>
-        {iconElement}
+        {iconElement ? (
+          iconElement
+        ) : (
+          <span
+            className={bulletIconClassName}
+            onClick={bulletIconClick}
+            onKeyDown={bulletIconClick}
+            role="button"
+            tabIndex={0}
+          ></span>
+        )}
         {label}
       </Link>
     )

--- a/src/components/Documentation/Layout/SidebarMenu/index.tsx
+++ b/src/components/Documentation/Layout/SidebarMenu/index.tsx
@@ -72,8 +72,12 @@ const SidebarMenuItem: React.FC<ISidebarMenuItemProps> = ({
   }
 
   const bulletIconClick = (event: SyntheticEvent<HTMLSpanElement>): void => {
-    event.preventDefault()
-    setIsActive(false)
+    if (isActive) {
+      event.preventDefault()
+      setIsActive(false)
+    } else {
+      setIsActive(true)
+    }
   }
 
   // Fetch a special icon if one is defined
@@ -116,8 +120,9 @@ const SidebarMenuItem: React.FC<ISidebarMenuItemProps> = ({
           className={styles.absBeforeIconOverlay}
           onClick={bulletIconClick}
           onKeyDown={bulletIconClick}
+          data-path={path}
           role="button"
-          tabIndex={-1}
+          tabIndex={0}
         ></span>
         {iconElement}
         {label}

--- a/src/components/Documentation/Layout/SidebarMenu/index.tsx
+++ b/src/components/Documentation/Layout/SidebarMenu/index.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from 'react'
+import React, { useEffect, useRef, useState, SyntheticEvent } from 'react'
 import { useLocation } from '@reach/router'
 import cn from 'classnames'
 import { Collapse } from 'react-collapse'
@@ -50,14 +50,22 @@ const SidebarMenuItem: React.FC<ISidebarMenuItemProps> = ({
   icon,
   type
 }) => {
-  const isActive = activePaths && includes(activePaths, path)
-  const [dropDownToggle, setDropDownToggle] = useState(isActive)
+  const [isActive, setIsActive] = useState(
+    activePaths && includes(activePaths, path)
+  )
+
+  useEffect(() => {
+    setIsActive(activePaths && includes(activePaths, path))
+  }, [activePaths])
+
   const isRootParent =
     activePaths && activePaths.length > 1 && activePaths[0] === path
   const isLeafItem = children === undefined || children.length === 0
-  const currentLevelOnClick = (): void => {
-    setDropDownToggle(!dropDownToggle)
-    onClick(isLeafItem)
+  const currentLevelOnClick = (): void => onClick(isLeafItem)
+
+  const bulletIconClick = (event: SyntheticEvent<HTMLSpanElement>): void => {
+    event.preventDefault()
+    setIsActive(false)
   }
 
   // Fetch a special icon if one is defined
@@ -68,7 +76,7 @@ const SidebarMenuItem: React.FC<ISidebarMenuItemProps> = ({
 
   const className = cn(
     styles.sectionLink,
-    dropDownToggle && styles.active,
+    isActive && styles.active,
     isRootParent && 'docSearch-lvl0',
     'link-with-focus',
     style ? styles[style] : styles.sidebarDefault,
@@ -96,6 +104,13 @@ const SidebarMenuItem: React.FC<ISidebarMenuItemProps> = ({
         className={className}
         onClick={currentLevelOnClick}
       >
+        <span
+          className={styles.absBeforeIconOverlay}
+          onClick={bulletIconClick}
+          onKeyDown={bulletIconClick}
+          role="button"
+          tabIndex={0}
+        ></span>
         {iconElement}
         {label}
       </Link>
@@ -105,8 +120,8 @@ const SidebarMenuItem: React.FC<ISidebarMenuItemProps> = ({
     <>
       {parentElement}
       {children && (
-        <span hidden={!dropDownToggle}>
-          <Collapse isOpened={!!dropDownToggle}>
+        <span hidden={!isActive}>
+          <Collapse isOpened={!!isActive}>
             {children.map(item => (
               <SidebarMenuItem
                 key={item.path}

--- a/src/components/Documentation/Layout/SidebarMenu/index.tsx
+++ b/src/components/Documentation/Layout/SidebarMenu/index.tsx
@@ -61,11 +61,14 @@ const SidebarMenuItem: React.FC<ISidebarMenuItemProps> = ({
   const isRootParent =
     activePaths && activePaths.length > 1 && activePaths[0] === path
   const isLeafItem = children === undefined || children.length === 0
-  const currentLevelOnClick = (): void => onClick(isLeafItem)
-
-  const bulletIconClick = (event: SyntheticEvent<HTMLSpanElement>): void => {
-    event.preventDefault()
-    setIsActive(false)
+  const currentLevelOnClick = (
+    event: SyntheticEvent<HTMLAnchorElement>
+  ): void => {
+    if (event.currentTarget.getAttribute('aria-current') === 'page') {
+      event.preventDefault()
+      setIsActive(!isActive)
+    }
+    onClick(isLeafItem)
   }
 
   // Fetch a special icon if one is defined
@@ -104,13 +107,6 @@ const SidebarMenuItem: React.FC<ISidebarMenuItemProps> = ({
         className={className}
         onClick={currentLevelOnClick}
       >
-        <span
-          className={styles.absBeforeIconOverlay}
-          onClick={bulletIconClick}
-          onKeyDown={bulletIconClick}
-          role="button"
-          tabIndex={0}
-        ></span>
         {iconElement}
         {label}
       </Link>

--- a/src/components/Documentation/Layout/SidebarMenu/index.tsx
+++ b/src/components/Documentation/Layout/SidebarMenu/index.tsx
@@ -72,12 +72,8 @@ const SidebarMenuItem: React.FC<ISidebarMenuItemProps> = ({
   }
 
   const bulletIconClick = (event: SyntheticEvent<HTMLSpanElement>): void => {
-    if (isActive) {
-      event.preventDefault()
-      setIsActive(false)
-    } else {
-      setIsActive(true)
-    }
+    event.preventDefault()
+    setIsActive(!isActive)
   }
 
   // Fetch a special icon if one is defined

--- a/src/components/Documentation/Layout/SidebarMenu/styles.module.css
+++ b/src/components/Documentation/Layout/SidebarMenu/styles.module.css
@@ -63,27 +63,10 @@
 
   &.active {
     color: var(--color-gray-hover);
-  }
-}
 
-.withDefaultBullet {
-  &::before {
-    content: '';
-    position: absolute;
-    left: 0;
-    top: 9px;
-    display: block;
-    height: 8px;
-    width: 8px;
-    background: url('/img/triangle_dark.svg') no-repeat center center;
-  }
-
-  &.active::before {
-    animation: rotateIcon 0.5s forwards;
-  }
-
-  &.leafItem::before {
-    background: url('/img/default_bullet_dark.svg') no-repeat center center;
+    .sidebarDefaultBullet {
+      animation: rotateIcon 0.5s forwards;
+    }
   }
 }
 
@@ -107,13 +90,19 @@
   left: -0.08rem;
 }
 
-.absBeforeIconOverlay {
+.sidebarDefaultBullet {
   content: '';
   position: absolute;
-  top: 9px;
   left: 0;
-  width: 10px;
-  height: 10px;
+  top: 9px;
+  display: block;
+  height: 8px;
+  width: 8px;
+  background: url('/img/triangle_dark.svg') no-repeat center center;
+
+  &.sidebarLeafBullet {
+    background: url('/img/default_bullet_dark.svg') no-repeat center center;
+  }
 
   &:focus {
     outline: none;

--- a/src/components/Documentation/Layout/SidebarMenu/styles.module.css
+++ b/src/components/Documentation/Layout/SidebarMenu/styles.module.css
@@ -80,6 +80,10 @@
 
   &.active::before {
     animation: rotateIcon 0.5s forwards;
+    height: 10px;
+    width: 10px;
+    background-size: 100% auto;
+    transition: 0.1s ease-in-out;
   }
 
   &.leafItem::before {
@@ -105,4 +109,13 @@
   height: 0.65rem;
   top: 0.5rem;
   left: -0.08rem;
+}
+
+.absBeforeIconOverlay {
+  content: '';
+  position: absolute;
+  top: 9px;
+  left: 0;
+  width: 10px;
+  height: 10px;
 }

--- a/src/components/Documentation/Layout/SidebarMenu/styles.module.css
+++ b/src/components/Documentation/Layout/SidebarMenu/styles.module.css
@@ -20,7 +20,7 @@
   }
 
   :global(.ReactCollapse--collapse) {
-    transition: height 250ms;
+    transition: height 500ms;
     padding-left: 10px;
   }
 }
@@ -99,12 +99,18 @@
   height: 8px;
   width: 8px;
   background: url('/img/triangle_dark.svg') no-repeat center center;
-
-  &.sidebarLeafBullet {
-    background: url('/img/default_bullet_dark.svg') no-repeat center center;
-  }
+  transition: 0.5s all;
 
   &:focus {
     outline: none;
+  }
+
+  &:hover {
+    transform: scale(1.5);
+  }
+
+  &.sidebarLeafBullet {
+    background: url('/img/default_bullet_dark.svg') no-repeat center center;
+    transform: unset;
   }
 }

--- a/src/components/Documentation/Layout/SidebarMenu/styles.module.css
+++ b/src/components/Documentation/Layout/SidebarMenu/styles.module.css
@@ -80,10 +80,6 @@
 
   &.active::before {
     animation: rotateIcon 0.5s forwards;
-    height: 10px;
-    width: 10px;
-    background-size: 100% auto;
-    transition: 0.1s ease-in-out;
   }
 
   &.leafItem::before {
@@ -109,13 +105,4 @@
   height: 0.65rem;
   top: 0.5rem;
   left: -0.08rem;
-}
-
-.absBeforeIconOverlay {
-  content: '';
-  position: absolute;
-  top: 9px;
-  left: 0;
-  width: 10px;
-  height: 10px;
 }

--- a/src/components/Documentation/Layout/SidebarMenu/styles.module.css
+++ b/src/components/Documentation/Layout/SidebarMenu/styles.module.css
@@ -106,3 +106,16 @@
   top: 0.5rem;
   left: -0.08rem;
 }
+
+.absBeforeIconOverlay {
+  content: '';
+  position: absolute;
+  top: 9px;
+  left: 0;
+  width: 10px;
+  height: 10px;
+
+  &:focus {
+    outline: none;
+  }
+}


### PR DESCRIPTION
I've fixed the drop down issue with sub-pages in documentation (closes #1427).

This changes improves the user experience when user tries to navigate quickly. Currently, the user has to scroll all the way down. 

I have used React state to handle the toggle based on the `activePaths`. The demo is attached below.

![dvc-org-drop-down-toggle-demo](https://user-images.githubusercontent.com/18111862/103669864-f8a72f80-4fa0-11eb-9e1d-e12c6cc907c8.gif)