### PR TITLE
Fix dvc.lock file example for `foreach`

### DIFF
--- a/content/docs/user-guide/project-structure/pipelines-files.md
+++ b/content/docs/user-guide/project-structure/pipelines-files.md
@@ -255,12 +255,18 @@ are saved to `dvc.lock`:
 ```yaml
 schema: '2.0'
 stages:
-  cleanups@raw2 labels2:
-    cmd: echo "raw2 labels2"
-  cleanups@raw1:
-    cmd: echo "raw1"
   cleanups@labels1:
-    cmd: echo "labels1"
+    cmd: clean.py "labels1"
+    outs:
+    - path: labels1.cln
+  cleanups@raw1:
+    cmd: clean.py "raw1"
+    outs:
+    - path: raw1.cln
+  cleanups@raw2:
+    cmd: clean.py "raw2"
+    outs:
+    - path: raw2.cln
 ```
 
 For lists containing complex values (e.g. dictionaries), the substitution


### PR DESCRIPTION
The `dvc.lock` reported as an illustration does not match the content of the `dvc.yaml` file.

I have made a test using a `clean.py` as follows:

```python
from pathlib import Path
import sys

with open(Path(sys.argv[1]).with_suffix(".cln"), "w") as file:
    file.write("cleaned\n")
```

> You may disregard these recommendations if you used the **Edit on GitHub** button from dvc.org to improve a doc in place.

❗ Please read the guidelines in the [Contributing to the Documentation](https://dvc.org/doc/user-guide/contributing/docs) list if you make any substantial changes to the documentation or JS engine.

🐛 Please make sure to mention `Fix #issue` (if applicable) in the description of the PR. This causes GitHub to close it automatically when the PR is merged.

Please choose to [allow us](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to edit your branch when creating the PR.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
