### PR TITLE
misc. updates

### DIFF
--- a/content/docs/command-reference/get-url.md
+++ b/content/docs/command-reference/get-url.md
@@ -57,11 +57,6 @@ DVC supports several types of (local or) remote data sources (protocols):
 - HDFS, HTTP, WebDav, and WebHDFS **do not** support downloading entire
   directories, only single files.
 
-- `remote://myremote/path/to/file` notation just means that a DVC
-  [remote](/doc/command-reference/remote) `myremote` is defined and when DVC is
-  running. DVC automatically expands this URL into a regular S3, SSH, GS, etc
-  URL by appending `/path/to/file` to the `myremote`'s configured base path.
-
 Another way to understand the `dvc get-url` command is as a tool for downloading
 data files. On GNU/Linux systems for example, instead of `dvc get-url` with
 HTTP(S) it's possible to instead use:

--- a/content/docs/command-reference/get.md
+++ b/content/docs/command-reference/get.md
@@ -14,6 +14,7 @@ usage: dvc get [-h] [-q | -v] [-o <path>] [--rev <commit>] [-j <number>]
 positional arguments:
   url              Location of DVC or Git repository to download from
   path             Path to a file or directory within the repository
+                   relative to the root of the repo
 ```
 
 ## Description

--- a/content/docs/command-reference/get.md
+++ b/content/docs/command-reference/get.md
@@ -14,7 +14,6 @@ usage: dvc get [-h] [-q | -v] [-o <path>] [--rev <commit>] [-j <number>]
 positional arguments:
   url              Location of DVC or Git repository to download from
   path             Path to a file or directory within the repository
-                   relative to the root of the repo
 ```
 
 ## Description
@@ -38,9 +37,9 @@ the data source. Both HTTP and SSH protocols are supported (e.g.
 (including the current project e.g. `.`).
 
 The `path` argument specifies a file or directory to download (paths inside
-tracked directories are supported), relative to the root of the repo at `url`.
-It can be tracked by either Git or DVC. Note that DVC-tracked targets must be
-found in a `dvc.yaml` or `.dvc` file of the repo.
+tracked directories are supported). It should be relative to the root of the
+repo (absolute paths are supported when `url` is local). Note that DVC-tracked
+targets must be found in a `dvc.yaml` or `.dvc` file of the repo.
 
 ⚠️ DVC repos should have a default [DVC remote](/doc/command-reference/remote)
 containing the target actual for this command to work. The only exception is for

--- a/content/docs/command-reference/get.md
+++ b/content/docs/command-reference/get.md
@@ -36,11 +36,10 @@ the data source. Both HTTP and SSH protocols are supported (e.g.
 `[user@]server:project.git`). `url` can also be a local file system path
 (including the current project e.g. `.`).
 
-The `path` argument is used to specify the location of the target to download
-within the source repository at `url`. `path` can specify any file or directory
-tracked by either Git or DVC (including paths inside tracked directories). Note
-that DVC-tracked targets must be found in a `dvc.yaml` or `.dvc` file of the
-repo.
+The `path` argument specifies a file or directory to download (paths inside
+tracked directories are supported), relative to the root of the repo at `url`.
+It can be tracked by either Git or DVC. Note that DVC-tracked targets must be
+found in a `dvc.yaml` or `.dvc` file of the repo.
 
 ⚠️ DVC repos should have a default [DVC remote](/doc/command-reference/remote)
 containing the target actual for this command to work. The only exception is for

--- a/content/docs/command-reference/import-url.md
+++ b/content/docs/command-reference/import-url.md
@@ -84,7 +84,6 @@ DVC supports several types of external locations (protocols):
 | `webdav`  | WebDav to file\*             | `webdavs://example.com/endpoint/path`         |
 | `webhdfs` | HDFS REST API\*              | `webhdfs://user@example.com/path/to/data.csv` |
 | `local`   | Local path                   | `/path/to/local/data`                         |
-| `remote`  | Remote path\*                | `remote://remote-name/data`                   |
 
 > If you installed DVC via `pip` and plan to use cloud services as remote
 > storage, you might need to install these optional dependencies: `[s3]`,
