### PR TITLE
codespaces: custom container and config

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,16 @@
+# See here for image contents: https://github.com/microsoft/vscode-dev-containers/tree/v0.177.0/containers/javascript-node/.devcontainer/base.Dockerfile
+
+# [Choice] Node.js version: 16, 14, 12
+ARG VARIANT="16-buster"
+FROM mcr.microsoft.com/vscode/devcontainers/javascript-node:0-${VARIANT}
+
+# [Optional] Uncomment this section to install additional OS packages.
+# RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+#     && apt-get -y install --no-install-recommends <your-package-list-here>
+
+# [Optional] Uncomment if you want to install an additional version of node using nvm
+# ARG EXTRA_NODE_VERSION=10
+# RUN su node -c "source /usr/local/share/nvm/nvm.sh && nvm install ${EXTRA_NODE_VERSION}"
+
+# [Optional] Uncomment if you want to install more global node modules
+# RUN su node -c "npm install -g <your-package-list-here>"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,31 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
+// https://github.com/microsoft/vscode-dev-containers/tree/v0.177.0/containers/javascript-node
+{
+  "name": "Node.js",
+  "build": {
+    "dockerfile": "Dockerfile",
+    // Update 'VARIANT' to pick a Node version: 12, 14, 16
+    "args": { "VARIANT": "14" }
+  },
+
+  // Set *default* container specific settings.json values on container create.
+  "settings": {
+    "terminal.integrated.shell.linux": "/bin/bash"
+  },
+
+  // Add the IDs of extensions you want installed when the container is created.
+  "extensions": [
+    "dbaeumer.vscode-eslint",
+    "stkb.rewrap",
+    "streetsidesoftware.code-spell-checker"
+  ],
+
+  // Use 'forwardPorts' to make a list of ports inside the container available locally.
+  // "forwardPorts": [],
+
+  // Use 'postCreateCommand' to run commands after the container is created.
+  // "postCreateCommand": "yarn install",
+
+  // Comment out connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
+  "remoteUser": "node"
+}

--- a/README.md
+++ b/README.md
@@ -23,6 +23,21 @@ details.
 [![](https://sourcerer.io/fame/shcheklein/iterative/dvc.org/images/6)](https://sourcerer.io/fame/shcheklein/iterative/dvc.org/links/6)
 [![](https://sourcerer.io/fame/shcheklein/iterative/dvc.org/images/7)](https://sourcerer.io/fame/shcheklein/iterative/dvc.org/links/7)
 
+## Developing with [Codespaces](https://docs.github.com/en/codespaces)
+
+Our repository has GitHub Codespaces enabled:
+
+![](https://docs.github.com/assets/images/help/codespaces/open-with-codespaces-button.png)
+
+Once the codespace has been [created], you can follow the [Development
+environment] instructions from it's [Terminal].
+
+[created]:
+  https://docs.github.com/en/codespaces/developing-in-codespaces/creating-a-codespace
+[development environment]:
+  https://dvc.org/doc/user-guide/contributing/docs#development-environment
+[terminal]: https://code.visualstudio.com/docs/editor/integrated-terminal
+
 # Writing a blog post
 
 Please, [contact us](mailto:support@dvc.org) if you'd like to write something

--- a/README.md
+++ b/README.md
@@ -23,9 +23,10 @@ details.
 [![](https://sourcerer.io/fame/shcheklein/iterative/dvc.org/images/6)](https://sourcerer.io/fame/shcheklein/iterative/dvc.org/links/6)
 [![](https://sourcerer.io/fame/shcheklein/iterative/dvc.org/images/7)](https://sourcerer.io/fame/shcheklein/iterative/dvc.org/links/7)
 
-## Developing with [Codespaces](https://docs.github.com/en/codespaces)
+## Developing online
 
-Our repository has GitHub Codespaces enabled:
+Our repository has GitHub [Codespaces](https://docs.github.com/en/codespaces)
+enabled:
 
 ![](https://docs.github.com/assets/images/help/codespaces/open-with-codespaces-button.png)
 


### PR DESCRIPTION
> Followed https://docs.github.com/en/codespaces/setting-up-your-codespace/configuring-codespaces-for-your-project#using-a-predefined-container-configuration

This customization uses a lighter Docker container and avoids running `yarn && yarn build` by default. It also includes a couple useful VSCode extensions for writing docs.

Contributors should be able to use `yarn && yarn develop` (as indicated in our dev env instructions) right away after the codespace is build/restarted.

> Unfortunately this ~~doesn't work at the moment with this repo since the dev app fails to render when shown via a forwarded port~~ works in the desktop app but not in-browser (as a workaround, it can be published with `ngrok` for now, but the dev auto-refresh doesn't work that way).