### PR TITLE
Improve right panel scroll bar

### DIFF
--- a/src/components/Documentation/RightPanel/index.tsx
+++ b/src/components/Documentation/RightPanel/index.tsx
@@ -127,7 +127,7 @@ const RightPanel: React.FC<IRightPanelProps> = ({
       menuItemsEleme.scrollHeight > menuItemsEleme.clientHeight
     ) {
       currentHeadingSlugElem.scrollIntoView({
-        behavior: 'instant',
+        behavior: 'auto',
         block: 'nearest',
         inline: 'start'
       })

--- a/src/components/Documentation/RightPanel/styles.module.css
+++ b/src/components/Documentation/RightPanel/styles.module.css
@@ -16,8 +16,14 @@
 }
 
 .contentBlock {
-  overflow-y: scroll;
   margin-bottom: 27px;
+  position: relative;
+  min-height: 100px;
+}
+
+.menuItems {
+  overflow-y: scroll;
+  height: 100%;
 
   &::-webkit-scrollbar {
     -webkit-appearance: none;
@@ -30,9 +36,35 @@
   }
 }
 
+.shadowTop {
+  &::before {
+    -webkit-box-shadow: 0 2px 2px -1px rgb(0 0 0 / 10%);
+    box-shadow: 0 2px 2px -1px rgb(0 0 0 / 10%);
+    border-bottom: 1px solid #e5e5e5;
+    position: absolute;
+    margin-top: -5px;
+    height: 4px;
+    width: 100%;
+    content: '';
+  }
+}
+
+.shadowBottom {
+  &::after {
+    -webkit-box-shadow: rgb(0 0 0 / 17%) 0 -2px 2px -1px;
+    box-shadow: rgb(0 0 0 / 17%) 0 -2px 2px -1px;
+    position: absolute;
+    height: 4px;
+    content: '';
+    width: 100%;
+    bottom: -4px;
+  }
+}
+
 .separator {
   border: none;
   border-top: 1px solid var(--color-lighter-blue);
+  margin-bottom: 0;
 }
 
 .header {


### PR DESCRIPTION
> You may disregard these recommendations if you used the **Edit on GitHub** button from dvc.org to improve a doc in place.

❗ Please read the guidelines in the [Contributing to the Documentation](https://dvc.org/doc/user-guide/contributing/docs) list if you make any substantial changes to the documentation or JS engine.

🐛 Please make sure to mention `Fix #issue` (if applicable) in the description of the PR. This causes GitHub to close it automatically when the PR is merged.

Please choose to [allow us](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to edit your branch when creating the PR.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏


Fix #1333 

Hi @shcheklein ,


I finished to do the improvements you asked for this https://github.com/iterative/dvc.org/issues/1333
I basically copied the GMail CSS for the shadow boxes like you commented.
I spent around 8h to finish it. Around 1.5h fixing dependency issues with with Mac M1 (more specifically libvips which is used by sharp and used by Gatsby) and problems with my node version. I was using node 12 and Sharp was not working on my Mac M1, so I switched to Node 15 and everything worked. Then I used around 4h to learn the basics about React hooks and 2.5h to actually create and execute a plan to fix the issues.

Follow below pictures to show the result. I hope it is exactly what you asked.
Can you tell me which branch you want me to open the PR against?
 
When the scroolbar appears and it is at the top, a shadow box appears at the bottom

![Screenshot 2021-06-01 at 13 03 49](https://user-images.githubusercontent.com/55927613/120385738-30bb6000-c2fe-11eb-8ad7-e9515e02c5c4.png)


When the scrollbar appears and it is anywhere in between, both shadow boxes appear in the top and bottom
![Screenshot 2021-06-01 at 13 05 13](https://user-images.githubusercontent.com/55927613/120385772-39ac3180-c2fe-11eb-94f1-835c2a069d18.png)


When the scrollbar appears and it is at the bottom/end of the div, a shadow box appears at the top
![Screenshot 2021-06-01 at 13 06 17](https://user-images.githubusercontent.com/55927613/120385783-3ca72200-c2fe-11eb-8aa8-86f5e9e1b0bb.png)


When the scrollbar is not present, the shadow boxes are not added
![Screenshot 2021-06-01 at 13 07 19](https://user-images.githubusercontent.com/55927613/120385808-42046c80-c2fe-11eb-9144-1e63b12f9a85.png)


All the changes above are also working on Firefox 89.0 and Safari 14.1.1.


I also made the "Selected Menu Item" to be visible all the time. I noticed the current code was attempting to do that, but it was not working, so I did a small change to fix it. Now whenever you scroll to a section the Menu Item will follow you along, even when there are scrollbars.

![Screenshot 2021-06-01 at 13 11 30](https://user-images.githubusercontent.com/55927613/120385831-4892e400-c2fe-11eb-8157-8122a1fed65e.png)

React is not my thing but I think I did a good job. Now lets see what you think. Thanks.


