### PR TITLE
Pin Node to version 15

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   },
   "homepage": "https://github.com/iterative/dvc.org#readme",
   "engines": {
-    "node": ">=12.0.0"
+    "node": "15.x"
   },
   "dependencies": {
     "@hapi/wreck": "^17.0.0",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   },
   "homepage": "https://github.com/iterative/dvc.org#readme",
   "engines": {
-    "node": "15"
+    "node": "<=15.x"
   },
   "dependencies": {
     "@hapi/wreck": "^17.0.0",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   },
   "homepage": "https://github.com/iterative/dvc.org#readme",
   "engines": {
-    "node": "15.x"
+    "node": "15"
   },
   "dependencies": {
     "@hapi/wreck": "^17.0.0",


### PR DESCRIPTION
Before, `>=12` resolved to 16, but anything above 15 breaks older `sharp` versions

This should fix #2411 