### PR TITLE
upgrades prettier to 2.2.1 to fix the bug causing trailingComma config to be ignored

### DIFF
--- a/content/docs/user-guide/basic-concepts/dvc-project.md
+++ b/content/docs/user-guide/basic-concepts/dvc-project.md
@@ -9,7 +9,7 @@ match:
     'DVC repository',
     'DVC repositories',
     repository,
-    repositories,
+    repositories
   ]
 tooltip: >-
   Initialized by running `dvc init` in the **workspace** (typically a Git

--- a/package.json
+++ b/package.json
@@ -149,7 +149,7 @@
     "postcss-custom-properties": "^9.1.1",
     "postcss-mixins": "^6.2.3",
     "postcss-nested": "^4.2.1",
-    "prettier": "^2.0.4",
+    "prettier": "^2.2.1",
     "rehype-parse": "^6.0.2",
     "rehype-stringify": "^7.0.0",
     "remark": "^12.0.0",


### PR DESCRIPTION
Previously #2194 was merged to update restylebot configuration. However prettier still seems to behave differently when it comes to trailing commas as can be seen in #2224. I made some tests and prettier version in `package.json` seems to be old and new version adheres the configuration in `.prettierrc`.

