### PR TITLE
fix link to azure default credential in add.md

### DIFF
--- a/content/docs/command-reference/remote/add.md
+++ b/content/docs/command-reference/remote/add.md
@@ -150,7 +150,7 @@ $ dvc remote add -d myremote azure://mycontainer/path
 ```
 
 By default, DVC authenticates using an Azure
-[default credential](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-configure.html)
+[default credential](https://docs.microsoft.com/en-us/python/api/azure-identity/azure.identity.defaultazurecredential)
 (if any). This uses certain environment variables or a signed in Microsoft
 application. To use a custom authentication method, use the parameters described
 in `dvc remote modify`.


### PR DESCRIPTION
The link to Azure default credential was pointing to AWS instead of azure ;-)

> You may disregard these recommendations if you used the **Edit on GitHub** button from dvc.org to improve a doc in place.

❗ Please read the guidelines in the [Contributing to the Documentation](https://dvc.org/doc/user-guide/contributing/docs) list if you make any substantial changes to the documentation or JS engine.

🐛 Please make sure to mention `Fix #issue` (if applicable) in the description of the PR. This causes GitHub to close it automatically when the PR is merged.

Please choose to [allow us](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to edit your branch when creating the PR.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
