### PR TITLE
Add target="_blank" rel="noopener noreferrer" to external-link

### DIFF
--- a/plugins/external-link-plugin/index.js
+++ b/plugins/external-link-plugin/index.js
@@ -15,7 +15,9 @@ function isCorrectExternalLinkAttr(attrsKeyTagArray) {
 function renderTag(attrs) {
   return `
     <section class="elp-content-holder">
-      <a href="${escape(attrs.href)}" class="external-link-preview">
+      <a href="${escape(
+        attrs.href
+      )}" class="external-link-preview" target="_blank" rel="noopener noreferrer">
           <div class="elp-description-holder">
             <h4 class="elp-title">${escape(attrs.title)}</h4>
             <div class="elp-description">${escape(attrs.description)}</div>


### PR DESCRIPTION
Fixes #2294 

I assume since it's called `external-link`, we want the attrs for external links on all instances of this custom component and there's no need to check for internal links conditionally.