### PR TITLE
Add a quality key to gatsby-remark-images options

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -94,7 +94,8 @@ const plugins = [
           resolve: 'gatsby-remark-images',
           options: {
             maxWidth: BLOG.imageMaxWidth,
-            withWebp: true
+            withWebp: true,
+            quality: 90
           }
         },
         'gatsby-remark-responsive-iframe',


### PR DESCRIPTION
* added a quality of 90 to lower any possible image blurring