### PR TITLE
guide: update links from old "DVC Files"

### DIFF
--- a/content/docs/api-reference/get_url.md
+++ b/content/docs/api-reference/get_url.md
@@ -36,7 +36,7 @@ URL returned depends on the
 `remote` used (see the [Parameters](#parameters) section).
 
 If the target is a directory, the returned URL will end in `.dir`. Refer to
-[Structure of cache directory](/doc/user-guide/dvc-internals#structure-of-the-cache-directory)
+[Structure of cache directory](/doc/user-guide/project-structure/internal-files#structure-of-the-cache-directory)
 and `dvc add` to learn more about how DVC handles data directories.
 
 ⚠️ This function does not check for the actual existence of the file or

--- a/content/docs/command-reference/add.md
+++ b/content/docs/command-reference/add.md
@@ -38,7 +38,7 @@ other DVC commands), a few actions are taken under the hood:
 1. Calculate the file hash.
 2. Move the file contents to the cache (by default in `.dvc/cache`), using the
    file hash to form the cached file path. (See
-   [Structure of cache directory](/doc/user-guide/dvc-internals#structure-of-the-cache-directory)
+   [Structure of cache directory](/doc/user-guide/project-structure/internal-files#structure-of-the-cache-directory)
    for more details.)
 3. Attempt to replace the file with a link to the cached data (more details on
    file linking further down).
@@ -82,7 +82,7 @@ the single `.dvc` file references a special JSON file in the cache (with `.dir`
 extension), that in turn points to the added files.
 
 > Refer to
-> [Structure of cache directory](/doc/user-guide/dvc-internals#structure-of-the-cache-directory)
+> [Structure of cache directory](/doc/user-guide/project-structure/internal-files#structure-of-the-cache-directory)
 > for more info. on `.dir` cache entries.
 
 Note that DVC commands that use tracked data support granular targeting of files

--- a/content/docs/command-reference/cache/dir.md
+++ b/content/docs/command-reference/cache/dir.md
@@ -18,7 +18,7 @@ positional arguments:
 ## Description
 
 Helper to set the `cache.dir` configuration option. (See
-[cache directory](/doc/user-guide/dvc-internals#structure-of-the-cache-directory).)
+[cache directory](/doc/user-guide/project-structure/internal-files#structure-of-the-cache-directory).)
 Unlike doing so with `dvc config cache`, `dvc cache dir` transform paths
 (`value`) that are provided relative to the current working directory into paths
 **relative to the config file location**. However, if the `value` provided is an

--- a/content/docs/command-reference/checkout.md
+++ b/content/docs/command-reference/checkout.md
@@ -18,9 +18,10 @@ positional arguments:
 ## Description
 
 This command is usually needed after `git checkout`, `git clone`, or any other
-operation that changes the current [DVC files](/doc/user-guide/dvc-files). It
-restores the corresponding versions of the DVC-tracked files and directories
-from the <abbr>cache</abbr> to the workspace.
+operation that changes the current
+[DVC files](/doc/user-guide/project-structure). It restores the corresponding
+versions of the DVC-tracked files and directories from the <abbr>cache</abbr> to
+the workspace.
 
 The `targets` given to this command (if any) limit what to checkout. It accepts
 paths to tracked files or directories (including paths inside tracked
@@ -85,9 +86,10 @@ the pipeline must be reproduced (using `dvc repro`) to regenerate its outputs.
   files referenced in later stages than the `targets`.
 
 - `-f`, `--force` - does not prompt when removing workspace files. Changing the
-  current set of [DVC files](/doc/user-guide/dvc-files) with `git checkout` can
-  result in the need for DVC to remove files that don't match those references
-  or are missing from cache. (They are not "committed", in DVC terms.)
+  current set of [DVC files](/doc/user-guide/project-structure) with
+  `git checkout` can result in the need for DVC to remove files that don't match
+  those references or are missing from cache. (They are not "committed", in DVC
+  terms.)
 
 - `--relink` - ensures the file linking strategy (`reflink`, `hardlink`,
   `symlink`, or `copy`) for all data in the workspace is consistent with the

--- a/content/docs/command-reference/checkout.md
+++ b/content/docs/command-reference/checkout.md
@@ -18,10 +18,9 @@ positional arguments:
 ## Description
 
 This command is usually needed after `git checkout`, `git clone`, or any other
-operation that changes the current
-[DVC files](/doc/user-guide/project-structure). It restores the corresponding
-versions of the DVC-tracked files and directories from the <abbr>cache</abbr> to
-the workspace.
+operation that changes the current <abbr>DVC files</abbr>. It restores the
+corresponding versions of the DVC-tracked data files and directories from the
+<abbr>cache</abbr> to the workspace.
 
 The `targets` given to this command (if any) limit what to checkout. It accepts
 paths to tracked files or directories (including paths inside tracked
@@ -86,10 +85,9 @@ the pipeline must be reproduced (using `dvc repro`) to regenerate its outputs.
   files referenced in later stages than the `targets`.
 
 - `-f`, `--force` - does not prompt when removing workspace files. Changing the
-  current [set of DVC files](/doc/user-guide/project-structure) with
-  `git checkout` can result in the need for DVC to remove files that don't match
-  those references or are missing from cache. (They are not "committed", in DVC
-  terms.)
+  current set of DVC files with `git checkout` can result in the need for DVC to
+  remove files that don't match those references or are missing from cache.
+  (They are not "committed", in DVC terms.)
 
 - `--relink` - ensures the file linking strategy (`reflink`, `hardlink`,
   `symlink`, or `copy`) for all data in the workspace is consistent with the

--- a/content/docs/command-reference/checkout.md
+++ b/content/docs/command-reference/checkout.md
@@ -86,7 +86,7 @@ the pipeline must be reproduced (using `dvc repro`) to regenerate its outputs.
   files referenced in later stages than the `targets`.
 
 - `-f`, `--force` - does not prompt when removing workspace files. Changing the
-  current set of [DVC files](/doc/user-guide/project-structure) with
+  current [set of DVC files](/doc/user-guide/project-structure) with
   `git checkout` can result in the need for DVC to remove files that don't match
   those references or are missing from cache. (They are not "committed", in DVC
   terms.)

--- a/content/docs/command-reference/config.md
+++ b/content/docs/command-reference/config.md
@@ -118,9 +118,9 @@ This is the main section with the general config options:
   (default) and `false`.
 
 - `core.autostage` - if enabled, DVC will automatically stage (`git add`)
-  [DVC files](/doc/user-guide/dvc-files) created or modified by DVC commands
-  (`dvc add`, `dvc run`, etc.). The files will not be committed. Accepts values
-  `true` and `false` (default).
+  [DVC files](/doc/user-guide/project-structure) created or modified by commands
+  like `dvc add`, `dvc run`, etc. The files will not be committed. Accepts
+  values `true` and `false` (default).
 
 ### remote
 

--- a/content/docs/command-reference/config.md
+++ b/content/docs/command-reference/config.md
@@ -207,8 +207,9 @@ This section contains the following options, which affect the project's
 
 ### state
 
-See [Internal directories and files](/doc/user-guide/dvc-internals) to learn
-more about the state file (database) that is used for optimization.
+See
+[Internal directories and files](/doc/user-guide/project-structure/internal-files)
+to learn more about the state file (database) that is used for optimization.
 
 - `state.row_limit` - maximum number of entries in the state database, which
   affects the physical size of the state file itself, as well as the performance

--- a/content/docs/command-reference/config.md
+++ b/content/docs/command-reference/config.md
@@ -118,9 +118,8 @@ This is the main section with the general config options:
   (default) and `false`.
 
 - `core.autostage` - if enabled, DVC will automatically stage (`git add`)
-  [DVC files](/doc/user-guide/project-structure) created or modified by commands
-  like `dvc add`, `dvc run`, etc. The files will not be committed. Accepts
-  values `true` and `false` (default).
+  <abbr>DVC files</abbr> created or modified by DVC commands. The files will not
+  be committed. Accepts values `true` and `false` (default).
 
 ### remote
 

--- a/content/docs/command-reference/destroy.md
+++ b/content/docs/command-reference/destroy.md
@@ -1,6 +1,6 @@
 # destroy
 
-Remove all [DVC files](/doc/user-guide/dvc-files) and
+Remove all [DVC files](/doc/user-guide/project-structure) and
 [internals](/doc/user-guide/dvc-internals) from a <abbr>DVC project</abbr>.
 
 ## Synopsis
@@ -21,9 +21,8 @@ Note that the <abbr>cache directory</abbr> will be removed as well, unless it's
 cache, DVC will replace them with the latest versions of the actual files and
 directories first, so that your data is intact after the project's destruction.
 
-> Refer to [DVC files](/doc/user-guide/dvc-files) and
-> [internals](/doc/user-guide/dvc-internals) for more details on the directories
-> and files deleted by this command.
+> Refer to [Project Structure](/doc/user-guide/project-structure) for more
+> details on the directories and files deleted by this command.
 
 ## Options
 

--- a/content/docs/command-reference/destroy.md
+++ b/content/docs/command-reference/destroy.md
@@ -1,6 +1,6 @@
 # destroy
 
-Remove all [DVC files](/doc/user-guide/project-structure) and
+Remove all <abbr>DVC files</abbr> and
 [internals](/doc/user-guide/project-structure/internal-files) from a <abbr>DVC
 project</abbr>.
 
@@ -12,7 +12,7 @@ usage: dvc destroy [-h] [-q | -v] [-f]
 
 ## Description
 
-`dvc destroy` removes `dvc.yaml`, `.dvc` files, and the internal `.dvc/`
+`dvc destroy` removes `dvc.yaml` and `.dvc` files, and the internal `.dvc/`
 directory from the <abbr>workspace</abbr>.
 
 Note that the <abbr>cache directory</abbr> will be removed as well, unless it's

--- a/content/docs/command-reference/destroy.md
+++ b/content/docs/command-reference/destroy.md
@@ -1,7 +1,8 @@
 # destroy
 
 Remove all [DVC files](/doc/user-guide/project-structure) and
-[internals](/doc/user-guide/dvc-internals) from a <abbr>DVC project</abbr>.
+[internals](/doc/user-guide/project-structure/internal-files) from a <abbr>DVC
+project</abbr>.
 
 ## Synopsis
 

--- a/content/docs/command-reference/fetch.md
+++ b/content/docs/command-reference/fetch.md
@@ -173,7 +173,7 @@ $ tree .dvc/cache
 > Refer to `dvc status`.
 
 Note that the
-[`.dvc/cache`](/doc/user-guide/dvc-internals#structure-of-the-cache-directory)
+[`.dvc/cache`](/doc/user-guide/project-structure/internal-files#structure-of-the-cache-directory)
 directory was created and populated.
 
 All the data needed in this version of the project is now in your cache: File

--- a/content/docs/command-reference/gc.md
+++ b/content/docs/command-reference/gc.md
@@ -25,9 +25,8 @@ explicitly provide the right set of options to specify what data is still needed
 One of the scope options (`--workspace`, `--all-branches`, `--all-tags`,
 `--all-commits`) or a combination of them must be provided. Each of them
 corresponds to keeping the data for the current workspace, and possibly for a
-certain set of commits (determined by reading the
-[DVC files](/doc/user-guide/project-structure) in them). See the
-[Options](#options) section for more details.
+certain set of commits (determined by reading the <abbr>DVC files</abbr> in
+them). See the [Options](#options) section for more details.
 
 > Note that `dvc gc` tries to fetch any missing
 > [`.dir` files](/doc/user-guide/project-structure/internal-files#structure-of-the-cache-directory)
@@ -119,7 +118,7 @@ $ du -sh .dvc/cache/
 
 When you run `dvc gc --workspace`, DVC removes all objects from cache that are
 not referenced in the <abbr>workspace</abbr> (by collecting hash values from the
-[DVC files](/doc/user-guide/project-structure)):
+<abbr>DVC files</abbr>):
 
 ```dvc
 $ dvc gc --workspace

--- a/content/docs/command-reference/gc.md
+++ b/content/docs/command-reference/gc.md
@@ -26,8 +26,8 @@ One of the scope options (`--workspace`, `--all-branches`, `--all-tags`,
 `--all-commits`) or a combination of them must be provided. Each of them
 corresponds to keeping the data for the current workspace, and possibly for a
 certain set of commits (determined by reading the
-[DVC files](/doc/user-guide/dvc-files) in them). See the [Options](#options)
-section for more details.
+[DVC files](/doc/user-guide/project-structure) in them). See the
+[Options](#options) section for more details.
 
 > Note that `dvc gc` tries to fetch any missing
 > [`.dir` files](/doc/user-guide/dvc-internals#structure-of-the-cache-directory)
@@ -119,7 +119,7 @@ $ du -sh .dvc/cache/
 
 When you run `dvc gc --workspace`, DVC removes all objects from cache that are
 not referenced in the <abbr>workspace</abbr> (by collecting hash values from the
-[DVC files](/doc/user-guide/dvc-files)):
+[DVC files](/doc/user-guide/project-structure)):
 
 ```dvc
 $ dvc gc --workspace

--- a/content/docs/command-reference/gc.md
+++ b/content/docs/command-reference/gc.md
@@ -30,7 +30,7 @@ certain set of commits (determined by reading the
 [Options](#options) section for more details.
 
 > Note that `dvc gc` tries to fetch any missing
-> [`.dir` files](/doc/user-guide/dvc-internals#structure-of-the-cache-directory)
+> [`.dir` files](/doc/user-guide/project-structure/internal-files#structure-of-the-cache-directory)
 > from [remote storage](/doc/command-reference/remote) to the local
 > <abbr>cache</abbr>, in order to determine which files should exist inside
 > cached directories. These files may be missing if the cache directory was

--- a/content/docs/command-reference/init.md
+++ b/content/docs/command-reference/init.md
@@ -16,9 +16,9 @@ repository root (a `.git/` directory should be present).
 
 At DVC initialization, a new `.dvc/` directory is created for internal
 configuration and <abbr>cache</abbr>
-[files and directories](/doc/user-guide/dvc-internals), that are hidden from the
-user. This directory is automatically staged with `git add`, so it can be easily
-committed with Git.
+[files and directories](/doc/user-guide/project-structure/internal-files), that
+are hidden from the user. This directory is automatically staged with `git add`,
+so it can be easily committed with Git.
 
 The command [options](#options) can be used to start an alternative workflow for
 advanced scenarios:
@@ -49,9 +49,9 @@ initializing DVC in the Git repo root:
 - Repository maintainers might not allow a top level `.dvc/` directory,
   especially if DVC is already being used by several sub-projects (monorepo).
 
-- DVC [internals](/doc/user-guide/dvc-internals) (config file, cache directory,
-  etc.) would be shared across different subdirectories. This forces all of them
-  to use the same DVC settings and
+- DVC [internals](/doc/user-guide/project-structure/internal-files) (config
+  file, cache directory, etc.) would be shared across different subdirectories.
+  This forces all of them to use the same DVC settings and
   [remote storage](/doc/command-reference/remote).
 
 - By default, DVC commands like `dvc pull` and `dvc repro` explore the whole

--- a/content/docs/command-reference/install.md
+++ b/content/docs/command-reference/install.md
@@ -169,10 +169,9 @@ $ dvc pull -aT
 ## Example: Checkout both Git and DVC
 
 Switching from one Git commit to another (with `git checkout`) may change the
-[set of DVC files](/doc/user-guide/project-structure) in the
-<abbr>workspace</abbr>. This would mean that the currently present data files
-and directories no longer matches project's version (which can be fixed with
-`dvc checkout`).
+set of <abbr>DVC files</abbr> in the <abbr>workspace</abbr>. This could mean
+that the currently present data no longer matches the project's version (which
+can be fixed with `dvc checkout`).
 
 Let's first list the available tags in the _Get Started_ repo:
 
@@ -267,7 +266,7 @@ Data and pipelines are up to date.
 
 Look carefully at this output and it is clear that the `dvc checkout` command
 has indeed been run. As a result the workspace is up to date with the data files
-matching what is referenced by the DVC files.
+matching what is referenced in the <abbr>DVC files</abbr>.
 
 ## Example: Showing DVC status when committing with Git
 

--- a/content/docs/command-reference/install.md
+++ b/content/docs/command-reference/install.md
@@ -22,10 +22,10 @@ etc.) doesn't have DVC initialized (no `.dvc/` directory present).
 Namely:
 
 **Checkout**: For any commit hash, branch or tag, `git checkout` retrieves the
-[DVC files](/doc/user-guide/dvc-files) corresponding to that version. These
-files in turn refer to data stored in <abbr>cache</abbr>, but not necessarily in
-the <abbr>workspace</abbr>. Normally, it would be necessary to use
-`dvc checkout` to update the workspace accordingly.
+[DVC files](/doc/user-guide/project-structure) corresponding to that version.
+These files in turn refer to data stored in <abbr>cache</abbr>, but not
+necessarily in the <abbr>workspace</abbr>. Normally, it would be necessary to
+use `dvc checkout` to update the workspace accordingly.
 
 This hook automates `dvc checkout` after `git checkout`.
 
@@ -168,9 +168,10 @@ $ dvc pull -aT
 ## Example: Checkout both Git and DVC
 
 Switching from one Git commit to another (with `git checkout`) may change the
-set of [DVC files](/doc/user-guide/dvc-files) in the <abbr>workspace</abbr>.
-This would mean that the currently present data files and directories no longer
-matches project's version (which can be fixed with `dvc checkout`).
+[set of DVC files](/doc/user-guide/project-structure) in the
+<abbr>workspace</abbr>. This would mean that the currently present data files
+and directories no longer matches project's version (which can be fixed with
+`dvc checkout`).
 
 Let's first list the available tags in the _Get Started_ repo:
 

--- a/content/docs/command-reference/install.md
+++ b/content/docs/command-reference/install.md
@@ -21,11 +21,12 @@ etc.) doesn't have DVC initialized (no `.dvc/` directory present).
 
 Namely:
 
-**Checkout**: For any commit hash, branch or tag, `git checkout` retrieves the
-[DVC files](/doc/user-guide/project-structure) corresponding to that version.
-These files in turn refer to data stored in <abbr>cache</abbr>, but not
-necessarily in the <abbr>workspace</abbr>. Normally, it would be necessary to
-use `dvc checkout` to update the workspace accordingly.
+**Checkout**: For any commit hash, branch or tag, `git checkout` restores the
+[DVC project files](/doc/user-guide/project-structure) corresponding to that
+version. Some of these files, in turn refer to data stored in
+<abbr>cache</abbr>, but not necessarily current in the <abbr>workspace</abbr>.
+Normally, it's necessary to use `dvc checkout` to also update the workspace
+accordingly.
 
 This hook automates `dvc checkout` after `git checkout`.
 

--- a/content/docs/command-reference/list.md
+++ b/content/docs/command-reference/list.md
@@ -17,12 +17,11 @@ positional arguments:
 ## Description
 
 A side-effect of DVC is that it hides actual data paths, by effectively
-replacing files and directories with
-[DVC files](/doc/user-guide/project-structure). So you don't see data files/dirs
-when you browse a <abbr>DVC repository</abbr> on Git hosting (e.g. GitHub), you
-just see the `dvc.yaml` and `.dvc` files. This can make it hard to navigate the
-project, for example to find files or directories for use with `dvc get`,
-`dvc import`, or `dvc.api` functions.
+replacing files and directories with <abbr>DVC files</abbr>. So you don't see
+data files/dirs when you browse a <abbr>DVC repository</abbr> on Git hosting
+(e.g. GitHub), you just see the `dvc.yaml` and `.dvc` files. This can make it
+hard to navigate the project, for example to find files or directories for use
+with `dvc get`, `dvc import`, or `dvc.api` functions.
 
 This command produces a view of a DVC repository, as if files and directories
 tracked by DVC were found directly in the Git repo. Its output is equivalent to

--- a/content/docs/command-reference/list.md
+++ b/content/docs/command-reference/list.md
@@ -17,11 +17,12 @@ positional arguments:
 ## Description
 
 A side-effect of DVC is that it hides actual data paths, by effectively
-replacing files and directories with [DVC files](/doc/user-guide/dvc-files). So
-you don't see data files/dirs when you browse a <abbr>DVC repository</abbr> on
-Git hosting (e.g. GitHub), you just see the `dvc.yaml` and `.dvc` files. This
-can make it hard to navigate the project, for example to find files or
-directories for use with `dvc get`, `dvc import`, or `dvc.api` functions.
+replacing files and directories with
+[DVC files](/doc/user-guide/project-structure). So you don't see data files/dirs
+when you browse a <abbr>DVC repository</abbr> on Git hosting (e.g. GitHub), you
+just see the `dvc.yaml` and `.dvc` files. This can make it hard to navigate the
+project, for example to find files or directories for use with `dvc get`,
+`dvc import`, or `dvc.api` functions.
 
 This command produces a view of a DVC repository, as if files and directories
 tracked by DVC were found directly in the Git repo. Its output is equivalent to

--- a/content/docs/command-reference/metrics/diff.md
+++ b/content/docs/command-reference/metrics/diff.md
@@ -31,8 +31,8 @@ specified, `dvc metrics diff` compares metrics currently present in the
 (required). A single specified revision results in comparing the workspace and
 that version.
 
-> Note that unlike `dvc diff`, this command doesn't always need DVC files to
-> find metrics files (see `--targets` option). For that reason, it doesn't
+> Note that unlike `dvc diff`, this command doesn't always need `dvc.yaml` files
+> to find metrics files (see `--targets` option). For that reason, it doesn't
 > require an existing DVC project to run in. It can work in any Git repo.
 
 Another way to display metrics is the `dvc metrics show` command, which just

--- a/content/docs/command-reference/metrics/show.md
+++ b/content/docs/command-reference/metrics/show.md
@@ -18,7 +18,7 @@ positional arguments:
 ## Description
 
 Finds and prints all metrics in the <abbr>project</abbr> by examining all of its
-[DVC files](/doc/user-guide/dvc-files).
+`dvc.yaml` files (by default).
 
 If `targets` are provided, it will show those specific metrics files instead.
 With the `-a` or `-T` options, this command shows the different metrics values

--- a/content/docs/command-reference/push.md
+++ b/content/docs/command-reference/push.md
@@ -187,7 +187,7 @@ Finally, we used `dvc status` to double check that all data had been uploaded.
 ## Example: What happens in the cache?
 
 Let's take a detailed look at what happens to the
-[cache directory](/doc/user-guide/dvc-internals#structure-of-the-cache-directory)
+[cache directory](/doc/user-guide/project-structure/internal-files#structure-of-the-cache-directory)
 as you run an experiment locally and push data to remote storage. To set the
 example consider having created a <abbr>workspace</abbr> that contains some code
 and data, and having set up a remote.
@@ -235,7 +235,7 @@ the cache having more files in it than the remote – which is what the `new`
 state means.
 
 > Refer to
-> [Structure of cache directory](/doc/user-guide/dvc-internals#structure-of-the-cache-directory)
+> [Structure of cache directory](/doc/user-guide/project-structure/internal-files#structure-of-the-cache-directory)
 > for more info.
 
 Next we can copy the remaining data from the cache to the remote using

--- a/content/docs/command-reference/remote/modify.md
+++ b/content/docs/command-reference/remote/modify.md
@@ -88,7 +88,8 @@ The following config options are available for all remote types:
   DVC will recalculate the file hashes upon download (e.g. `dvc pull`) to make
   sure that these haven't been modified, or corrupted during download. It may
   slow down the aforementioned commands. The calculated hash is compared to the
-  value saved in the corresponding [DVC file](/doc/user-guide/dvc-files).
+  value saved in the corresponding
+  [DVC file](/doc/user-guide/project-structure).
 
   > Note that this option is enabled on **Google Drive** remotes by default.
 

--- a/content/docs/command-reference/remote/modify.md
+++ b/content/docs/command-reference/remote/modify.md
@@ -85,11 +85,10 @@ The following config options are available for all remote types:
   ```
 
 - `verify` - upon downloading <abbr>cache</abbr> files (`dvc pull`, `dvc fetch`)
-  DVC will recalculate the file hashes upon download (e.g. `dvc pull`) to make
-  sure that these haven't been modified, or corrupted during download. It may
-  slow down the aforementioned commands. The calculated hash is compared to the
-  value saved in the corresponding
-  [DVC file](/doc/user-guide/project-structure).
+  DVC will recalculate the file hashes, to make sure that these haven't been
+  modified or corrupted. This may slow down the aforementioned commands. The
+  calculated hash is compared to the value saved in the corresponding <abbr>DVC
+  file</abbr>.
 
   > Note that this option is enabled on **Google Drive** remotes by default.
 

--- a/content/docs/command-reference/run.md
+++ b/content/docs/command-reference/run.md
@@ -97,7 +97,7 @@ Relevant notes:
 
 - Entire directories produced by the stage can be tracked as outputs by DVC,
   which generates a single `.dir` entry in the cache (refer to
-  [Structure of cache directory](/doc/user-guide/dvc-internals#structure-of-the-cache-directory)
+  [Structure of cache directory](/doc/user-guide/project-structure/internal-files#structure-of-the-cache-directory)
   for more info.)
 
 - [external dependencies](/doc/user-guide/external-dependencies) and

--- a/content/docs/command-reference/status.md
+++ b/content/docs/command-reference/status.md
@@ -40,8 +40,8 @@ tracked files or directories (including paths inside tracked directories),
 `.dvc` files, and stage names (found in `dvc.yaml`).
 
 The `--all-branches`, `--all-tags`, and `--all-commits` options enable comparing
-[DVC files](/doc/user-guide/dvc-files) referenced in multiple Git commits at
-once.
+[DVC files](/doc/user-guide/project-structure) referenced in multiple Git
+commits at once.
 
 If no differences are detected, `dvc status` prints
 `Data and pipelines are up to date.` or

--- a/content/docs/command-reference/status.md
+++ b/content/docs/command-reference/status.md
@@ -40,8 +40,7 @@ tracked files or directories (including paths inside tracked directories),
 `.dvc` files, and stage names (found in `dvc.yaml`).
 
 The `--all-branches`, `--all-tags`, and `--all-commits` options enable comparing
-[DVC files](/doc/user-guide/project-structure) referenced in multiple Git
-commits at once.
+DVC-tracked files referenced in multiple Git commits at once.
 
 If no differences are detected, `dvc status` prints
 `Data and pipelines are up to date.` or

--- a/content/docs/install/plugins.md
+++ b/content/docs/install/plugins.md
@@ -1,8 +1,8 @@
 # IDE Plugins and Syntax Highlighting
 
 When files or directories are added to the project, or stages to a pipeline,
-[DVC files](/doc/user-guide/dvc-files) are created. These use a simple YAML
-format.
+[DVC files](/doc/user-guide/project-structure) are created. These use a simple
+YAML format.
 
 We maintain a [schema](https://github.com/iterative/dvcyaml-schema) for
 `dvc.yaml` that can enable IDE syntax checks and auto-completion.

--- a/content/docs/install/plugins.md
+++ b/content/docs/install/plugins.md
@@ -1,11 +1,11 @@
 # IDE Plugins and Syntax Highlighting
 
 When files or directories are added to the project, or stages to a pipeline,
-[DVC files](/doc/user-guide/project-structure) are created. These use a simple
-YAML format.
+<abbr>DVC files</abbr> are created or updated. These use a simple YAML format.
 
-We maintain a [schema](https://github.com/iterative/dvcyaml-schema) for
-`dvc.yaml` that can enable IDE syntax checks and auto-completion.
+In the case of `dvc.yaml`, we maintain a
+[schema description](https://github.com/iterative/dvcyaml-schema) that can
+enable IDE syntax checks and auto-completion.
 
 ## Visual Studio Code
 

--- a/content/docs/start/index.md
+++ b/content/docs/start/index.md
@@ -36,8 +36,8 @@ $ git init
 $ dvc init
 ```
 
-A few [directories and files](/doc/user-guide/dvc-internals) are created that
-should be added to Git:
+A few [directories and files](/doc/user-guide/project-structure/internal-files)
+are created that should be added to Git:
 
 ```dvc
 $ git status

--- a/content/docs/use-cases/data-registries.md
+++ b/content/docs/use-cases/data-registries.md
@@ -183,7 +183,7 @@ $ git commit -am "Add 1,000 more songs to music/ dataset."
 
 Iterating on this process for several datasets can give shape to a robust
 registry. The result is basically a repo that versions a set of
-[metafiles](/doc/user-guide/dvc-files). Let's see an example:
+[metafiles](/doc/user-guide/project-structure). Let's see an example:
 
 ```dvc
 $ tree --filelimit=10

--- a/content/docs/use-cases/sharing-data-and-model-files.md
+++ b/content/docs/use-cases/sharing-data-and-model-files.md
@@ -67,8 +67,8 @@ with the `dvc push` command:
 $ dvc push
 ```
 
-Code and [DVC files](/doc/user-guide/project-structure/pipelines-files) can be
-safely committed and pushed with Git.
+Code and [DVC project files](/doc/user-guide/project-structure/pipelines-files)
+can be safely committed and pushed with Git.
 
 ## Download code
 

--- a/content/docs/use-cases/sharing-data-and-model-files.md
+++ b/content/docs/use-cases/sharing-data-and-model-files.md
@@ -67,8 +67,8 @@ with the `dvc push` command:
 $ dvc push
 ```
 
-Code and [DVC files](/doc/user-guide/dvc-files) can be safely committed and
-pushed with Git.
+Code and [DVC files](/doc/user-guide/project-structure/pipelines-files) can be
+safely committed and pushed with Git.
 
 ## Download code
 

--- a/content/docs/use-cases/versioning-data-and-model-files/index.md
+++ b/content/docs/use-cases/versioning-data-and-model-files/index.md
@@ -35,10 +35,10 @@ the data, [restore](/doc/command-reference/checkout) previous versions,
 to learn how DVC looks and feels firsthand.
 
 As you use DVC, unique versions of your data files and directories are
-[cached](/doc/user-guide/dvc-internals#structure-of-the-cache-directory) in a
-systematic way (preventing file duplication). The working datastore is separated
-from your <abbr>workspace</abbr> to keep the project light, but stays connected
-via file
+[cached](/doc/user-guide/project-structure/internal-files#structure-of-the-cache-directory)
+in a systematic way (preventing file duplication). The working datastore is
+separated from your <abbr>workspace</abbr> to keep the project light, but stays
+connected via file
 [links](/doc/user-guide/large-dataset-optimization#file-link-types-for-the-dvc-cache)
 handled automatically by DVC.
 

--- a/content/docs/use-cases/versioning-data-and-model-files/index.md
+++ b/content/docs/use-cases/versioning-data-and-model-files/index.md
@@ -23,8 +23,8 @@ work!
 and models for you 💘._
 
 DVC enables data _versioning through codification_. You produce simple
-[metafiles](/doc/user-guide/dvc-files) once, describing what datasets, ML
-artifacts, etc. to track. This metadata can be put in Git in lieu of large
+[metafiles](/doc/user-guide/project-structure) once, describing what datasets,
+ML artifacts, etc. to track. This metadata can be put in Git in lieu of large
 files. Now you can use DVC to create [snapshots](/doc/command-reference/add) of
 the data, [restore](/doc/command-reference/checkout) previous versions,
 [reproduce](/doc/command-reference/repro) experiments, record evolving

--- a/content/docs/use-cases/versioning-data-and-model-files/tutorial.md
+++ b/content/docs/use-cases/versioning-data-and-model-files/tutorial.md
@@ -136,7 +136,7 @@ intermediate results, etc. It tells Git to ignore the directory and puts it into
 the <abbr>cache</abbr> (while keeping a
 [file link](/doc/user-guide/large-dataset-optimization#file-link-types-for-the-dvc-cache)
 to it in the <abbr>workspace</abbr>, so you can continue working the same way as
-before). This is achieved by creating a simple human-readable `.dvc` file that
+before). This is achieved by creating a tiny, human-readable `.dvc` file that
 serves as a pointer to the cache.
 
 Next, we train our first model with `train.py`. Because of the small dataset,
@@ -168,13 +168,10 @@ $ git tag -a "v1.0" -m "model v1.0, 1000 images"
 
 As we mentioned briefly, DVC does not commit the `data/` directory and
 `model.h5` file with Git. Instead, `dvc add` stores them in the
-<abbr>cache</abbr> (usually in `.dvc/cache`) and adds them to `.gitignore`. We
-then `git commit` `.dvc` files that contain file hashes that point to cached
-data.
+<abbr>cache</abbr> (usually in `.dvc/cache`) and adds them to `.gitignore`.
 
-In this case we created `data.dvc` and `model.h5.dvc`. Refer to
-[DVC Files](/doc/user-guide/project-structure/dvc-files) to learn more about how
-these files work.
+In this case, we created `data.dvc` and `model.h5.dvc`, which contain file
+hashes that point to cached data. We then `git commit` these `.dvc` files.
 
 </details>
 
@@ -270,7 +267,7 @@ or model files each time. So `dvc checkout` is quick even if you have large
 datasets, data files, or models.
 
 On the other hand, if we want to keep the current code, but go back to the
-previous dataset version, we can do something like this:
+previous dataset version, we can target specific data, like this:
 
 ```dvc
 $ git checkout v1.0 data.dvc
@@ -280,22 +277,6 @@ $ dvc checkout data.dvc
 If you run `git status` you'll see that `data.dvc` is modified and currently
 points to the `v1.0` version of the dataset, while code and model files are from
 the `v2.0` tag.
-
-<details>
-
-### Expand to learn more about DVC files
-
-As we have learned already, DVC keeps data files out of Git (by adjusting
-`.gitignore`) and puts them into the <abbr>cache</abbr> (usually it's a
-`.dvc/cache` directory inside the repository). Instead, DVC creates
-[DVC files](/doc/user-guide/project-structure). These text files serve as data
-placeholders that point to the cached files, and they can be easily version
-controlled with Git.
-
-When we run `git checkout` we restore these pointers first. Then, when we run
-`dvc checkout`, we use these pointers to put the right data in the right place.
-
-</details>
 
 ## Automating capturing
 

--- a/content/docs/use-cases/versioning-data-and-model-files/tutorial.md
+++ b/content/docs/use-cases/versioning-data-and-model-files/tutorial.md
@@ -71,8 +71,8 @@ $ pip install -r requirements.txt
 The repository you cloned is already DVC-initialized. It already contains a
 `.dvc/` directory with the `config` and `.gitignore` files. These and other
 files and directories are hidden from user, as typically there's no need to
-interact with them directly. See [DVC Internals](/doc/user-guide/dvc-internals)
-to learn more.
+interact with them directly. See
+[DVC Internals](/doc/user-guide/project-structure/internal-files) to learn more.
 
 </details>
 

--- a/content/docs/use-cases/versioning-data-and-model-files/tutorial.md
+++ b/content/docs/use-cases/versioning-data-and-model-files/tutorial.md
@@ -288,13 +288,12 @@ the `v2.0` tag.
 As we have learned already, DVC keeps data files out of Git (by adjusting
 `.gitignore`) and puts them into the <abbr>cache</abbr> (usually it's a
 `.dvc/cache` directory inside the repository). Instead, DVC creates
-[DVC files](/doc/user-guide/dvc-files). These text files serve as data
+[DVC files](/doc/user-guide/project-structure). These text files serve as data
 placeholders that point to the cached files, and they can be easily version
 controlled with Git.
 
-When we run `git checkout` we restore pointers (`.dvc` files) first. Then, when
-we run `dvc checkout`, we use these pointers to put the right data in the right
-place.
+When we run `git checkout` we restore these pointers first. Then, when we run
+`dvc checkout`, we use these pointers to put the right data in the right place.
 
 </details>
 

--- a/content/docs/user-guide/basic-concepts/dvc-cache.md
+++ b/content/docs/user-guide/basic-concepts/dvc-cache.md
@@ -6,4 +6,4 @@ match: ['DVC cache', cache, caches, cached, 'cache directory']
 The DVC cache is a hidden storage (by default in `.dvc/cache`) for files and
 directories tracked by DVC, and their different versions. Learn more about it's
 structure
-[here](/doc/user-guide/dvc-internals#structure-of-the-cache-directory).
+[here](/doc/user-guide/project-structure/internal-files#structure-of-the-cache-directory).

--- a/content/docs/user-guide/basic-concepts/dvc-files.md
+++ b/content/docs/user-guide/basic-concepts/dvc-files.md
@@ -1,0 +1,9 @@
+---
+name: DVC File
+match: ['dvc files', 'dvc file']
+---
+
+`dvc.yaml`, `dvc.lock`, or `.dvc` files. DVC commands create these in the
+workspace to codify [pipelines](/doc/command-reference/dag) and/or to track data
+for [versioning](/doc/use-cases/versioning-data-and-model-files). See also
+`dvc repro`, `dvc add`.

--- a/content/docs/user-guide/basic-concepts/dvc-project.md
+++ b/content/docs/user-guide/basic-concepts/dvc-project.md
@@ -15,5 +15,6 @@ match:
 
 Initialized by running `dvc init` in the **workspace** (typically a Git
 repository). It will contain the
-[`.dvc/` directory](/doc/user-guide/dvc-internals), as well as `dvc.yaml` and
-`.dvc` files created with commands such as `dvc add` or `dvc run`.
+[`.dvc/` directory](/doc/user-guide/project-structure/internal-files), as well
+as `dvc.yaml` and `.dvc` files created with commands such as `dvc add` or
+`dvc run`.

--- a/content/docs/user-guide/contributing/docs.md
+++ b/content/docs/user-guide/contributing/docs.md
@@ -169,8 +169,8 @@ is installed when `yarn` runs (see [dev env](#development-environment)).
   `dvc`, `yaml`, or `diff` custom languages. `usage` is employed to show the
   `dvc --help` output for each command reference. `dvc` can be used to show
   examples of commands and their output in a terminal session. `yaml` is used to
-  show [DVC file](/doc/user-guide/dvc-files) contents, or other YAML data.
-  `diff` is used mainly for examples of `git diff` output.
+  show [DVC file](/doc/user-guide/project-structure) contents, or other YAML
+  data. `diff` is used mainly for examples of `git diff` output.
 
 > Check out the `.md` source code of any command reference to get a better idea,
 > for example in

--- a/content/docs/user-guide/contributing/docs.md
+++ b/content/docs/user-guide/contributing/docs.md
@@ -169,8 +169,8 @@ is installed when `yarn` runs (see [dev env](#development-environment)).
   `dvc`, `yaml`, or `diff` custom languages. `usage` is employed to show the
   `dvc --help` output for each command reference. `dvc` can be used to show
   examples of commands and their output in a terminal session. `yaml` is used to
-  show [DVC file](/doc/user-guide/project-structure) contents, or other YAML
-  data. `diff` is used mainly for examples of `git diff` output.
+  show samples of <abbr>DVC files</abbr>, or other YAML contents. `diff` is used
+  mainly for examples of `git diff` output.
 
 > Check out the `.md` source code of any command reference to get a better idea,
 > for example in

--- a/content/docs/user-guide/how-to/merge-conflicts.md
+++ b/content/docs/user-guide/how-to/merge-conflicts.md
@@ -8,8 +8,8 @@ from multiple team members.'
 
 Sometimes multiple members of a team might work on the the same DVC-tracked
 data. And when the time comes to combine their changes, merge conflicts can
-happen in Git-tracked [DVC files](/doc/user-guide/dvc-files), which need to be
-resolved.
+happen in Git-tracked [DVC files](/doc/user-guide/project-structure), which need
+to be resolved.
 
 ## `dvc.yaml`
 

--- a/content/docs/user-guide/how-to/merge-conflicts.md
+++ b/content/docs/user-guide/how-to/merge-conflicts.md
@@ -1,15 +1,15 @@
 ---
 title: 'How to Merge Conflicts'
-description: 'Git merge conflicts can happen in DVC files when combining changes
-from multiple team members.'
+description: 'Git merge conflicts can happen in DVC project files when combining
+changes from multiple team members.'
 ---
 
 # How to Merge Conflicts in DVC Files
 
-Sometimes multiple members of a team might work on the the same DVC-tracked
-data. And when the time comes to combine their changes, merge conflicts can
-happen in Git-tracked [DVC files](/doc/user-guide/project-structure), which need
-to be resolved.
+Sometimes multiple tam members work on the the same DVC-tracked data. When the
+time comes to combine their changes, merge conflicts can occur in Git-tracked
+[DVC project files](/doc/user-guide/project-structure), which need to be
+resolved.
 
 ## `dvc.yaml`
 

--- a/content/docs/user-guide/how-to/merge-conflicts.md
+++ b/content/docs/user-guide/how-to/merge-conflicts.md
@@ -1,15 +1,14 @@
 ---
 title: 'How to Merge Conflicts'
-description: 'Git merge conflicts can happen in DVC project files when combining
-changes from multiple team members.'
+description: 'Git merge conflicts can happen in DVC files when combining changes
+from multiple team members.'
 ---
 
 # How to Merge Conflicts in DVC Files
 
 Sometimes multiple tam members work on the the same DVC-tracked data. When the
 time comes to combine their changes, merge conflicts can occur in Git-tracked
-[DVC project files](/doc/user-guide/project-structure), which need to be
-resolved.
+<abbr>DVC files</abbr>, which need to be resolved.
 
 ## `dvc.yaml`
 

--- a/content/docs/user-guide/project-structure/dvcignore-files.md
+++ b/content/docs/user-guide/project-structure/dvcignore-files.md
@@ -96,7 +96,7 @@ stored. Checking the hash value of the data files manually, we can see that
 `data2` was cached. This means that `dvc add` did ignore `data1`.
 
 > Refer to
-> [Structure of cache directory](/doc/user-guide/dvc-internals#structure-of-the-cache-directory)
+> [Structure of cache directory](/doc/user-guide/project-structure/internal-files#structure-of-the-cache-directory)
 > for more info.
 
 ## Example: Ignore file state changes

--- a/content/docs/user-guide/project-structure/internal-files.md
+++ b/content/docs/user-guide/project-structure/internal-files.md
@@ -24,8 +24,8 @@ operation.
 
   > Note that DVC includes the cache directory in `.gitignore` during
   > initialization. No data tracked by DVC should ever be pushed to the Git
-  > repository, only the [DVC files](/doc/user-guide/project-structure) that are
-  > needed to download or reproduce that data.
+  > repository, only the <abbr>DVC files</abbr> that are needed to download or
+  > reproduce that data.
 
 - `.dvc/plots`: Directory for
   [plot templates](/doc/command-reference/plots#plot-templates)

--- a/content/docs/user-guide/project-structure/internal-files.md
+++ b/content/docs/user-guide/project-structure/internal-files.md
@@ -4,7 +4,7 @@ Once initialized in a <abbr>project</abbr>, DVC populates its installation
 directory (`.dvc/`) with the internal directories and files needed for DVC
 operation.
 
-> See also [DVC Files](/doc/user-guide/dvc-files).
+> See also `dvc.yaml` and `.dvc` files.
 
 - `.dvc/config`: This is a configuration file. The config file can be edited by
   hand or with the `dvc config` command.
@@ -23,9 +23,9 @@ operation.
   `dvc config cache` for related configuration options.
 
   > Note that DVC includes the cache directory in `.gitignore` during
-  > initialization. No data tracked by DVC will ever be pushed to the Git
-  > repository, only [DVC files](/doc/user-guide/dvc-files) that are needed to
-  > download or reproduce them.
+  > initialization. No data tracked by DVC should ever be pushed to the Git
+  > repository, only the [DVC files](/doc/user-guide/project-structure) that are
+  > needed to download or reproduce that data.
 
 - `.dvc/plots`: Directory for
   [plot templates](/doc/command-reference/plots#plot-templates)

--- a/content/docs/user-guide/related-technologies.md
+++ b/content/docs/user-guide/related-technologies.md
@@ -93,8 +93,8 @@ _Luigi_, etc.
   visualizations.
 
 - DVC has transparent design. Its
-  [internal directories and files](/doc/user-guide/dvc-internals) have a
-  human-readable format and can be easily reused by external tools.
+  [internal directories and files](/doc/user-guide/project-structure/internal-files)
+  have a human-readable format and can be easily reused by external tools.
 
 ## Build automation tools
 

--- a/content/docs/user-guide/what-is-dvc.md
+++ b/content/docs/user-guide/what-is-dvc.md
@@ -24,9 +24,9 @@ can version experiments, manage large datasets, and make projects reproducible.
 
 - **Data versioning** is enabled by replacing large files, dataset directories,
   machine learning models, etc. with small
-  [metafiles](/doc/user-guide/dvc-files) (easy to handle with Git). These
-  placeholders point to the original data, which is decoupled from source code
-  management.
+  [metafiles](/doc/user-guide/project-structure) (easy to handle with Git).
+  These placeholders point to the original data, which is decoupled from source
+  code management.
 
 - **Data storage**: On-premises or cloud storage can be used to store the
   project's data separate from its code base. This is how data scientists can
@@ -52,8 +52,8 @@ can version experiments, manage large datasets, and make projects reproducible.
 
 DVC file such as `dvc.yaml` and `.dvc` files serve as placeholders to track
 large data files and directories for versioning (among other
-[purposes](/doc/user-guide/dvc-files)). These metafiles change along with your
-data, and you can use Git to place them under
+[purposes](/doc/user-guide/project-structure)). These metafiles change along
+with your data, and you can use Git to place them under
 [version control](https://git-scm.com/book/en/v2/Getting-Started-About-Version-Control)
 as a proxy to the actual data versions, which are stored in the <abbr>DVC
 cache</abbr> (outside of Git). This does not replace features of Git.

--- a/content/docs/user-guide/what-is-dvc.md
+++ b/content/docs/user-guide/what-is-dvc.md
@@ -50,7 +50,7 @@ can version experiments, manage large datasets, and make projects reproducible.
 
 ## DVC does not replace Git!
 
-DVC file such as `dvc.yaml` and `.dvc` files serve as placeholders to track
+DVC files such as `dvc.yaml` and `.dvc` files serve as placeholders to track
 large data files and directories for versioning (among other
 [purposes](/doc/user-guide/project-structure)). These metafiles change along
 with your data, and you can use Git to place them under

--- a/redirects-list.json
+++ b/redirects-list.json
@@ -28,12 +28,10 @@
   "^/doc/tutorials(/.*)?                                                                  /doc/start",
 
   "^/doc/use-cases/data-and-model-files-versioning/?$                                     /doc/use-cases/versioning-data-and-model-files",
-  "^/doc/user-guide/dvc-file-format$                                                      /doc/user-guide/project-structure",
-  "^/doc/user-guide/dvc-files-and-directories$                                            /doc/user-guide/project-structure",
-  "^/doc/user-guide/dvc-files$                                                            /doc/user-guide/project-structure",
   "^/doc/user-guide/updating-tracked-files$                                               /doc/user-guide/how-to/update-tracked-data",
   "^/doc/user-guide/how-to/update-tracked-files$                                          /doc/user-guide/how-to/update-tracked-data",
   "^/doc/user-guide/merge-conflicts$                                                      /doc/user-guide/how-to/merge-conflicts",
+  "^/doc/user-guide/dvc-files$                                                            /doc/user-guide/project-structure",
   "^/doc/user-guide/dvc-files/dvc-yaml$                                                   /doc/user-guide/project-structure",
   "^/doc/user-guide/dvc-files/advanced-dvc-yaml$                                          /doc/user-guide/project-structure/pipelines-files",
   "^/doc/user-guide/dvc-files/.dvc$                                                       /doc/user-guide/project-structure/dvc-files",


### PR DESCRIPTION
> Continues #2098

- [x] Updates old links to https://dvc.org/doc/user-guide/dvc-files to the new "Project Structure" section, as appropriate (+ copy edits).
- [x] Review of term "DVC file(s)" - change for **new tooltip** or use another term (& link).
- [x] Removes outdated redirects from an even older guide structure (now obsolete, see https://github.com/iterative/dvc.org/pull/2098#pullrequestreview-574728791).
- [x] Review mentions/links of DVC Internals and .dvcignore
- [ ] Review mentions/links of .dvcignore