### PR TITLE
ref: document `exp run` behavior for untracked files

### DIFF
--- a/content/docs/command-reference/exp/run.md
+++ b/content/docs/command-reference/exp/run.md
@@ -118,11 +118,11 @@ changes between/after queueing runs.
 `dvc exp run --temp`, for example to continue working on the project meanwhile
 (e.g. on another terminal).
 
-> ⚠️ Note that only tracked files and directories will be included in `--queue/temp`
-> experiments. To include untracked files, stage them with
+> ⚠️ Note that only tracked files and directories will be included in
+> `--queue/temp` experiments. To include untracked files, stage them with
 > `git add -N` first (before `dvc exp run`). Feel free to `git reset` them
 > afterwards. Git-ignored files/dirs are explicitly excluded from runs outside
-> the workspace.
+> the workspace to avoid committing secrets into experiments.
 
 Adding `-j` (`--jobs`), experiment queues can be run in parallel for better
 performance (creates a tmp dir for each job).

--- a/content/docs/command-reference/exp/run.md
+++ b/content/docs/command-reference/exp/run.md
@@ -120,7 +120,7 @@ changes between/after queueing runs.
 
 > ⚠️ Note that only tracked files and directories will be included in
 > `--queue/temp` experiments. To include untracked files, stage them with
-> `git add -N` first (before `dvc exp run`). Feel free to `git reset` them
+> `git add` first (before `dvc exp run`). Feel free to `git reset` them
 > afterwards. Git-ignored files/dirs are explicitly excluded from runs outside
 > the workspace to avoid committing unwanted files into experiments.
 

--- a/content/docs/command-reference/exp/run.md
+++ b/content/docs/command-reference/exp/run.md
@@ -122,7 +122,7 @@ changes between/after queueing runs.
 > `--queue/temp` experiments. To include untracked files, stage them with
 > `git add -N` first (before `dvc exp run`). Feel free to `git reset` them
 > afterwards. Git-ignored files/dirs are explicitly excluded from runs outside
-> the workspace to avoid committing secrets into experiments.
+> the workspace to avoid committing unwanted files into experiments.
 
 Adding `-j` (`--jobs`), experiment queues can be run in parallel for better
 performance (creates a tmp dir for each job).

--- a/content/docs/command-reference/exp/run.md
+++ b/content/docs/command-reference/exp/run.md
@@ -119,7 +119,7 @@ changes between/after queueing runs.
 (e.g. on another terminal).
 
 > ⚠️ Note that only tracked files and directories will be included in `--queue/temp`
-> experiments. To include untracked files or directories, stage them with
+> experiments. To include untracked files, stage them with
 > `git add -N` first (before `dvc exp run`). Feel free to `git reset` them
 > afterwards. Git-ignored files/dirs are explicitly excluded from runs outside
 > the workspace.

--- a/content/docs/command-reference/exp/run.md
+++ b/content/docs/command-reference/exp/run.md
@@ -121,8 +121,8 @@ changes between/after queueing runs.
 > ⚠️ Note that only tracked code and data will be included in `--queue/temp`
 > experiments. To include untracked files or directories, stage them with
 > `git add (-N)` first (before `dvc exp run`). Feel free to `git reset` them
-> afterwards. Git-ignored files/dirs are explicitly excluded from the runs
-> outside the workspace.
+> afterwards. Git-ignored files/dirs are explicitly excluded from runs outside
+> the workspace.
 
 Adding `-j` (`--jobs`), experiment queues can be run in parallel for better
 performance (creates a tmp dir for each job).

--- a/content/docs/command-reference/exp/run.md
+++ b/content/docs/command-reference/exp/run.md
@@ -118,6 +118,16 @@ changes between/after queueing runs.
 `dvc exp run --temp`, for example to continue working on the project meanwhile
 (e.g. on another terminal).
 
+> Note that only Git-tracked and DVC-tracked files and data will be included in
+> the execution environment when running experiments outside of your workspace.
+> Git-ignored files and directories are explicitly excluded from the execution
+> environment.
+>
+> To include untracked files (such as new code or new DVC pipeline files) in the
+> experiment, you should first stage the file in Git using `git add <file>` or
+> `git add --intent-to-add <file>` and then use `dvc exp run --queue/--temp`
+> once all of your untracked files have been staged.
+
 Adding `-j` (`--jobs`), experiment queues can be run in parallel for better
 performance (creates a tmp dir for each job).
 

--- a/content/docs/command-reference/exp/run.md
+++ b/content/docs/command-reference/exp/run.md
@@ -118,15 +118,11 @@ changes between/after queueing runs.
 `dvc exp run --temp`, for example to continue working on the project meanwhile
 (e.g. on another terminal).
 
-> Note that only Git-tracked and DVC-tracked files and data will be included in
-> the execution environment when running experiments outside of your workspace.
-> Git-ignored files and directories are explicitly excluded from the execution
-> environment.
->
-> To include untracked files (such as new code or new DVC pipeline files) in the
-> experiment, you should first stage the file in Git using `git add <file>` or
-> `git add --intent-to-add <file>` and then use `dvc exp run --queue/--temp`
-> once all of your untracked files have been staged.
+> ⚠️ Note that only tracked code and data will be included in `--queue/temp`
+> experiments. To include untracked files or directories, stage them with
+> `git add (-N)` first (before `dvc exp run`). Feel free to `git reset` them
+> afterwards. Git-ignored files/dirs are explicitly excluded from the runs
+> outside the workspace.
 
 Adding `-j` (`--jobs`), experiment queues can be run in parallel for better
 performance (creates a tmp dir for each job).

--- a/content/docs/command-reference/exp/run.md
+++ b/content/docs/command-reference/exp/run.md
@@ -120,7 +120,7 @@ changes between/after queueing runs.
 
 > ⚠️ Note that only tracked code and data will be included in `--queue/temp`
 > experiments. To include untracked files or directories, stage them with
-> `git add (-N)` first (before `dvc exp run`). Feel free to `git reset` them
+> `git add -N` first (before `dvc exp run`). Feel free to `git reset` them
 > afterwards. Git-ignored files/dirs are explicitly excluded from runs outside
 > the workspace.
 

--- a/content/docs/command-reference/exp/run.md
+++ b/content/docs/command-reference/exp/run.md
@@ -118,7 +118,7 @@ changes between/after queueing runs.
 `dvc exp run --temp`, for example to continue working on the project meanwhile
 (e.g. on another terminal).
 
-> ⚠️ Note that only tracked code and data will be included in `--queue/temp`
+> ⚠️ Note that only tracked files and directories will be included in `--queue/temp`
 > experiments. To include untracked files or directories, stage them with
 > `git add -N` first (before `dvc exp run`). Feel free to `git reset` them
 > afterwards. Git-ignored files/dirs are explicitly excluded from runs outside


### PR DESCRIPTION
Document `exp run` behavior for https://github.com/iterative/dvc/pull/5029

Will close https://github.com/iterative/dvc.org/issues/2374