### PR TITLE
fix path to checkpoint signal file

### DIFF
--- a/content/docs/api-reference/make_checkpoint.md
+++ b/content/docs/api-reference/make_checkpoint.md
@@ -30,7 +30,7 @@ logger). This function can be called by the code in stages executed by
    executed via `dvc exp run`, and it contains the location to the correct
    `.dvc/` directory for this experiment (which can vary when `-j` is used)
 2. Creates an empty `$DVC_ROOT/.dvc/tmp/DVC_CHECKPOINT` signal file so DVC knows
-   that a checkpoint should be captures now.
+   that a checkpoint should be captured now.
 3. Blocks the execution of any further code (that changes the state of the
    <abbr>workspace</abbr>) until the signal file is deleted, which means that
    DVC has finished caching all the data, calculating hashes, etc. (see

--- a/content/docs/api-reference/make_checkpoint.md
+++ b/content/docs/api-reference/make_checkpoint.md
@@ -29,8 +29,8 @@ logger). This function can be called by the code in stages executed by
 1. Check that the `DVC_ROOT` env var is set. It means this code is being
    executed via `dvc exp run`, and it contains the location to the correct
    `.dvc/` directory for this experiment (which can vary when `-j` is used)
-2. Creates an empty `$DVC_ROOT/tmp/DVC_CHECKPOINT` signal file so DVC knows that
-   a checkpoint should be captures now.
+2. Creates an empty `$DVC_ROOT/.dvc/tmp/DVC_CHECKPOINT` signal file so DVC knows
+   that a checkpoint should be captures now.
 3. Blocks the execution of any further code (that changes the state of the
    <abbr>workspace</abbr>) until the signal file is deleted, which means that
    DVC has finished caching all the data, calculating hashes, etc. (see


### PR DESCRIPTION
The path to the checkpoint signal file in the docs is missing `.dvc` after `$DVC_ROOT`. See https://github.com/iterative/dvc-checkpoints-mnist/tree/signal_file for an example.
