### PR TITLE
cmd: fix params example for using custom params file

### DIFF
--- a/content/docs/command-reference/params/index.md
+++ b/content/docs/command-reference/params/index.md
@@ -240,10 +240,11 @@ stages:
     deps:
       - users.csv
     params:
-      - BOOL
-      - INT
-      - TrainConfig.EPOCHS
-      - TrainConfig.layers
+      - params.py:
+          - BOOL
+          - INT
+          - TrainConfig.EPOCHS
+          - TrainConfig.layers
     outs:
       - model.pkl
 ```
@@ -257,10 +258,11 @@ stages:
       - path: users.csv
         md5: 23be4307b23dcd740763d5fc67993f11
     params:
-      INT: 5
-      BOOL: true
-      TrainConfig.EPOCHS: 70
-      TrainConfig.layers: 9
+      - params.py:
+          INT: 5
+          BOOL: true
+          TrainConfig.EPOCHS: 70
+          TrainConfig.layers: 9
     outs:
       - path: model.pkl
         md5: 1c06b4756f08203cc496e4061b1e7d67

--- a/content/docs/command-reference/params/index.md
+++ b/content/docs/command-reference/params/index.md
@@ -258,11 +258,11 @@ stages:
       - path: users.csv
         md5: 23be4307b23dcd740763d5fc67993f11
     params:
-      - params.py:
-          INT: 5
-          BOOL: true
-          TrainConfig.EPOCHS: 70
-          TrainConfig.layers: 9
+      params.py:
+        INT: 5
+        BOOL: true
+        TrainConfig.EPOCHS: 70
+        TrainConfig.layers: 9
     outs:
       - path: model.pkl
         md5: 1c06b4756f08203cc496e4061b1e7d67


### PR DESCRIPTION
The last example in 

https://dvc.org/doc/command-reference/params

has shows parameter tracking for custom filenames. But the supplied `dvc.yaml` and `dvc.lock` files don't contain any custom filename. 

This PR fixes that. 