### PR TITLE
Added Katacoda experiments scenario link and fixed two other links

### DIFF
--- a/content/docs/sidebar.json
+++ b/content/docs/sidebar.json
@@ -49,18 +49,20 @@
       {
         "slug": "data-pipelines",
         "tutorials": {
-          "katacoda": "https://katacoda.com/dvc/courses/get-started"
+          "katacoda": "https://katacoda.com/dvc/courses/get-started/stages"
         }
       },
       {
         "label": "Metrics, Parameters, and Plots",
         "slug": "metrics-parameters-plots",
         "tutorials": {
-          "katacoda": "https://katacoda.com/dvc/courses/get-started"
+          "katacoda": "https://katacoda.com/dvc/courses/get-started/params-metrics-plots"
         }
       },
       {
-        "slug": "experiments"
+        "slug": "experiments",
+        "tutorials": {
+            "katacoda": "https://katacoda.com/dvc/courses/get-started/experiments"
       }
     ]
   },

--- a/content/docs/sidebar.json
+++ b/content/docs/sidebar.json
@@ -62,7 +62,8 @@
       {
         "slug": "experiments",
         "tutorials": {
-            "katacoda": "https://katacoda.com/dvc/courses/get-started/experiments"
+          "katacoda": "https://katacoda.com/dvc/courses/get-started/experiments"
+        }
       }
     ]
   },


### PR DESCRIPTION
This PR adds Katacoda link to GS:Experiments page and fixes two other links that wasn't pointing the exact scenarios. 

Closes #2358 
