### PR TITLE
dvc: still pending 1.x updates (1)

### DIFF
--- a/content/docs/command-reference/commit.md
+++ b/content/docs/command-reference/commit.md
@@ -122,7 +122,7 @@ $ pip install -r src/requirements.txt
 Download the precomputed data using:
 
 ```dvc
-$ dvc pull --all-branches --all-tags
+$ dvc pull -aT
 ```
 
 </details>

--- a/content/docs/command-reference/config.md
+++ b/content/docs/command-reference/config.md
@@ -280,7 +280,8 @@ or to a relative path (resolved from `./.dvc/`):
 
 ```dvc
 $ dvc config cache.dir ../../mycache
-$ dvc pull -q
+$ dvc pull
+
 $ ls ../mycache
 2f/
 ```

--- a/content/docs/command-reference/import.md
+++ b/content/docs/command-reference/import.md
@@ -146,6 +146,7 @@ but it also creates an import stage (`.dvc` file) with a link to the data source
 
 ```yaml
 md5: 7de90e7de7b432ad972095bc1f2ec0f8
+frozen: true
 wdir: .
 deps:
   - path: data/data.xml

--- a/content/docs/command-reference/install.md
+++ b/content/docs/command-reference/install.md
@@ -160,7 +160,7 @@ $ pip install -r src/requirements.txt
 Download the precomputed data using:
 
 ```dvc
-$ dvc pull --all-branches --all-tags
+$ dvc pull -aT
 ```
 
 </details>

--- a/content/docs/command-reference/plots/modify.md
+++ b/content/docs/command-reference/plots/modify.md
@@ -101,9 +101,10 @@ Note, a new field _y_ was added to `dvc.yaml` file for the plot. Please do not
 forget to commit the change in Git if the modification needs to be preserved.
 
 ```yaml
-- logs.csv:
-    cache: false
-    y: accuracy
+plots:
+  - logs.csv:
+      cache: false
+      y: accuracy
 ```
 
 Changing the plot `title` and `x-label`:

--- a/content/docs/command-reference/pull.md
+++ b/content/docs/command-reference/pull.md
@@ -208,7 +208,8 @@ to retrieve part of the data?
 ```dvc
 $ dvc pull --with-deps featurize
 
-... Use the partial update, then pull the remaining data:
+# Use the partial update...
+# Then pull the remaining data:
 
 $ dvc pull
 Everything is up to date.

--- a/content/docs/command-reference/push.md
+++ b/content/docs/command-reference/push.md
@@ -134,7 +134,7 @@ the default remote:
 $ dvc push
 ```
 
-Push <abbr>outputs</abbr> of a specific `.dvc` file only:
+Push files related to a specific `.dvc` file only:
 
 ```dvc
 $ dvc push data.zip.dvc
@@ -165,11 +165,10 @@ want to upload part of the data?
 ```dvc
 $ dvc push --with-deps test-posts
 
-... Do some work based on the partial update
+# Do some work based on the partial update...
+# Then push the rest of the data:
 
 $ dvc push --with-deps matrix-train
-
-... Push the rest of the data
 
 $ dvc status --cloud
 Cache and remote 'r1' are in sync.

--- a/content/docs/start/data-pipelines.md
+++ b/content/docs/start/data-pipelines.md
@@ -130,8 +130,8 @@ stages:
   prepare:
     cmd: python src/prepare.py data/data.xml
     deps:
-      - data/data.xml
       - src/prepare.py
+      - data/data.xml
     params:
       - prepare.seed
       - prepare.split

--- a/content/docs/use-cases/sharing-data-and-model-files.md
+++ b/content/docs/use-cases/sharing-data-and-model-files.md
@@ -67,7 +67,7 @@ with the `dvc push` command:
 $ dvc push
 ```
 
-Code and [DVC-files](/doc/user-guide/dvc-files-and-directories) can be safely
+Code and [DVC files](/doc/user-guide/dvc-files-and-directories) can be safely
 committed and pushed with Git.
 
 ## Download code


### PR DESCRIPTION
Per #2026

- [x] Review all .dvc file examples throughout docs (YAML code blocks)
- [x] ^ Also push/pull examples
- [x] Review DVC cache definitions (found in `dvc cache`, DVC Cache tooltip, Internal Files guide, `dvc config` cache section, and Large Dataset Optimization guide, some in `add` and possibly other refs...) - rel. #550.
- [ ] plots refs (closes #1414)
- [ ] other refs? (closes #1824)

---

- [ ] Port this to `master` (2.0) after merge.