### PR TITLE
Added verify option to docs

### DIFF
--- a/content/docs/command-reference/remote/modify.md
+++ b/content/docs/command-reference/remote/modify.md
@@ -182,6 +182,12 @@ these parameters, you could use the following options.
   ```dvc
   $ dvc remote modify myremote use_ssl false
   ```
+  
+- `verify` - whether or not to validate SSL certificates, By default, validation is used. 
+
+  ```dvc
+  $ dvc remote modify myremote verify false
+  ```
 
 - `listobjects` - whether or not to use `list_objects`. By default,
   `list_objects_v2` is used. Useful for ceph and other S3 emulators.

--- a/content/docs/command-reference/remote/modify.md
+++ b/content/docs/command-reference/remote/modify.md
@@ -183,9 +183,8 @@ these parameters, you could use the following options.
   $ dvc remote modify myremote use_ssl false
   ```
   
-- `ssl_verify` - whether or not to verify SSL certificates. By default SSL certificates are verified. You can provide the following values:
-  False - do not validate SSL certificates. SSL will still be used (unless use_ssl is False), but SSL certificates will not be verified.
-  path/to/cert/bundle.pem - A filename of the CA cert bundle to use.
+- `ssl_verify` - whether or not to verify SSL certificates. 
+  By default SSL certificates are verified.
 
   ```dvc
   $ dvc remote modify myremote verify_ssl false

--- a/content/docs/command-reference/remote/modify.md
+++ b/content/docs/command-reference/remote/modify.md
@@ -183,7 +183,9 @@ these parameters, you could use the following options.
   $ dvc remote modify myremote use_ssl false
   ```
   
-- `verify_ssl` - whether or not to validate SSL certificates, By default, validation is used. 
+- `ssl_verify` - whether or not to verify SSL certificates. By default SSL certificates are verified. You can provide the following values:
+  False - do not validate SSL certificates. SSL will still be used (unless use_ssl is False), but SSL certificates will not be verified.
+  path/to/cert/bundle.pem - A filename of the CA cert bundle to use.
 
   ```dvc
   $ dvc remote modify myremote verify_ssl false

--- a/content/docs/command-reference/remote/modify.md
+++ b/content/docs/command-reference/remote/modify.md
@@ -183,10 +183,10 @@ these parameters, you could use the following options.
   $ dvc remote modify myremote use_ssl false
   ```
   
-- `verify` - whether or not to validate SSL certificates, By default, validation is used. 
+- `verify_ssl` - whether or not to validate SSL certificates, By default, validation is used. 
 
   ```dvc
-  $ dvc remote modify myremote verify false
+  $ dvc remote modify myremote verify_ssl false
   ```
 
 - `listobjects` - whether or not to use `list_objects`. By default,


### PR DESCRIPTION
Added Docs for verify option to s3 remotes: [Pull request](https://github.com/iterative/dvc/pull/5732)

> You may disregard these recommendations if you used the **Edit on GitHub** button from dvc.org to improve a doc in place.

❗ Please read the guidelines in the [Contributing to the Documentation](https://dvc.org/doc/user-guide/contributing/docs) list if you make any substantial changes to the documentation or JS engine.

🐛 Please make sure to mention `Fix #issue` (if applicable) in the description of the PR. This causes GitHub to close it automatically when the PR is merged.

Please choose to [allow us](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to edit your branch when creating the PR.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
