### PR TITLE
guide: Experiment Management

### DIFF
--- a/content/docs/index.md
+++ b/content/docs/index.md
@@ -1,8 +1,9 @@
 # DVC Documentation
 
-Data Version Control, or DVC, is a data and ML experiment management tool that
-takes advantage of the existing engineering toolset that you're already familiar
-with (Git, CI/CD, etc.).
+Data Version Control, or DVC, is a data and ML
+[experiment management](/doc/user-guide/experiment-management) tool that takes
+advantage of the existing engineering toolset that you're already familiar with
+(Git, CI/CD, etc.).
 
 <cards>
 

--- a/content/docs/sidebar.json
+++ b/content/docs/sidebar.json
@@ -127,6 +127,7 @@
           "merge-conflicts"
         ]
       },
+      "experiment-management",
       "setup-google-drive-remote",
       "large-dataset-optimization",
       "external-dependencies",

--- a/content/docs/start/experiments.md
+++ b/content/docs/start/experiments.md
@@ -14,6 +14,9 @@ Read on or watch our video to see how it's done!
 
 https://youtu.be/iduHPtBncBk
 
+> 📖 See [Experiment Management](/doc/user-guide/experiment-management) for more
+> information on DVC's approach.
+
 ## Collecting metrics
 
 First, let's see what is the mechanism to capture values for these ML experiment

--- a/content/docs/user-guide/basic-concepts/experiment.md
+++ b/content/docs/user-guide/basic-concepts/experiment.md
@@ -1,11 +1,11 @@
 ---
 name: Experiment
 match: [experiment, experiments]
