### PR TITLE
cases: enable file links for shared dev config (external cache)

### DIFF
--- a/content/docs/use-cases/shared-development-server.md
+++ b/content/docs/use-cases/shared-development-server.md
@@ -55,18 +55,20 @@ your <abbr>project</abbr>:
 $ dvc cache dir /home/shared/dvc-cache
 ```
 
-Let's do a few important configurations:
+External cache configuration:
 
 ```dvc
 $ dvc config cache.shared group
 $ dvc config cache.type "reflink,symlink,hardlink,copy"
-$ dvc config cache.protected true
 ```
 
-First we tells DVC to set group permissions on new cache files. Then we enable
-soft and hard links (you limit to one or the other) to avoid copying from the
-external cache to the <abbr>workspace</abbr>. Finally we must "protect" the
-symlinked data in our project to avoid corrupting the cache.
+Above, we first tell DVC to set group permissions on new cache files. Then we
+enable soft and hard links (you limit to one or the other) to avoid having
+copies from the external cache to the <abbr>workspace</abbr>.
+
+⚠️ Note that enabling symlinks/hardlinks causes DVC to protect the linked data
+in the workspace, since editing them in-place would corrupt the cache. See also
+`dvc unprotect`.
 
 > See `dvc cache dir` and `dvc config cache` for more information.
 

--- a/content/docs/use-cases/shared-development-server.md
+++ b/content/docs/use-cases/shared-development-server.md
@@ -55,12 +55,18 @@ your <abbr>project</abbr>:
 $ dvc cache dir /home/shared/dvc-cache
 ```
 
-And tell DVC to set group permissions on newly created or downloaded cache
-files:
+Let's do a few important configurations:
 
 ```dvc
 $ dvc config cache.shared group
+$ dvc config cache.type "reflink,symlink,hardlink,copy"
+$ dvc config cache.protected true
 ```
+
+First we tells DVC to set group permissions on new cache files. Then we enable
+soft and hard links (you limit to one or the other) to avoid copying from the
+external cache to the <abbr>workspace</abbr>. Finally we must "protect" the
+symlinked data in our project to avoid corrupting the cache.
 
 > See `dvc cache dir` and `dvc config cache` for more information.
 

--- a/content/docs/use-cases/shared-development-server.md
+++ b/content/docs/use-cases/shared-development-server.md
@@ -59,19 +59,18 @@ External cache configuration:
 
 ```dvc
 $ dvc config cache.shared group
-$ dvc config cache.type "symlink,hardlink,copy"
+$ dvc config cache.type symlink
 ```
 
 Above, we first tell DVC to set group permissions on new cache files. Then we
-enable soft and hard [file links](/doc/user-guide/large-dataset-optimization)
-(you can pick only one or the other) to avoid having copies from the external
-cache to the <abbr>workspace</abbr>.
+enable symlinks to avoid having copies from the external cache to the
+<abbr>workspace</abbr>.
 
-> See `dvc config cache` for more information.
+> See `dvc config cache` and
+> [File link types](/doc/user-guide/large-dataset-optimization) for more info.
 
-⚠️ Note that enabling symlinks/hardlinks causes DVC to protect the linked data
-in the workspace, since editing them in-place would corrupt the cache. See also
-`dvc unprotect`.
+⚠️ Note that enabling soft/hard links causes DVC to protect the linked data,
+because editing them in-place would corrupt the cache. See `dvc unprotect`.
 
 If you're using Git, commit changes to your project's config file (`.dvc/config`
 by default):

--- a/content/docs/use-cases/shared-development-server.md
+++ b/content/docs/use-cases/shared-development-server.md
@@ -59,18 +59,19 @@ External cache configuration:
 
 ```dvc
 $ dvc config cache.shared group
-$ dvc config cache.type "reflink,symlink,hardlink,copy"
+$ dvc config cache.type "symlink,hardlink,copy"
 ```
 
 Above, we first tell DVC to set group permissions on new cache files. Then we
-enable soft and hard links (you limit to one or the other) to avoid having
-copies from the external cache to the <abbr>workspace</abbr>.
+enable soft and hard [file links](/doc/user-guide/large-dataset-optimization)
+(you can pick only one or the other) to avoid having copies from the external
+cache to the <abbr>workspace</abbr>.
+
+> See `dvc config cache` for more information.
 
 ⚠️ Note that enabling symlinks/hardlinks causes DVC to protect the linked data
 in the workspace, since editing them in-place would corrupt the cache. See also
 `dvc unprotect`.
-
-> See `dvc cache dir` and `dvc config cache` for more information.
 
 If you're using Git, commit changes to your project's config file (`.dvc/config`
 by default):


### PR DESCRIPTION
Closes #429

See https://dvc-org-cases-shared-de-2cu4a8.herokuapp.com/doc/use-cases/shared-development-server#configure-the-external-shared-cache