### PR TITLE
document ssl_verify for http/webdav remotes

### DIFF
--- a/content/docs/command-reference/remote/modify.md
+++ b/content/docs/command-reference/remote/modify.md
@@ -905,11 +905,13 @@ by HDFS. Read more about by expanding the WebHDFS section in
   > `password` is specified, DVC will not prompt the user to enter a password
   > for this remote.
 
-- `ssl_verify` - allows to disable SSH verification, which is enabled by
-  default.
+- `ssl_verify` - whether or not to verify SSL certificates, or a path to a
+  custom CA certificates bundle to do so (implies `true`).
 
   ```dvc
   $ dvc remote modify myremote ssl_verify false
+  # or
+  $ dvc remote modify myremote ssl_verify path/to/ca_bundle.pem
   ```
 
 </details>
@@ -964,6 +966,15 @@ by HDFS. Read more about by expanding the WebHDFS section in
 
   ```dvc
   $ dvc remote modify myremote ask_password true
+  ```
+
+- `ssl_verify` - whether or not to verify SSL certificates, or a path to a
+  custom CA certificates bundle to do so (implies `true`).
+
+  ```dvc
+  $ dvc remote modify myremote ssl_verify false
+  # or
+  $ dvc remote modify myremote ssl_verify path/to/ca_bundle.pem
   ```
 
 - `cert_path` - path to certificate used for WebDAV server authentication, if

--- a/content/docs/command-reference/remote/modify.md
+++ b/content/docs/command-reference/remote/modify.md
@@ -906,7 +906,7 @@ by HDFS. Read more about by expanding the WebHDFS section in
   > for this remote.
 
 - `ssl_verify` - whether or not to verify SSL certificates, or a path to a
-  custom CA certificates bundle to do so (implies `true`).
+  custom CA bundle to do so (`true` by default).
 
   ```dvc
   $ dvc remote modify myremote ssl_verify false
@@ -969,7 +969,7 @@ by HDFS. Read more about by expanding the WebHDFS section in
   ```
 
 - `ssl_verify` - whether or not to verify SSL certificates, or a path to a
-  custom CA certificates bundle to do so (implies `true`).
+  custom CA bundle to do so (`true` by default).
 
   ```dvc
   $ dvc remote modify myremote ssl_verify false


### PR DESCRIPTION
Adding `ssl_verify` to http and webdav remotes. See https://github.com/iterative/dvc/pull/6142