+tooltip: >-
+  An attempt to reach desired/better/interesting results during data pipelining
+  or ML model development. DVC is designed to help [manage
+  experiments](/doc/user-guide/experiment-management), having built-in
+  mechanisms like the
+  [run-cache](/doc/user-guide/project-structure/internal-files#run-cache) and
+  the `dvc experiments` commands (coming in DVC 2.0).
 ---
-
-An attempt to reach desired/better/interesting results during data pipelining or
-ML model development. DVC is designed to help
-[manage experiments](/doc/user-guide/experiment-management), having built-in
-mechanisms like the
-[run-cache](/doc/user-guide/project-structure/internal-files#run-cache) and the
-`dvc experiments` commands (coming in DVC 2.0).

--- a/content/docs/user-guide/basic-concepts/experiment.md
+++ b/content/docs/user-guide/basic-concepts/experiment.md
@@ -1,0 +1,11 @@
+---
+name: Experiment
+match: [experiment, experiments]
+---
+
+An attempt to reach desired/better/interesting results during data pipelining or
+ML model development. DVC is designed to help
+[manage experiments](/doc/user-guide/experiment-management), having built-in
+mechanisms like the
+[run-cache](/doc/user-guide/project-structure/internal-files#run-cache) and the
+`dvc experiments` commands (coming in DVC 2.0).

--- a/content/docs/user-guide/basic-concepts/run-cache.md
+++ b/content/docs/user-guide/basic-concepts/run-cache.md
@@ -3,9 +3,9 @@ name: 'Run-cache'
 match: ['run-cache']
 ---
 
-The DVC run-cache is a log of stages that have been run in the project. It's
-comprised of `dvc.lock` file backups, identified as combinations of
-dependencies, commands, and outputs that correspond to each other. `dvc repro`
-and `dvc run` populate and reutilize the run-cache. See
+A log of stages that have been run in the project. It's comprised of `dvc.lock`
+file backups, identified as combinations of dependencies, commands, and outputs
+that correspond to each other. `dvc repro` and `dvc run` populate and reutilize
+the run-cache. See
 [Run-cache](/doc/user-guide/project-structure/internal-files#run-cache) for more
 details.

--- a/content/docs/user-guide/experiment-management.md
+++ b/content/docs/user-guide/experiment-management.md
@@ -1,0 +1,1 @@
+# Experiment Management

--- a/content/docs/user-guide/experiment-management.md
+++ b/content/docs/user-guide/experiment-management.md
@@ -40,13 +40,14 @@ disabled with the `--no-run-cache` command option).
 
 `dvc experiments` commands let you work on DVC
 [pipelines](/doc/command-reference/dag) in a virtual branch, so that each
-experiment is captured automatically in a way that you can visualize later. The
-<abbr>workspace</abbr> may reflect each experiment's results for you to check,
-but there's no need to save them manually. The base workflow goes like this:
+experiment is captured automatically in a way that you can review and roll back
+later. The <abbr>workspace</abbr> may reflect each experiment's results for you
+to check, but there's no need to save them manually. The base workflow goes like
+this:
 
-- Establish or change the <abbr>dependencies</abbr> (e.g. input data or source
-  code), <abbr>parameters</abbr>, or commands (`cmd` field of `dvc.yaml`) of
-  your stages.
+- Modify <abbr>dependencies</abbr> (e.g. input data or source code),
+  <abbr>parameters</abbr>, or commands (`cmd` field of `dvc.yaml`) of a
+  committed stage.
 - Use `dvc exp run` (instead of `repro`) to execute the pipeline, which creates
   a transient commit that records this experiment.
 - Visualize the experiments statistics with `dvc exp show`. Repeat.
@@ -60,9 +61,11 @@ but there's no need to save them manually. The base workflow goes like this:
 
 DVC uses actual commits under custom
 [Git references](https://git-scm.com/book/en/v2/Git-Internals-Git-References)
-(found in `.git/refs/exps`) to keep track of `dvc exp run` branches. The first
-experiment has the Git repo's `HEAD` as parent. Each reference has a unique
-signature similar to the
+(found in `.git/refs/exps`) to keep track of `dvc exp run` branches. These are
+not pushed to the Git remote by default (see `dvc exp push`).
+
+The first transient commits has the Git repo's `HEAD` as parent, and the rest
+branch off there. Each reference has a unique signature similar to the
 [entries in the run-cache](/doc/user-guide/project-structure/internal-files#run-cache).
 
 </details>

--- a/content/docs/user-guide/experiment-management.md
+++ b/content/docs/user-guide/experiment-management.md
@@ -3,35 +3,23 @@
 Data science and ML are iterative processes that tend to require a large number
 of attempts during their course, for example to develop data features,
 hyperspace exploration, deep learning optimization, etc. DVC helps you codify
-and manage all of your <abbr>experiments</abbr>, considering the following
-levels at which they may exist:
+and manage all of your <abbr>experiments</abbr>, supporting these main
+experimentation approaches:
 
-1. DVC enters the scene with an automatic log of every stage `dvc repro` runs.
-2. Create [ephemeral experiments](#ephemeral-experiments) and
-   [in-code checkpoints](#checkpoints-in-python-code) that virtually branch off
-   your current workspace. DVC lets you quickly visualize and compare them from
-   terminal. The best ones can be promoted to the next level, and the rest
-   archived.
+1. Create [ephemeral experiments](#ephemeral-experiments) that derive from your
+   latest project version, without having to keep track manually. DVC does that
+   for you, letting you list and compare them. The best ones can be promoted,
+   and the rest archived.
+2. Place [in-code checkpoints](#checkpoints-in-python-code) that form series of
+   (ephemeral) experiments. DVC helps you capture them at runtime, and manage
+   them as batches.
 3. [Persistent experiments](#persistent-experiments) have their results
-   **committed** to Git. They can be selected from previous levels, or created
-   from scratch. This is where you may want to consider the different
-   [ways to organize](#organizing-experimentats) them in your project (as
-   branches, folders, etc.).
+   **committed** to Git. They can be selected from existing attempts, or created
+   from scratch.
 
-> Note that DVC assumes that all experiments are deterministic (see **Avoiding
-> unexpected behavior** in `dvc run`).
-
-## Automatic log of stage runs (run-cache)
-
-Every time you `dvc repro` pipelines, DVC logs the unique signature of each
-stage run (to `.dvc/cache/runs` by default). If it never happened before, the
-stage command(s) are executed normally. Every subsequent time a
-[stage](/doc/command-reference/run) runs under the same conditions, the previous
-results can be restored instantly, without wasting time or computing resources.
-
-✅ This built-in feature is called <abbr>run-cache</abbr> and it can
-dramatically improve performance. It's enabled out-of-the-box (but can be
-disabled with the `--no-run-cache` command option).
+   At this point you may also want to consider the different
+   [ways to organize](#organizing-experimentats) experiments in your project (as
+   Git branches, as folders, etc.).
 
 ## Ephemeral experiments
 
@@ -70,15 +58,25 @@ branch off there. Each reference has a unique signature similar to the
 
 </details>
 
-Note that `dvc exp run` also logs and reuses
-[stage runs](#automatic-log-of-stage-runs-run-cache) in the
-<abbr>run-cache</abbr> by default.
-
 > See `dvc exp` for more details and other commands.
 
 ## Checkpoints in Python code
 
+⚠️ This feature is only available in DVC 2.0, and for Git-enabled
+<abbr>repositories</abbr> ⚠️
+
 ...
+
+<details>
+
+### How are checkpoints captured by DVC?
+
+When DVC runs checkpoint-enabled stages, a new transient commit is generated in
+the experiment's virtual branch each time the code calls
+`dvc.api.make_checkpoint()` or writes a `.dvc/tmp/DVC_CHECKPOINT` signal file.
+See `dvc exp run` for more details
+
+</details>
 
 ## Persistent experiments
 
@@ -92,6 +90,19 @@ have the right `dvc.yaml` and `dvc.lock` file pair, as well as the corresponding
 
 See [Get Started: Experiments](/doc/start/experiments) for a hands-on intro
 guide on regular experiments.
+
+## Automatic log of stage runs (run-cache)
+
+Every time you `dvc repro` pipelines or `dvc exp run` experiments, DVC logs the
+unique signature of each stage run (to `.dvc/cache/runs` by default). If it
+never happened before, the stage command(s) are executed normally. Every
+subsequent time a [stage](/doc/command-reference/run) runs under the same
+conditions, the previous results can be restored instantly, without wasting time
+or computing resources.
+
+✅ This built-in feature is called <abbr>run-cache</abbr> and it can
+dramatically improve performance. It's enabled out-of-the-box (but can be
+disabled with the `--no-run-cache` command option).
 
 ## Organizing experiments
 

--- a/content/docs/user-guide/experiment-management.md
+++ b/content/docs/user-guide/experiment-management.md
@@ -74,7 +74,7 @@ track the progress in deep learning techniques such as evolving neural networks.
 This kind of experiment is also derived fom your latest project version, but it
 tracks a series of variations (the checkpoints). You interact with them using
 `dvc exp run`, `dvc exp resume`, and `dvc exp reset` (see also the `checkpoint`
-field of `dvc.yaml`).
+field of `dvc.yaml` outputs).
 
 <details>
 

--- a/content/docs/user-guide/experiment-management.md
+++ b/content/docs/user-guide/experiment-management.md
@@ -43,24 +43,35 @@ option).
 experiment is captured automatically as a transient commit. Your parent Git repo
 is not cluttered with all these commits. The base workflow goes like this:
 
-- Establish or change the dependencies, parameters, or commands/source code of
-  your stages.
+- Establish or change the <abbr>dependencies</abbr>, <abbr>parameters</abbr>,
+  commands (`cmd` field of `dvc.yaml`), or the source code of your stages.
 - Use `dvc exp run` (instead of `repro`) to execute the pipeline, which creates
   a transient commit that represents this experiment.
 - Visualize the experiments statistics with `dvc exp show`. Repeat.
-- Use metrics in your pipeline to help you identify the best experiment(s), and
-  use `dvc exp apply` to promote them as persistent experiments (regular
-  commits) to the project.
+- Use [metrics](/doc/command-reference/metrics) in your pipeline to help you
+  identify the best experiment(s), and promote them to persistent experiments
+  (regular commits) with `dvc exp apply`.
+
+> See `dvc exp` for more options.
 
 <details>
 
-### What are virtual experiment branches?
+### What are _virtual branches_ and _transient commits_?
 
 DVC uses actual commits under custom
+
 [Git references](https://git-scm.com/book/en/v2/Git-Internals-Git-References)
 (found in `.git/refs/exps`) to keep track of `dvc exp run` branches. The first
-run has the current Git repo's `HEAD` as parent.
+run has the current Git repo's `HEAD` as parent. Each reference has a unique
+signature similar to the entries in the <abbr>run-cache</abbr>.
 
 </details>
 
-> See `dvc exp` for more details.
+## Persistent experiments
+
+> See [Get Started: Experiments](/doc/start/experiments) for a primer.
+
+When your experiments are good enough to save or share, you may want to store
+them persistently as commits in your (Git-enabled) <abbr>repository</abbr>. The
+results may have been produced with `dvc repro` directly, or as a `dvc exp run`
+that gets promoted with `dvc exp apply`.

--- a/content/docs/user-guide/experiment-management.md
+++ b/content/docs/user-guide/experiment-management.md
@@ -1,10 +1,10 @@
 # Experiment Management
 
-Data science and ML are iterative processes that tend to require a large number
-of attempts during their course, for example to develop data features,
-hyperspace exploration, deep learning optimization, etc. DVC helps you codify
-and manage all of your <abbr>experiments</abbr>, supporting these main
-experimentation approaches:
+Data science and ML are iterative processes that require a large number of
+attempts to reach a certain level of a metric. Experimentation is part of the
+development of data features, hyperspace exploration, deep learning
+optimization, etc. DVC helps you codify and manage all of your
+<abbr>experiments</abbr>, supporting these main approaches:
 
 1. Create [ephemeral experiments](#ephemeral-experiments) that derive from your
    latest project version, without having to keep track manually. DVC does that
@@ -21,6 +21,13 @@ experimentation approaches:
    [ways to organize](#organizing-experimentats) experiments in your project (as
    Git branches, as folders, etc.).
 
+DVC also provides specialized features to codify and analyze experiments.
+[Parameters](/doc/command-reference/params) are simple values you can tweak in a
+human-readable text file, which cause different behaviors in your code and
+models. On the other end, [metrics](/doc/command-reference/metrics) (and
+[plots](/doc/command-reference/plots)) let you define, visualize, and compare
+meaningful measures for the experimental results.
+
 ## Ephemeral experiments
 
 ⚠️ This feature is only available in DVC 2.0 ⚠️
@@ -31,7 +38,7 @@ compare, and restore them at any time, or roll back to the baseline. The basic
 workflow goes like this:
 
 - Modify <abbr>dependencies</abbr> (e.g. input data or source code),
-  <abbr>parameters</abbr>, or commands (`cmd` field of `dvc.yaml`) of a
+  <abbr>hyperparameters</abbr>, or commands (`cmd` field of `dvc.yaml`) of a
   committed stage.
 - Use `dvc exp run` (instead of `repro`) to execute the pipeline. This puts the
   experiment's results in your <abbr>workspace</abbr>, and records it under the
@@ -86,13 +93,14 @@ default (see `dvc exp push`).
 When your experiments are good enough to save or share, you may want to store
 them persistently as commits in your <abbr>repository</abbr>.
 
-The results may have been produced with `dvc repro` directly, or after an
-[ephemeral workflow](#ephemeral-experiments). In any case the workspace will
-have the right `dvc.yaml` and `dvc.lock` file pair, as well as the corresponding
-<abbr>outputs</abbr> (via `dvc checkout`).
+Whether the results were produced with `dvc repro` directly, or after an
+[ephemeral workflow](#ephemeral-experiments), the <abbr>workspace</abbr> will
+have a corresponding `dvc.yaml` and `dvc.lock` file pair. The right
+<abbr>outputs</abbr> (including [metrics](/doc/command-reference/metrics)) will
+also be present, or available via `dvc checkout`.
 
-See [Get Started: Experiments](/doc/start/experiments) for a hands-on intro
-guide on regular experiments.
+See [Get Started: Experiments](/doc/start/experiments) for a hands-on
+introduction to regular experiments.
 
 ## Automatic log of stage runs (run-cache)
 

--- a/content/docs/user-guide/experiment-management.md
+++ b/content/docs/user-guide/experiment-management.md
@@ -1,1 +1,39 @@
 # Experiment Management
+
+Data science and ML are iterative processes that tend to require a large number
+of attempts during their course, for example to develop data features,
+hyperspace exploration, model accuracy optimization, etc. DVC is designed to
+help you codify and manage all of your experiments.
+
+Kinds of exps... With DVC, no variation of your code or data is left
+hyperparameters
+
+## Automatic log of stage runs
+
+DVC already caches every change to <abbr>outputs</abbr> when it can (see also
+`dvc status`). Additionally, `dvc repro` and `dvc run` by default populate and
+reutilize a log of stages that have been run in the project, known as the
+<abbr>run-cache</abbr>.
+
+This means that every time you execute [stages](/doc/command-reference/run) with
+DVC, the unique combination that identifies that "run" is saved internally (in
+`.dvc/cache/runs` by default). The corresponding results (typically
+<abbr>cached</abbr>) can later be retrieved in subsequent runs, even if you
+didn't remember that the combination had been tried before!
+
+When this happens, the results are restored instantly, without wasting time or
+computing resources. This can dramatically improve performance, and it's a
+built-in feature that just works out-of-the-box (it can be disabled via the
+`--no-run-cache` option).
+
+## Ephemeral experiments
+
+frequent, transient, brain storming
+
+## Persistent experiments
+
+selected, committed
+
+## Ways to organize experimentation
+
+Implicit vs. Git branches/tags vs. file structures

--- a/content/docs/user-guide/experiment-management.md
+++ b/content/docs/user-guide/experiment-management.md
@@ -29,49 +29,59 @@ stage command(s) are executed normally. Every subsequent time a
 [stage](/doc/command-reference/run) runs under the same conditions, the previous
 results can be restored instantly, without wasting time or computing resources.
 
-✅ This mechanism can dramatically improve performance, and it's a built-in
-feature, enabled out-of-the-box (it can be disabled via the `--no-run-cache`
-option).
+✅ This built-in feature is called <abbr>run-cache</abbr> and it can
+dramatically improve performance. It's enabled out-of-the-box (but can be
+disabled with the `--no-run-cache` command option).
 
 ## Ephemeral experiments
 
 ⚠️ This feature is only available in DVC 2.0, and for Git-enabled
 <abbr>repositories</abbr> ⚠️
 
-`dvc experiments` commands let you run DVC
-[pipelines](/doc/command-reference/dag) in a "virtual branch", so that each
-experiment is captured automatically as a transient commit. Your parent Git repo
-is not cluttered with all these commits. The base workflow goes like this:
+`dvc experiments` commands let you work on DVC
+[pipelines](/doc/command-reference/dag) in a virtual branch, so that each
+experiment is captured automatically in a way that you can visualize later. The
+<abbr>workspace</abbr> may reflect each experiment's results for you to check,
+but there's no need to save them manually. The base workflow goes like this:
 
-- Establish or change the <abbr>dependencies</abbr>, <abbr>parameters</abbr>,
-  commands (`cmd` field of `dvc.yaml`), or the source code of your stages.
+- Establish or change the <abbr>dependencies</abbr> (e.g. input data or source
+  code), <abbr>parameters</abbr>, or commands (`cmd` field of `dvc.yaml`) of
+  your stages.
 - Use `dvc exp run` (instead of `repro`) to execute the pipeline, which creates
-  a transient commit that represents this experiment.
+  a transient commit that records this experiment.
 - Visualize the experiments statistics with `dvc exp show`. Repeat.
-- Use [metrics](/doc/command-reference/metrics) in your pipeline to help you
-  identify the best experiment(s), and promote them to persistent experiments
-  (regular commits) with `dvc exp apply`.
-
-> See `dvc exp` for more options.
+- Use [metrics](/doc/command-reference/metrics) in your pipeline to identify the
+  best experiment(s), and promote them to persistent experiments (regular
+  commits) with `dvc exp apply`.
 
 <details>
 
 ### What are _virtual branches_ and _transient commits_?
 
 DVC uses actual commits under custom
-
 [Git references](https://git-scm.com/book/en/v2/Git-Internals-Git-References)
 (found in `.git/refs/exps`) to keep track of `dvc exp run` branches. The first
-run has the current Git repo's `HEAD` as parent. Each reference has a unique
-signature similar to the entries in the <abbr>run-cache</abbr>.
+experiment has the Git repo's `HEAD` as parent. Each reference has a unique
+signature similar to the
+[entries in the run-cache](/doc/user-guide/project-structure/internal-files#run-cache).
 
 </details>
 
+Note that `dvc exp run` also logs and reuses
+[stage runs](#automatic-log-of-stage-runs-run-cache) in the
+<abbr>run-cache</abbr> by default.
+
+> See `dvc exp` for more details and other commands.
+
 ## Persistent experiments
 
-> See [Get Started: Experiments](/doc/start/experiments) for a primer.
-
 When your experiments are good enough to save or share, you may want to store
-them persistently as commits in your (Git-enabled) <abbr>repository</abbr>. The
-results may have been produced with `dvc repro` directly, or as a `dvc exp run`
-that gets promoted with `dvc exp apply`.
+them persistently as commits in your (Git-enabled) <abbr>repository</abbr>.
+
+The results may have been produced with `dvc repro` directly, or after an
+[ephemeral workflow](#ephemeral-experiments). In any case the workspace will
+have the right `dvc.yaml` and `dvc.lock` file pair, as well as the corresponding
+<abbr>outputs</abbr> (via `dvc checkout`).
+
+See [Get Started: Experiments](/doc/start/experiments) for a hands-on intro
+guide on regular experiments.

--- a/content/docs/user-guide/experiment-management.md
+++ b/content/docs/user-guide/experiment-management.md
@@ -2,56 +2,45 @@
 
 Data science and ML are iterative processes that tend to require a large number
 of attempts during their course, for example to develop data features,
-hyperspace exploration, deep learning optimization, etc. DVC is designed to help
-you codify and manage all of your experiments.
+hyperspace exploration, deep learning optimization, etc. DVC helps you codify
+and manage all of your <abbr>experiments</abbr>, considering the following
+levels at which they may exist:
 
-DVC considers certain levels at which the variants of your work are considered
-_experiments_:
+0. Tests you do on you own (without DVC knowing) — that's all you!
+1. DVC enters the scene with an automatic log of every stage `dvc repro` runs.
+2. Create [ephemeral experiments](#ephemeral-experiments) that virtually branch
+   off your current workspace. You can start **automating** them at this point,
+   and quickly visualize and compare them from terminal. The best ones can be
+   promoted to the next level, and the rest archived.
+3. [Persistent experiments](#persistent-experiments) have their results
+   **committed** to Git. They can be selected from previous levels, or created
+   from scratch. This is where you may want to consider the different
+   [ways to organize](#organizing-experimentats) them in your project (as
+   branches, folders, etc.).
 
-0. Tests you do on you own without DVC knowing about them — we can't help with
-   that!
-1. An automatic log of every stage run through `dvc repro` is the entry point
-   for DVC.
-2. _Ephemeral experiments_ can be setup in virtual project branches. This is
-   where you can start **automating** their execution and generate reports
-   comparing many of them. At some point a few are selected/promoted, and the
-   rest can be abandoned.
-3. _Persistent experiments_ can be picked up from previous levels, or they can
-   be registered manually by **committed** their results to Git. This is where
-   you may want to start thinking about the different ways to
-   [organize](#organizing-experimentats) them in your project (branches,
-   folders, etc.).
+> Note that DVC assumes that all experiments are deterministic (see **Avoiding
+> unexpected behavior** in `dvc run`).
 
 ## Automatic log of stage runs (run-cache)
 
-Every time you `dvc repro` each stage [stages](/doc/command-reference/run), DVC
-determines a unique identifier of each stage "run" (logged to `.dvc/cache/runs`
-by default). If it never happened before, the stage command(s) are executed and
-their <abbr>outputs</abbr> cached normally. Every subsequent time the stage runs
-under the same conditions, those results can be restored instantly, without
-wasting time or computing resources.
+Every time you `dvc repro` stages, DVC logs the unique signature of that "run"
+(to `.dvc/cache/runs` by default). If it never happened before, the stage
+command(s) are executed normally. Every subsequent time the
+[stage](/doc/command-reference/run) runs under the same conditions, the previous
+results can be restored instantly, without wasting time or computing resources.
 
-This mechanism can dramatically improve performance, and it's a built-in
+✅ This mechanism can dramatically improve performance, and it's a built-in
 feature, enabled out-of-the-box (it can be disabled via the `--no-run-cache`
 option).
 
-> Note that the run-cache assumes that stage commands are deterministic (see
-> **Avoiding unexpected behavior** in `dvc run`).
-
 ## Ephemeral experiments
 
-Unique stage runs can be identified by the combination of their dependencies
-(including params) and the command(s) to execute.
-
-Every run of a stage or pipeline can be considered an experiment. These are
-identified by the exact combination of dependencies, , and
-
-frequent, transient, brain storming
+...
 
 ## Persistent experiments
 
-selected, committed
+...
 
 ## Organizing experiments
 
-Implicit vs. Git branches/tags vs. file structures
+...

--- a/content/docs/user-guide/experiment-management.md
+++ b/content/docs/user-guide/experiment-management.md
@@ -6,12 +6,12 @@ hyperspace exploration, deep learning optimization, etc. DVC helps you codify
 and manage all of your <abbr>experiments</abbr>, considering the following
 levels at which they may exist:
 
-0. Tests you do on you own (without DVC knowing) — that's all you!
 1. DVC enters the scene with an automatic log of every stage `dvc repro` runs.
-2. Create [ephemeral experiments](#ephemeral-experiments) that virtually branch
-   off your current workspace. You can start **automating** them at this point,
-   and quickly visualize and compare them from terminal. The best ones can be
-   promoted to the next level, and the rest archived.
+2. Create [ephemeral experiments](#ephemeral-experiments) and
+   [in-code checkpoints](#checkpoints-in-python-code) that virtually branch off
+   your current workspace. DVC lets you quickly visualize and compare them from
+   terminal. The best ones can be promoted to the next level, and the rest
+   archived.
 3. [Persistent experiments](#persistent-experiments) have their results
    **committed** to Git. They can be selected from previous levels, or created
    from scratch. This is where you may want to consider the different
@@ -48,8 +48,8 @@ this:
 - Modify <abbr>dependencies</abbr> (e.g. input data or source code),
   <abbr>parameters</abbr>, or commands (`cmd` field of `dvc.yaml`) of a
   committed stage.
-- Use `dvc exp run` (instead of `repro`) to execute the pipeline, which creates
-  a transient commit that records this experiment.
+- Use `dvc exp run` (instead of `repro`) to execute the pipeline. This creates a
+  transient commit that records this experiment.
 - Visualize the experiments statistics with `dvc exp show`. Repeat.
 - Use [metrics](/doc/command-reference/metrics) in your pipeline to identify the
   best experiment(s), and promote them to persistent experiments (regular
@@ -75,6 +75,10 @@ Note that `dvc exp run` also logs and reuses
 <abbr>run-cache</abbr> by default.
 
 > See `dvc exp` for more details and other commands.
+
+## Checkpoints in Python code
+
+...
 
 ## Persistent experiments
 

--- a/content/docs/user-guide/experiment-management.md
+++ b/content/docs/user-guide/experiment-management.md
@@ -85,3 +85,17 @@ have the right `dvc.yaml` and `dvc.lock` file pair, as well as the corresponding
 
 See [Get Started: Experiments](/doc/start/experiments) for a hands-on intro
 guide on regular experiments.
+
+## Organizing experiments
+
+Automatic [stage run logs](#automatic-log-of-stage-runs-run-cache) are dumped
+without a structure in the <abbr>run-cache</abbr>.
+[Ephemeral experiments](#ephemeral-experiments) always have a linear branch
+structure (a queue) based on current `HEAD` commit. But when it comes to
+full-blown [persistent experiments](#persistent-experiments), it's up to you to
+decide how to organize them in your project. These are the main alternatives:
+
+- Branches
+- Tags
+- Directories
+- Hybrid

--- a/content/docs/user-guide/experiment-management.md
+++ b/content/docs/user-guide/experiment-management.md
@@ -23,38 +23,36 @@ experimentation approaches:
 
 ## Ephemeral experiments
 
-⚠️ This feature is only available in DVC 2.0, and for Git-enabled
-<abbr>repositories</abbr> ⚠️
+⚠️ This feature is only available in DVC 2.0 ⚠️
 
-`dvc experiments` commands let you work on DVC
-[pipelines](/doc/command-reference/dag) in a virtual branch, so that each
-experiment is captured automatically in a way that you can review and roll back
-later. The <abbr>workspace</abbr> may reflect each experiment's results for you
-to check, but there's no need to save them manually. The base workflow goes like
+`dvc exp` commands let you automatically track variations to established DVC
+[pipelines](/doc/command-reference/dag), so you can review, compare, and restore
+them at any time, or roll back to the baseline. The base workflow goes like
 this:
 
 - Modify <abbr>dependencies</abbr> (e.g. input data or source code),
   <abbr>parameters</abbr>, or commands (`cmd` field of `dvc.yaml`) of a
   committed stage.
-- Use `dvc exp run` (instead of `repro`) to execute the pipeline. This creates a
-  transient commit that records this experiment.
-- Visualize the experiments statistics with `dvc exp show`. Repeat.
+- Use `dvc exp run` (instead of `repro`) to execute the pipeline. This puts the
+  experiment's results in your <abbr>workspace</abbr>, and records it under the
+  hood.
+- Visualize experiment configurations and results with `dvc exp show`. Repeat.
 - Use [metrics](/doc/command-reference/metrics) in your pipeline to identify the
   best experiment(s), and promote them to persistent experiments (regular
   commits) with `dvc exp apply`.
 
 <details>
 
-### What are _virtual branches_ and _transient commits_?
+### How does DVC capture these experiments?
 
 DVC uses actual commits under custom
 [Git references](https://git-scm.com/book/en/v2/Git-Internals-Git-References)
-(found in `.git/refs/exps`) to keep track of `dvc exp run` branches. These are
-not pushed to the Git remote by default (see `dvc exp push`).
+(found in `.git/refs/exps`) to keep track of ephemeral experiments. Each commit
+has the Git repo's `HEAD` as parent. These are not pushed to the Git remote by
+default (see `dvc exp push`).
 
-The first transient commits has the Git repo's `HEAD` as parent, and the rest
-branch off there. Each reference has a unique signature similar to the
-[entries in the run-cache](/doc/user-guide/project-structure/internal-files#run-cache).
+> References have a unique signature similar to the
+> [entries in the run-cache](/doc/user-guide/project-structure/internal-files#run-cache).
 
 </details>
 
@@ -62,8 +60,7 @@ branch off there. Each reference has a unique signature similar to the
 
 ## Checkpoints in Python code
 
-⚠️ This feature is only available in DVC 2.0, and for Git-enabled
-<abbr>repositories</abbr> ⚠️
+⚠️ This feature is only available in DVC 2.0 ⚠️
 
 ...
 
@@ -71,17 +68,18 @@ branch off there. Each reference has a unique signature similar to the
 
 ### How are checkpoints captured by DVC?
 
-When DVC runs checkpoint-enabled stages, a new transient commit is generated in
-the experiment's virtual branch each time the code calls
-`dvc.api.make_checkpoint()` or writes a `.dvc/tmp/DVC_CHECKPOINT` signal file.
-See `dvc exp run` for more details
+When DVC runs checkpoint-enabled stages, a new commit is generated in a custom
+Git branch (found in `.git/refs/exps`) each time the code calls
+`dvc.api.make_checkpoint()` or writes a `.dvc/tmp/DVC_CHECKPOINT` signal file
+(see `dvc exp run` for info). These are not pushed to the Git remote by default
+(see `dvc exp push`).
 
 </details>
 
 ## Persistent experiments
 
 When your experiments are good enough to save or share, you may want to store
-them persistently as commits in your (Git-enabled) <abbr>repository</abbr>.
+them persistently as commits in your <abbr>repository</abbr>.
 
 The results may have been produced with `dvc repro` directly, or after an
 [ephemeral workflow](#ephemeral-experiments). In any case the workspace will

--- a/content/docs/user-guide/experiment-management.md
+++ b/content/docs/user-guide/experiment-management.md
@@ -23,9 +23,9 @@ levels at which they may exist:
 
 ## Automatic log of stage runs (run-cache)
 
-Every time you `dvc repro` stages, DVC logs the unique signature of that "run"
-(to `.dvc/cache/runs` by default). If it never happened before, the stage
-command(s) are executed normally. Every subsequent time the
+Every time you `dvc repro` pipelines, DVC logs the unique signature of each
+stage run (to `.dvc/cache/runs` by default). If it never happened before, the
+stage command(s) are executed normally. Every subsequent time a
 [stage](/doc/command-reference/run) runs under the same conditions, the previous
 results can be restored instantly, without wasting time or computing resources.
 
@@ -35,12 +35,32 @@ option).
 
 ## Ephemeral experiments
 
-...
+⚠️ This feature is only available in DVC 2.0, and for Git-enabled
+<abbr>repositories</abbr> ⚠️
 
-## Persistent experiments
+`dvc experiments` commands let you run DVC
+[pipelines](/doc/command-reference/dag) in a "virtual branch", so that each
+experiment is captured automatically as a transient commit. Your parent Git repo
+is not cluttered with all these commits. The base workflow goes like this:
 
-...
+- Establish or change the dependencies, parameters, or commands/source code of
+  your stages.
+- Use `dvc exp run` (instead of `repro`) to execute the pipeline, which creates
+  a transient commit that represents this experiment.
+- Visualize the experiments statistics with `dvc exp show`. Repeat.
+- Use metrics in your pipeline to help you identify the best experiment(s), and
+  use `dvc exp apply` to promote them as persistent experiments (regular
+  commits) to the project.
 
-## Organizing experiments
+<details>
 
-...
+### What are virtual experiment branches?
+
+DVC uses actual commits under custom
+[Git references](https://git-scm.com/book/en/v2/Git-Internals-Git-References)
+(found in `.git/refs/exps`) to keep track of `dvc exp run` branches. The first
+run has the current Git repo's `HEAD` as parent.
+
+</details>
+
+> See `dvc exp` for more details.

--- a/content/docs/user-guide/experiment-management.md
+++ b/content/docs/user-guide/experiment-management.md
@@ -2,31 +2,49 @@
 
 Data science and ML are iterative processes that tend to require a large number
 of attempts during their course, for example to develop data features,
-hyperspace exploration, model accuracy optimization, etc. DVC is designed to
-help you codify and manage all of your experiments.
+hyperspace exploration, deep learning optimization, etc. DVC is designed to help
+you codify and manage all of your experiments.
 
-Kinds of exps... With DVC, no variation of your code or data is left
-hyperparameters
+DVC considers certain levels at which the variants of your work are considered
+_experiments_:
 
-## Automatic log of stage runs
+0. Tests you do on you own without DVC knowing about them — we can't help with
+   that!
+1. An automatic log of every stage run through `dvc repro` is the entry point
+   for DVC.
+2. _Ephemeral experiments_ can be setup in virtual project branches. This is
+   where you can start **automating** their execution and generate reports
+   comparing many of them. At some point a few are selected/promoted, and the
+   rest can be abandoned.
+3. _Persistent experiments_ can be picked up from previous levels, or they can
+   be registered manually by **committed** their results to Git. This is where
+   you may want to start thinking about the different ways to
+   [organize](#organizing-experimentats) them in your project (branches,
+   folders, etc.).
 
-DVC already caches every change to <abbr>outputs</abbr> when it can (see also
-`dvc status`). Additionally, `dvc repro` and `dvc run` by default populate and
-reutilize a log of stages that have been run in the project, known as the
-<abbr>run-cache</abbr>.
+## Automatic log of stage runs (run-cache)
 
-This means that every time you execute [stages](/doc/command-reference/run) with
-DVC, the unique combination that identifies that "run" is saved internally (in
-`.dvc/cache/runs` by default). The corresponding results (typically
-<abbr>cached</abbr>) can later be retrieved in subsequent runs, even if you
-didn't remember that the combination had been tried before!
+Every time you `dvc repro` each stage [stages](/doc/command-reference/run), DVC
+determines a unique identifier of each stage "run" (logged to `.dvc/cache/runs`
+by default). If it never happened before, the stage command(s) are executed and
+their <abbr>outputs</abbr> cached normally. Every subsequent time the stage runs
+under the same conditions, those results can be restored instantly, without
+wasting time or computing resources.
 
-When this happens, the results are restored instantly, without wasting time or
-computing resources. This can dramatically improve performance, and it's a
-built-in feature that just works out-of-the-box (it can be disabled via the
-`--no-run-cache` option).
+This mechanism can dramatically improve performance, and it's a built-in
+feature, enabled out-of-the-box (it can be disabled via the `--no-run-cache`
+option).
+
+> Note that the run-cache assumes that stage commands are deterministic (see
+> **Avoiding unexpected behavior** in `dvc run`).
 
 ## Ephemeral experiments
+
+Unique stage runs can be identified by the combination of their dependencies
+(including params) and the command(s) to execute.
+
+Every run of a stage or pipeline can be considered an experiment. These are
+identified by the exact combination of dependencies, , and
 
 frequent, transient, brain storming
 
@@ -34,6 +52,6 @@ frequent, transient, brain storming
 
 selected, committed
 
-## Ways to organize experimentation
+## Organizing experiments
 
 Implicit vs. Git branches/tags vs. file structures

--- a/content/docs/user-guide/experiment-management.md
+++ b/content/docs/user-guide/experiment-management.md
@@ -6,19 +6,19 @@ development of data features, hyperspace exploration, deep learning
 optimization, etc. DVC helps you codify and manage all of your
 <abbr>experiments</abbr>, supporting these main approaches:
 
-1. Create [ephemeral experiments](#ephemeral-experiments) that derive from your
-   latest project version, without having to keep track manually. DVC does that
-   for you, letting you list and compare them. The best ones can be promoted,
-   and the rest archived.
-2. Place [in-code checkpoints](#checkpoints-in-source-code) that form series of
-   (ephemeral) experiments. DVC helps you capture them at runtime, and manage
-   them as batches.
-3. [Persistent experiments](#persistent-experiments) have their results
-   **committed** to Git. They can be selected from existing attempts, or created
-   from scratch.
+1. Create [experiments](#experiments) that derive from your latest project
+   version without having to track them manually. DVC does that automatically,
+   letting you list and compare them. The best ones can be promoted, and the
+   rest archived.
+2. Place in-code [checkpoints](#checkpoints-in-source-code) that mark a series
+   of variations, forming an in-depth experiment. DVC helps you capture them at
+   runtime, and manage them in batches.
+3. Apply experiments or checkpoints as [persistent](#persistent-experiments)
+   commits in your <abbr>repository</abbr>. Or create these versions from
+   scratch like typical project changes.
 
    At this point you may also want to consider the different
-   [ways to organize](#organizing-experimentats) experiments in your project (as
+   [ways to organize](#organization-patterns) experiments in your project (as
    Git branches, as folders, etc.).
 
 DVC also provides specialized features to codify and analyze experiments.
@@ -28,20 +28,20 @@ models. On the other end, [metrics](/doc/command-reference/metrics) (and
 [plots](/doc/command-reference/plots)) let you define, visualize, and compare
 meaningful measures for the experimental results.
 
-## Ephemeral experiments
+## Experiments
 
 ⚠️ This feature is only available in DVC 2.0 ⚠️
 
-`dvc exp` commands let you automatically track multiple variations to
-established DVC [pipelines](/doc/command-reference/dag), so you can review,
-compare, and restore them at any time, or roll back to the baseline. The basic
-workflow goes like this:
+`dvc exp` commands let you automatically track a variation to an established
+[data pipeline](/doc/command-reference/dag). You can create multiple isolated
+experiments this way, as well as review, compare, and restore them later, or
+roll back to the baseline. The basic workflow goes like this:
 
 - Modify <abbr>dependencies</abbr> (e.g. input data or source code),
-  <abbr>hyperparameters</abbr>, or commands (`cmd` field of `dvc.yaml`) of a
-  committed stage.
+  <abbr>hyperparameters</abbr>, or commands (`cmd` field of `dvc.yaml`) of
+  committed stages.
 - Use `dvc exp run` (instead of `repro`) to execute the pipeline. This puts the
-  experiment's results in your <abbr>workspace</abbr>, and records it under the
+  experiment's results in your <abbr>workspace</abbr>, and tracks it under the
   hood.
 - Visualize experiment configurations and results with `dvc exp show`. Repeat.
 - Use [metrics](/doc/command-reference/metrics) in your pipeline to identify the
@@ -50,13 +50,13 @@ workflow goes like this:
 
 <details>
 
-### How does DVC capture these experiments?
+### How does DVC track experiments?
 
 DVC uses actual commits under custom
 [Git references](https://git-scm.com/book/en/v2/Git-Internals-Git-References)
-(found in `.git/refs/exps`) to keep track of ephemeral experiments. Each commit
-has the repo `HEAD` as parent. These are not pushed to the Git remote by default
-(see `dvc exp push`).
+(found in `.git/refs/exps`) to keep track of experiments created with `dvc exp`.
+Each commit has the repo `HEAD` as parent. These are not pushed to the Git
+remote by default (see `dvc exp push`).
 
 > References have a unique signature similar to the
 > [entries in the run-cache](/doc/user-guide/project-structure/internal-files#run-cache).
@@ -72,9 +72,9 @@ registers checkpoints with DVC at runtime. This allows you, for example, to
 track the progress in deep learning techniques such as evolving neural networks.
 
 This kind of experiment is also derived fom your latest project version, but it
-can contain a series of variations (the checkpoints). You mainly interact with
-them using `dvc exp run`, `dvc exp resume`, and `dvc exp reset`. See also the
-`checkpoint` field of `dvc.yaml`.
+tracks a series of variations (the checkpoints). You interact with them using
+`dvc exp run`, `dvc exp resume`, and `dvc exp reset` (see also the `checkpoint`
+field of `dvc.yaml`).
 
 <details>
 
@@ -93,14 +93,36 @@ default (see `dvc exp push`).
 When your experiments are good enough to save or share, you may want to store
 them persistently as commits in your <abbr>repository</abbr>.
 
-Whether the results were produced with `dvc repro` directly, or after an
-[ephemeral workflow](#ephemeral-experiments), the <abbr>workspace</abbr> will
-have a corresponding `dvc.yaml` and `dvc.lock` file pair. The right
-<abbr>outputs</abbr> (including [metrics](/doc/command-reference/metrics)) will
-also be present, or available via `dvc checkout`.
+Whether the results were produced with `dvc repro` directly, or after a
+`dvc exp` workflow (refer to previous sections), the `dvc.yaml` and `dvc.lock`
+pair in the <abbr>workspace</abbr> will codify the experiment as a new project
+version. The right <abbr>outputs</abbr> (including
+[metrics](/doc/command-reference/metrics)) should also be present, or available
+via `dvc checkout`.
 
-See [Get Started: Experiments](/doc/start/experiments) for a hands-on
-introduction to regular experiments.
+> 👨‍💻 See [Get Started: Experiments](/doc/start/experiments) for a hands-on
+> introduction to regular experiments.
+
+### Organization patterns
+
+DVC takes care of arranging `dvc exp` experiments and the data
+<abbr>cache</abbr> under the hood. But when it comes to full-blown persistent
+experiments, it's up to you to decide how to organize them in your project.
+These are the main alternatives:
+
+- **Git tags and branches** - use the repo's "time dimension" to distribute your
+  experiments. This makes the most sense for experiments that build on each
+  other. Helpful if the Git [revisions](https://git-scm.com/docs/revisions) can
+  be easily visualized, for example with tools
+  [like GitHub](https://docs.github.com/en/github/visualizing-repository-data-with-graphs/viewing-a-repositorys-network).
+- **Directories** - the project's "space dimension" can be structured with
+  directories (folders) to organize experiments. Useful when you want to see all
+  your experiments at the same time (without switching versions) by just
+  exploring the file system.
+- **Hybrid** - combining an intuitive directory structure with a good repo
+  branching strategy tends to be the best option for complex projects.
+  Completely independent experiments live in separate directories, while their
+  progress can be found in different branches.
 
 ## Automatic log of stage runs (run-cache)
 
@@ -114,17 +136,3 @@ or computing resources.
 ✅ This built-in feature is called <abbr>run-cache</abbr> and it can
 dramatically improve performance. It's enabled out-of-the-box (but can be
 disabled with the `--no-run-cache` command option).
-
-## Organizing experiments
-
-Automatic [stage run logs](#automatic-log-of-stage-runs-run-cache) are dumped
-without a structure in the <abbr>run-cache</abbr>.
-[Ephemeral experiments](#ephemeral-experiments) always have a linear branch
-structure (a queue) based on current `HEAD` commit. But when it comes to
-full-blown [persistent experiments](#persistent-experiments), it's up to you to
-decide how to organize them in your project. These are the main alternatives:
-
-- Branches
-- Tags
-- Directories
-- Hybrid

--- a/content/docs/user-guide/experiment-management.md
+++ b/content/docs/user-guide/experiment-management.md
@@ -10,7 +10,7 @@ experimentation approaches:
    latest project version, without having to keep track manually. DVC does that
    for you, letting you list and compare them. The best ones can be promoted,
    and the rest archived.
-2. Place [in-code checkpoints](#checkpoints-in-python-code) that form series of
+2. Place [in-code checkpoints](#checkpoints-in-source-code) that form series of
    (ephemeral) experiments. DVC helps you capture them at runtime, and manage
    them as batches.
 3. [Persistent experiments](#persistent-experiments) have their results
@@ -25,10 +25,10 @@ experimentation approaches:
 
 ⚠️ This feature is only available in DVC 2.0 ⚠️
 
-`dvc exp` commands let you automatically track variations to established DVC
-[pipelines](/doc/command-reference/dag), so you can review, compare, and restore
-them at any time, or roll back to the baseline. The base workflow goes like
-this:
+`dvc exp` commands let you automatically track multiple variations to
+established DVC [pipelines](/doc/command-reference/dag), so you can review,
+compare, and restore them at any time, or roll back to the baseline. The basic
+workflow goes like this:
 
 - Modify <abbr>dependencies</abbr> (e.g. input data or source code),
   <abbr>parameters</abbr>, or commands (`cmd` field of `dvc.yaml`) of a
@@ -48,31 +48,36 @@ this:
 DVC uses actual commits under custom
 [Git references](https://git-scm.com/book/en/v2/Git-Internals-Git-References)
 (found in `.git/refs/exps`) to keep track of ephemeral experiments. Each commit
-has the Git repo's `HEAD` as parent. These are not pushed to the Git remote by
-default (see `dvc exp push`).
+has the repo `HEAD` as parent. These are not pushed to the Git remote by default
+(see `dvc exp push`).
 
 > References have a unique signature similar to the
 > [entries in the run-cache](/doc/user-guide/project-structure/internal-files#run-cache).
 
 </details>
 
-> See `dvc exp` for more details and other commands.
-
-## Checkpoints in Python code
+## Checkpoints in source code
 
 ⚠️ This feature is only available in DVC 2.0 ⚠️
 
-...
+To track successive steps in a longer experiment, you can write your code so it
+registers checkpoints with DVC at runtime. This allows you, for example, to
+track the progress in deep learning techniques such as evolving neural networks.
+
+This kind of experiment is also derived fom your latest project version, but it
+can contain a series of variations (the checkpoints). You mainly interact with
+them using `dvc exp run`, `dvc exp resume`, and `dvc exp reset`. See also the
+`checkpoint` field of `dvc.yaml`.
 
 <details>
 
 ### How are checkpoints captured by DVC?
 
-When DVC runs checkpoint-enabled stages, a new commit is generated in a custom
-Git branch (found in `.git/refs/exps`) each time the code calls
-`dvc.api.make_checkpoint()` or writes a `.dvc/tmp/DVC_CHECKPOINT` signal file
-(see `dvc exp run` for info). These are not pushed to the Git remote by default
-(see `dvc exp push`).
+When DVC runs a checkpoint-enabled pipeline, a custom Git branch (in
+`.git/refs/exps`) is started off the repo `HEAD`. A new commit is appended each
+time the code calls `dvc.api.make_checkpoint()` or writes a
+`.dvc/tmp/DVC_CHECKPOINT` signal file. These are not pushed to the Git remote by
+default (see `dvc exp push`).
 
 </details>
 

--- a/content/docs/user-guide/project-structure/internal-files.md
+++ b/content/docs/user-guide/project-structure/internal-files.md
@@ -131,9 +131,10 @@ That's how DVC knows that the other two cached files belong in the directory.
 have been run in the project. It is found in the `runs/` directory inside the
 cache (or [remote storage](/doc/command-reference/remote)).
 
-Runs are identified as combinations of <abbr>dependencies</abbr>, commands, and
-<abbr>outputs</abbr> that correspond to each other. These combinations are
-hashed into special values that make up the file paths inside the run-cache dir.
+Runs are identified as combinations of exact <abbr>dependency</abbr> contents
+(or [parameter](/doc/command-reference/params) values), and the literal
+command(s) to execute. These combinations are represented by special hashes that
+translate to the file paths inside the run-cache dir:
 
 ```dvc
 $ tree .dvc/cache/runs
@@ -151,3 +152,6 @@ run.
 
 💡 `dvc push` and `dvc pull` (and `dvc fetch`) can download and upload the
 run-cache to remote storage for sharing and/or as a back up.
+
+> Note that the run-cache assumes that stage commands are deterministic (see
+> **Avoiding unexpected behavior** in `dvc run`).

--- a/content/docs/user-guide/project-structure/pipelines-files.md
+++ b/content/docs/user-guide/project-structure/pipelines-files.md
@@ -353,7 +353,6 @@ These are the fields that are accepted in each stage:
 | `metrics`        | List of [metrics files](/doc/command-reference/metrics), and optionally, whether or not this metrics file is <abbr>cached</abbr> (`true` by default). See the `--metrics-no-cache` (`-M`) option of `dvc run`.                                                                            |
 | `plots`          | List of [plot metrics](/doc/command-reference/plots), and optionally, their default configuration (subfields matching the options of `dvc plots modify`), and whether or not this plots file is <abbr>cached</abbr> ( `true` by default). See the `--plots-no-cache` option of `dvc run`. |
 | `frozen`         | Whether or not this stage is frozen from reproduction                                                                                                                                                                                                                                     |
-| `checkpoint`     | Set to `true` to let DVC know this stage registers [in-code checkpoint](/doc/user-guide/experiment-management#checkpoints-in-source-code) experiments.                                                                                                                                    |
 | `always_changed` | Whether or not this stage is considered as changed by commands such as `dvc status` and `dvc repro`. `false` by default                                                                                                                                                                   |
 | `meta`           | (Optional) arbitrary metadata can be added manually with this field. Any YAML content is supported. `meta` contents are ignored by DVC, but they can be meaningful for user processes that read or write `.dvc` files directly.                                                           |
 | `desc`           | (Optional) user description for this stage. This doesn't affect any DVC operations.                                                                                                                                                                                                       |
@@ -374,11 +373,12 @@ validation and auto-completion.
 > Notice that these are a subset of those in `.dvc` file
 > [output entries](/doc/user-guide/project-structure/dvc-files#output-entries).
 
-| Field     | Description                                                                                                                                |
-| --------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
-| `cache`   | Whether or not this file or directory is <abbr>cached</abbr> (`true` by default). See the `--no-commit` option of `dvc add`.               |
-| `persist` | Whether the output file/dir should remain in place while `dvc repro` runs (`false` by default: outputs are deleted when `dvc repro` starts |
-| `desc`    | (Optional) user description for this output. This doesn't affect any DVC operations.                                                       |
+| Field        | Description                                                                                                                                                                        |
+| ------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `cache`      | Whether or not this file or directory is <abbr>cached</abbr> (`true` by default). See the `--no-commit` option of `dvc add`.                                                       |
+| `persist`    | Whether the output file/dir should remain in place while `dvc repro` runs (`false` by default: outputs are deleted when `dvc repro` starts                                         |
+| `desc`       | (Optional) user description for this output. This doesn't affect any DVC operations.                                                                                               |
+| `checkpoint` | Set to `true` to let DVC know that this output is associated with [in-code checkpoints](/doc/user-guide/experiment-management#checkpoints-in-source-code) (for `dvc experiments`). |
 
 ## dvc.lock file
 

--- a/content/docs/user-guide/project-structure/pipelines-files.md
+++ b/content/docs/user-guide/project-structure/pipelines-files.md
@@ -44,6 +44,8 @@ changed to decide whether the stage requires re-execution (see `dvc status`).
 If it writes files or dirs, they can be defined as <abbr>outputs</abbr>
 (`outs`). DVC will track them going forward (similar to using `dvc add`).
 
+> See the full stage entry [specification](#stage-entries).
+
 ### Parameter dependencies
 
 [Parameters](/doc/command-reference/params) are a special type of stage
@@ -337,7 +339,9 @@ stages:
 > Note that this feature is not compatible with [templating](#templating) at the
 > moment.
 
-## Specification
+## Stage entries
+
+These are the fields that are accepted in each stage:
 
 | Field            | Description                                                                                                                                                                                                                                                                               |
 | ---------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -349,6 +353,7 @@ stages:
 | `metrics`        | List of [metrics files](/doc/command-reference/metrics), and optionally, whether or not this metrics file is <abbr>cached</abbr> (`true` by default). See the `--metrics-no-cache` (`-M`) option of `dvc run`.                                                                            |
 | `plots`          | List of [plot metrics](/doc/command-reference/plots), and optionally, their default configuration (subfields matching the options of `dvc plots modify`), and whether or not this plots file is <abbr>cached</abbr> ( `true` by default). See the `--plots-no-cache` option of `dvc run`. |
 | `frozen`         | Whether or not this stage is frozen from reproduction                                                                                                                                                                                                                                     |
+| `checkpoint`     | Set to `true` to let DVC know this stage registers [in-code checkpoint](/doc/user-guide/experiment-management#checkpoints-in-source-code) experiments.                                                                                                                                    |
 | `always_changed` | Whether or not this stage is considered as changed by commands such as `dvc status` and `dvc repro`. `false` by default                                                                                                                                                                   |
 | `meta`           | (Optional) arbitrary metadata can be added manually with this field. Any YAML content is supported. `meta` contents are ignored by DVC, but they can be meaningful for user processes that read or write `.dvc` files directly.                                                           |
 | `desc`           | (Optional) user description for this stage. This doesn't affect any DVC operations.                                                                                                                                                                                                       |

--- a/content/docs/user-guide/related-technologies.md
+++ b/content/docs/user-guide/related-technologies.md
@@ -82,6 +82,9 @@ _Luigi_, etc.
 
 ## Experiment management software
 
+> See also the [Experiment Management](/doc/user-guide/experiment-management)
+> guide.
+
 - DVC uses Git as the underlying version control layer for data, pipelines, and
   experiments. Data versions exist as metadata in Git, as opposed to using
   external databases or APIs, so no additional services are required.

--- a/content/docs/user-guide/what-is-dvc.md
+++ b/content/docs/user-guide/what-is-dvc.md
@@ -1,10 +1,11 @@
 # What Is DVC?
 
 **Data Version Control** is a new type of data versioning, workflow, and
-experiment management software, that builds upon [Git](https://git-scm.com/)
-(although it can work stand-alone). DVC reduces the gap between established
-engineering tool sets and data science needs, allowing users to take advantage
-of new [features](#core-features) while reusing existing skills and intuition.
+[experiment management](/doc/user-guide/experiment-management) software, that
+builds upon [Git](https://git-scm.com/) (although it can work stand-alone). DVC
+reduces the gap between established engineering tool sets and data science
+needs, allowing users to take advantage of new [features](#core-features) while
+reusing existing skills and intuition.
 
 ![](/img/reproducibility.png) _DVC codifies data and ML experiments_
 


### PR DESCRIPTION
To support the new 2.0 features (`dvc exp`) per #2026. Closes #816

- New guide doc (main file to review): [content/docs/user-guide/experiment-management.md](https://github.com/iterative/dvc.org/pull/2146/files#diff-be6aa503d0cf32633b8a90ecca42b73c0059fd54c83ea20dc55406a9e549aaa8)
- Relevant links to ^ from existing docs
- Intros "experiment" tooltip
- Add `checkpoint` field to dvc.yaml outputs spec
- Update "run-cache" tooltip + some copy edits on that topic

---

Based on https://github.com/iterative/dvc/wiki/Experiments#usage, et al.

> May reuse some stuff from https://github.com/iterative/dvc.org/pull/828/files
