### PR TITLE
hotfix: fix automatic dvc.yaml/lock links

### DIFF
--- a/content/linked-terms.js
+++ b/content/linked-terms.js
@@ -5,10 +5,10 @@ module.exports = [
   },
   {
     matches: 'dvc.yaml',
-    url: '/doc/user-guide/dvc-files/dvc.yaml'
+    url: '/doc/user-guide/dvc-files/dvc-yaml'
   },
   {
     matches: 'dvc.lock',
-    url: '/doc/user-guide/dvc-files/dvc.yaml#dvclock-file'
+    url: '/doc/user-guide/dvc-files/dvc-yaml#dvclock-file'
   }
 ]


### PR DESCRIPTION
I just realized that all `dvc.yaml` and `dvc.lock` auto-links are broken 😱 

E.g. in https://dvc.org/doc/user-guide/dvc-files:

![image](https://user-images.githubusercontent.com/1477535/104795593-2c3e4280-5775-11eb-92c4-fa05f6a684db.png)
![image](https://user-images.githubusercontent.com/1477535/104795600-3bbd8b80-5775-11eb-9030-66245e94b698.png)
> Should be https://dvc.org/doc/user-guide/dvc-files/dvc-yaml