### PR TITLE
cmd: move import-url --to-remote ref from to-cache to to-remote

### DIFF
--- a/content/docs/command-reference/add.md
+++ b/content/docs/command-reference/add.md
@@ -379,9 +379,6 @@ outs:
     path: data.xml
 ```
 
-> For a similar operation that actually keeps a connection to the data source,
-> please see `dvc import-url`.
-
 ## Example: Transfer to remote storage
 
 When you have a large dataset in an external location, you may want to track it
@@ -428,3 +425,6 @@ system that can handle it), they can use `dvc pull` as usual:
 A       data.xml
 1 file added and 1 file fetched
 ```
+
+> For a similar operation that actually keeps a connection to the data source,
+> please see `dvc import-url`.


### PR DESCRIPTION
This is probably something leftover from the time that I changed order regarding to-cache/to-remote. `import-url` doesn't offer an alternative to to-cache but offers an alternative to `to-remote` so this patch moves the comment to the to-remote's segm