### PR TITLE
Add configuration information for Doom Emacs.

### DIFF
--- a/content/docs/install/plugins.md
+++ b/content/docs/install/plugins.md
@@ -46,3 +46,18 @@ autocmd! BufNewFile,BufRead Dvcfile,*.dvc,dvc.lock setfiletype yaml
 ```
 
 to your `~/.vimrc`(to be created if it doesn't exist).
+
+## Doom Emacs
+
+In order to recognize `dvc.lock` and `.dvc` files as YAML in Doom Emacs, you 
+should add:
+
+```emacs-lisp
+(use-package! yaml-mode
+  :config
+  (add-to-list 'auto-mode-alist '("\\.dvc" . yaml-mode))
+  (add-to-list 'auto-mode-alist '("dvc.lock" . yaml-mode))
+  )
+```
+
+to your `~/.doom.d/config.el`.

--- a/content/docs/install/plugins.md
+++ b/content/docs/install/plugins.md
@@ -49,8 +49,7 @@ to your `~/.vimrc`(to be created if it doesn't exist).
 
 ## Doom Emacs
 
-In order to recognize `dvc.lock` and `.dvc` files as YAML in Doom Emacs, you
-should add:
+In order to recognize `dvc.lock` and `.dvc` files as YAML in Doom Emacs, add
 
 ```emacs-lisp
 (use-package! yaml-mode

--- a/content/docs/install/plugins.md
+++ b/content/docs/install/plugins.md
@@ -49,7 +49,7 @@ to your `~/.vimrc`(to be created if it doesn't exist).
 
 ## Doom Emacs
 
-In order to recognize `dvc.lock` and `.dvc` files as YAML in Doom Emacs, you 
+In order to recognize `dvc.lock` and `.dvc` files as YAML in Doom Emacs, you
 should add:
 
 ```emacs-lisp


### PR DESCRIPTION
This adds a blurb for how to get Doom Emacs to recognize the `dvc.lock` and `.dvc` files as YAML files, similar to the Vim blurb. Thanks so much!