@@ -100,11 +99,6 @@ DVC supports several types of external locations (protocols):
 - In case of HTTP,
   [ETag](https://en.wikipedia.org/wiki/HTTP_ETag#Strong_and_weak_validation) is
   necessary to track if the specified URL changed.
-
-- `remote://myremote/path/to/file` notation just means that a DVC
-  [remote](/doc/command-reference/remote) `myremote` is defined and when DVC is
-  running. DVC automatically expands this URL into a regular S3, SSH, GS, etc
-  URL by appending `/path/to/file` to the `myremote`'s configured base path.
 
 Another way to understand the `dvc import-url` command is as a shortcut for
 generating a pipeline stage with and external dependency. This is discussed in

--- a/content/docs/command-reference/import.md
+++ b/content/docs/command-reference/import.md
@@ -16,6 +16,7 @@ usage: dvc import [-h] [-q | -v] [-j <number>]
 positional arguments:
   url              Location of DVC or Git repository to download from
   path             Path to a file or directory within the repository
+                   relative to the root of the repo
 ```
 
 ## Description

--- a/content/docs/command-reference/import.md
+++ b/content/docs/command-reference/import.md
@@ -16,7 +16,6 @@ usage: dvc import [-h] [-q | -v] [-j <number>]
 positional arguments:
   url              Location of DVC or Git repository to download from
   path             Path to a file or directory within the repository
-                   relative to the root of the repo
 ```
 
 ## Description
@@ -49,9 +48,9 @@ the data source. Both HTTP and SSH protocols are supported (e.g.
 (including the current project e.g. `.`).
 
 The `path` argument specifies a file or directory to download (paths inside
-tracked directories are supported), relative to the root of the repo at `url`.
-It can be tracked by either Git or DVC. Note that DVC-tracked targets must be
-found in a `dvc.yaml` or `.dvc` file of the repo.
+tracked directories are supported). It should be relative to the root of the
+repo (absolute paths are supported when `url` is local). Note that DVC-tracked
+targets must be found in a `dvc.yaml` or `.dvc` file of the repo.
 
 ⚠️ Source DVC repos should have a default
 [DVC remote](/doc/command-reference/remote) containing the target data for this

--- a/content/docs/command-reference/import.md
+++ b/content/docs/command-reference/import.md
@@ -47,11 +47,10 @@ the data source. Both HTTP and SSH protocols are supported (e.g.
 `[user@]server:project.git`). `url` can also be a local file system path
 (including the current project e.g. `.`).
 
-The `path` argument is used to specify the location of the target to download
-within the source repository at `url`. `path` can specify any file or directory
-tracked by either Git or DVC (including paths inside tracked directories). Note
-that DVC-tracked targets must be found in a `dvc.yaml` or `.dvc` file of the
-repo.
+The `path` argument specifies a file or directory to download (paths inside
+tracked directories are supported), relative to the root of the repo at `url`.
+It can be tracked by either Git or DVC. Note that DVC-tracked targets must be
+found in a `dvc.yaml` or `.dvc` file of the repo.
 
 ⚠️ Source DVC repos should have a default
 [DVC remote](/doc/command-reference/remote) containing the target data for this

--- a/content/docs/command-reference/list.md
+++ b/content/docs/command-reference/list.md
@@ -39,7 +39,8 @@ $ ls <path>
 The `url` argument specifies the address of the DVC or Git repository containing
 the data source. Both HTTP and SSH protocols are supported (e.g.
 `[user@]server:project.git`). `url` can also be a local file system path
-(including the current project e.g. `.`).
+(including the current project e.g. `.`). Any path inside a DVC project will be
+resolved to the project's root.
 
 The optional `path` argument is used to specify a directory to list within the
 Git repo at `url` (including paths inside tracked directories). It's similar to

--- a/content/docs/command-reference/list.md
+++ b/content/docs/command-reference/list.md
@@ -14,7 +14,8 @@ usage: dvc list [-h] [-q | -v] [-R] [--dvc-only]
 
 positional arguments:
   url            Location of DVC or Git repository to list from
-  path           Path to a file or directory within the repository
+  path           Path to a file or directory in the repository
+                 relative to the root of the repo
 ```
 
 ## Description
@@ -42,9 +43,10 @@ the data source. Both HTTP and SSH protocols are supported (e.g.
 (including the current project e.g. `.`). Any path inside a DVC project will be
 resolved to the project's root.
 
-The optional `path` argument is used to specify a directory to list within the
-Git repo at `url` (including paths inside tracked directories). It's similar to
-providing a path to list to commands such as `ls` or `aws s3 ls`.
+The optional `path` argument specifies a file or directory to list (paths inside
+tracked directories are supported), relative to the root of the repo at `url`.
+This is similar to providing a path to listing commands such as `ls` or
+`aws s3 ls`.
 
 Only the root directory is listed by default, but the `-R` option can be used to
 list files recursively.

--- a/content/docs/command-reference/list.md
+++ b/content/docs/command-reference/list.md
@@ -15,7 +15,6 @@ usage: dvc list [-h] [-q | -v] [-R] [--dvc-only]
 positional arguments:
   url            Location of DVC or Git repository to list from
   path           Path to a file or directory in the repository
-                 relative to the root of the repo
 ```
 
 ## Description
@@ -44,9 +43,9 @@ the data source. Both HTTP and SSH protocols are supported (e.g.
 resolved to the project's root.
 
 The optional `path` argument specifies a file or directory to list (paths inside
-tracked directories are supported), relative to the root of the repo at `url`.
-This is similar to providing a path to listing commands such as `ls` or
-`aws s3 ls`.
+tracked directories are supported). It should be relative to the root of the
+repo (absolute paths are supported when `url` is local). This is similar to
+providing a path to listing commands such as `ls` or `aws s3 ls`.
 
 Only the root directory is listed by default, but the `-R` option can be used to
 list files recursively.

--- a/content/docs/start/data-and-model-versioning.md
+++ b/content/docs/start/data-and-model-versioning.md
@@ -8,7 +8,7 @@ Git.'
 # Get Started: Data Versioning
 
 How cool would it be to make Git handle arbitrarily large files and directories
-with the same performance that you get with small code files? Imagine doing a
+with the same performance it has with small code files? Imagine doing a
 `git clone` and seeing data files and machine learning models in the workspace.
 Or switching to a different version of a 100Gb file in less than a second with a
 `git checkout`.

--- a/content/docs/user-guide/contributing/docs.md
+++ b/content/docs/user-guide/contributing/docs.md
@@ -5,9 +5,13 @@ We welcome any contributions to our documentation repository,
 the documentation content, or (rare) changes to the JS engine we use to run the
 website.
 
-Please see our
-[Writing a Blog Post guide](https://dvc.org/doc/user-guide/contributing/blog)
-for more details on how to write and submit a new blog post.
+In case of a minor change, you can use the **Edit on GitHub** button to open the
+source code page. Use thethe Edit button (pencil icon) to edit the file
+in-place, and then **Commit changes** from the bottom of the page.
+
+> Please see our
+> [Writing a Blog Post guide](https://dvc.org/doc/user-guide/contributing/blog)
+> for more details on how to write and submit a new blog post.
 
 ## Structure of the project
 
@@ -28,12 +32,6 @@ Merging the appropriate changes to these files into the master branch is enough
 to update the docs and redeploy the website.
 
 ## Submitting changes
-
-In case of a minor change, you can use the **Edit on GitHub** button (found to
-the right of each page) to fork the repository, edit it in place (with the
-source code file **Edit** button in GitHub), and create a pull request (PR).
-
-Otherwise, please refer to the following procedure:
 
 - Find or open a new issue in the
   [issue tracker](https://github.com/iterative/dvc.org/issues) to let us know


### PR DESCRIPTION
1. `path` arg usage (`list/get/import`)
2. A typo
3. Docs contrib guide update
4. `get/import-url` don't support `remote://` URLs

- [ ] (1) requires a matching core `dvc` repo update.