### PR TITLE
feat: focus search box on forward slash keydown

### DIFF
--- a/src/components/Documentation/Layout/index.tsx
+++ b/src/components/Documentation/Layout/index.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState } from 'react'
+import React, { useCallback, useEffect, useState } from 'react'
 import cn from 'classnames'
 
 import MainLayout, { LayoutComponent, LayoutModifiers } from '../../MainLayout'
@@ -7,6 +7,7 @@ import HamburgerIcon from '../../HamburgerIcon'
 import SearchForm from './SearchForm'
 import SidebarMenu from './SidebarMenu'
 import { matchMedia } from '../../../utils/front/breakpoints'
+import { focusElementWithHotkey } from '../../../utils/front/focusElementWithHotkey'
 
 import styles from './styles.module.css'
 
@@ -17,6 +18,10 @@ const Layout: LayoutComponent = ({ children, ...restProps }) => {
   } = restProps
 
   const toggleMenu = useCallback(() => setIsMenuOpen(!isMenuOpen), [isMenuOpen])
+
+  useEffect(() => {
+    focusElementWithHotkey('#doc-search', '/')
+  }, [])
 
   return (
     <MainLayout

--- a/src/components/Documentation/Layout/index.tsx
+++ b/src/components/Documentation/Layout/index.tsx
@@ -20,7 +20,8 @@ const Layout: LayoutComponent = ({ children, ...restProps }) => {
   const toggleMenu = useCallback(() => setIsMenuOpen(!isMenuOpen), [isMenuOpen])
 
   useEffect(() => {
-    focusElementWithHotkey('#doc-search', '/')
+    const closeEventListener = focusElementWithHotkey('#doc-search', '/')
+    return closeEventListener
   }, [])
 
   return (

--- a/src/components/Documentation/Layout/index.tsx
+++ b/src/components/Documentation/Layout/index.tsx
@@ -20,6 +20,9 @@ const Layout: LayoutComponent = ({ children, ...restProps }) => {
   const toggleMenu = useCallback(() => setIsMenuOpen(!isMenuOpen), [isMenuOpen])
 
   useEffect(() => {
+    if (matchMedia('--xs-scr')) {
+      return
+    }
     const closeEventListener = focusElementWithHotkey('#doc-search', '/')
     return closeEventListener
   }, [])

--- a/src/components/Documentation/Layout/index.tsx
+++ b/src/components/Documentation/Layout/index.tsx
@@ -10,6 +10,7 @@ import { matchMedia } from '../../../utils/front/breakpoints'
 import { focusElementWithHotkey } from '../../../utils/front/focusElementWithHotkey'
 
 import styles from './styles.module.css'
+import { useWindowSize } from 'react-use'
 
 const Layout: LayoutComponent = ({ children, ...restProps }) => {
   const [isMenuOpen, setIsMenuOpen] = useState(false)
@@ -19,13 +20,15 @@ const Layout: LayoutComponent = ({ children, ...restProps }) => {
 
   const toggleMenu = useCallback(() => setIsMenuOpen(!isMenuOpen), [isMenuOpen])
 
+  const windowSize = useWindowSize()
+
   useEffect(() => {
     if (matchMedia('--xs-scr')) {
       return
     }
     const closeEventListener = focusElementWithHotkey('#doc-search', '/')
     return closeEventListener
-  }, [])
+  }, [windowSize])
 
   return (
     <MainLayout

--- a/src/utils/front/focusElementWithHotkey.ts
+++ b/src/utils/front/focusElementWithHotkey.ts
@@ -1,0 +1,15 @@
+/**
+ * Utility function to focus on an element by pressing a specified hotkey.
+ * @param target CSS selector for the element to be focused
+ * @param hotkey The key that should trigger the target element to be focused
+ */
+export const focusElementWithHotkey = (target: string, hotkey: string) => {
+  document.addEventListener('keydown', $event => {
+    if ($event.key !== hotkey || document.activeElement?.matches(target)) {
+      return
+    }
+    const targetElement = document.querySelector(target) as HTMLElement
+    targetElement?.focus()
+    $event.preventDefault()
+  })
+}

--- a/src/utils/front/focusElementWithHotkey.ts
+++ b/src/utils/front/focusElementWithHotkey.ts
@@ -2,17 +2,20 @@
  * Utility function to focus on an element by pressing a specified hotkey.
  * @param target CSS selector for the element to be focused
  * @param hotkey The key that should trigger the target element to be focused
+ * @returns A function that will remove the event listener (e.g. on component unmount)
  */
 export const focusElementWithHotkey = (
   target: string,
   hotkey: string
-): void => {
-  document.addEventListener('keydown', e => {
+): (() => void) => {
+  const hotkeyEventHandler = (e: KeyboardEvent): void => {
     if (e.key !== hotkey || document.activeElement?.matches(target)) {
       return
     }
     const targetElement = document.querySelector(target) as HTMLElement
     targetElement?.focus()
     e.preventDefault()
-  })
+  }
+  document.addEventListener('keydown', hotkeyEventHandler)
+  return (): void => document.removeEventListener('keydown', hotkeyEventHandler)
 }

--- a/src/utils/front/focusElementWithHotkey.ts
+++ b/src/utils/front/focusElementWithHotkey.ts
@@ -3,7 +3,10 @@
  * @param target CSS selector for the element to be focused
  * @param hotkey The key that should trigger the target element to be focused
  */
-export const focusElementWithHotkey = (target: string, hotkey: string) => {
+export const focusElementWithHotkey = (
+  target: string,
+  hotkey: string
+): void => {
   document.addEventListener('keydown', $event => {
     if ($event.key !== hotkey || document.activeElement?.matches(target)) {
       return

--- a/src/utils/front/focusElementWithHotkey.ts
+++ b/src/utils/front/focusElementWithHotkey.ts
@@ -7,12 +7,12 @@ export const focusElementWithHotkey = (
   target: string,
   hotkey: string
 ): void => {
-  document.addEventListener('keydown', $event => {
-    if ($event.key !== hotkey || document.activeElement?.matches(target)) {
+  document.addEventListener('keydown', e => {
+    if (e.key !== hotkey || document.activeElement?.matches(target)) {
       return
     }
     const targetElement = document.querySelector(target) as HTMLElement
     targetElement?.focus()
-    $event.preventDefault()
+    e.preventDefault()
   })
 }


### PR DESCRIPTION
Adds a reusable `focusElementWithHotkey` function to listen for the `keydown` event on a particular key and respond by setting focus on the specified element. Implementing this with the "/" key and "#doc-search" element will fix #722.

Note to reviewer: This PR adds the `useEffect` for initializing this event listener to the main Layout component, but I am open to feedback on whether there is an alternate location that would be more appropriate.