### PR TITLE
Update repro.md

### DIFF
--- a/content/docs/command-reference/repro.md
+++ b/content/docs/command-reference/repro.md
@@ -106,7 +106,7 @@ up-to-date and only execute the final stage.
   depending on the flags used (more details in each option). Examples:
 
   - `dvc repro linear/dvc.yaml`: Specific `dvc.yaml` file to reproduce
-  - `dvc repro -R pipelines/`: Directory path to explore recursively for for
+  - `dvc repro -R pipelines/`: Directory path to explore recursively for
     `dvc.yaml` files
   - `dvc repro train-model`: Specific stage in `./dvc.yaml`
   - `dvc repro modeling/dvc.yaml:prepare`: Stage in a specific `dvc.yaml` file


### PR DESCRIPTION
Fixed "for for" -> "for"

Aside, i've noticed that all instances of `dvc.yaml` (and not just in repro.md) link to https://dvc.org/doc/user-guide/dvc-files/dvc.yaml which returns 404, file not found.

Instead I believe these requests should be redirected to https://dvc.org/doc/user-guide/dvc-files/dvc-yaml