### PR TITLE
Updated S3 ssl_verify documentation

### DIFF
--- a/content/docs/command-reference/remote/modify.md
+++ b/content/docs/command-reference/remote/modify.md
@@ -185,21 +185,15 @@ parameters to customize the authentication method:
   $ dvc remote modify myremote use_ssl false
   ```
 
-- `ssl_verify` - whether or not to verify SSL certificates, or a path to a 
-  custom CA bundle. By default SSL certificates are verified using the CA bundle
-  specified in the AWS config, if one is specified there. If one is not specified,
-  the default CA bundle used by `botocore` will be used. Setting to `false` will 
-  still use SSL if `use_ssl` is `true`, but SSL certificates will not be verified.
+- `ssl_verify` - whether or not to verify SSL certificates, or a path to a
+  custom CA certificates bundle to do so (implies `true`). The CA specified in
+  [AWS CLI config](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html#cli-configure-files-settings)
+  (if any) is used by default.
 
   ```dvc
   $ dvc remote modify myremote ssl_verify false
-  ```
-  
-  To specify a custom CA bundle:
-  
-  ```dvc
-  $ dvc remote modify myremote ssl_verify path/to/cabundle.pem
-  ```
+  # or
+  $ dvc remote modify myremote ssl_verify path/to/ca_bundle.pem
 
 > The credentials file path, access key and secret, and other options contains
 > sensitive user info. Therefore, it's safer to add it with the `--local`

--- a/content/docs/command-reference/remote/modify.md
+++ b/content/docs/command-reference/remote/modify.md
@@ -194,6 +194,7 @@ parameters to customize the authentication method:
   $ dvc remote modify myremote ssl_verify false
   # or
   $ dvc remote modify myremote ssl_verify path/to/ca_bundle.pem
+  ```
 
 > The credentials file path, access key and secret, and other options contains
 > sensitive user info. Therefore, it's safer to add it with the `--local`

--- a/content/docs/command-reference/remote/modify.md
+++ b/content/docs/command-reference/remote/modify.md
@@ -185,11 +185,20 @@ parameters to customize the authentication method:
   $ dvc remote modify myremote use_ssl false
   ```
 
-- `ssl_verify` - whether or not to verify SSL certificates. By default SSL
-  certificates are verified.
+- `ssl_verify` - whether or not to verify SSL certificates, or a path to a 
+  custom CA bundle. By default SSL certificates are verified using the CA bundle
+  specified in the AWS config, if one is specified there. If one is not specified,
+  the default CA bundle used by `botocore` will be used. Setting to `false` will 
+  still use SSL if `use_ssl` is `true`, but SSL certificates will not be verified.
 
   ```dvc
   $ dvc remote modify myremote ssl_verify false
+  ```
+  
+  To specify a custom CA bundle:
+  
+  ```dvc
+  $ dvc remote modify myremote ssl_verify path/to/cabundle.pem
   ```
 
 > The credentials file path, access key and secret, and other options contains

--- a/content/docs/command-reference/remote/modify.md
+++ b/content/docs/command-reference/remote/modify.md
@@ -186,9 +186,9 @@ parameters to customize the authentication method:
   ```
 
 - `ssl_verify` - whether or not to verify SSL certificates, or a path to a
-  custom CA certificates bundle to do so (implies `true`). The CA specified in
+  custom CA certificates bundle to do so (implies `true`). The certs in
   [AWS CLI config](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html#cli-configure-files-settings)
-  (if any) is used by default.
+  (if any) are used by default.
 
   ```dvc
   $ dvc remote modify myremote ssl_verify false


### PR DESCRIPTION
https://github.com/iterative/dvc/pull/6018 implements the ability to set `ssl_verify` in the S3 remote config to a path to a custom CA bundle file in addition to setting `true`/`false`. It also makes the default the same as the `botocore` default, which is to read the CA bundle path from the AWS config. This updates the docs to reflect those changes.

> You may disregard these recommendations if you used the **Edit on GitHub** button from dvc.org to improve a doc in place.

❗ Please read the guidelines in the [Contributing to the Documentation](https://dvc.org/doc/user-guide/contributing/docs) list if you make any substantial changes to the documentation or JS engine.

🐛 Please make sure to mention `Fix #issue` (if applicable) in the description of the PR. This causes GitHub to close it automatically when the PR is merged.

Please choose to [allow us](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to edit your branch when creating the PR.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
