### PR TITLE
Fix right sidebar to scroll with main page

### DIFF
--- a/src/components/Documentation/RightPanel/index.tsx
+++ b/src/components/Documentation/RightPanel/index.tsx
@@ -88,40 +88,28 @@ const RightPanel: React.FC<IRightPanelProps> = ({
       window.removeEventListener('resize', updateHeadingsPosition)
     }
   }, [updateCurrentHeader])
+
   useEffect(initHeadingsPosition, [headings])
+
   useEffect(updateCurrentHeader, [headingsOffsets, documentHeight])
 
   const contentBlockRef = useRef<HTMLDivElement>(null)
-  const [
-    isScrollToCurrentHeadingHappened,
-    setIsScrollToCurrentHeadingHappened
-  ] = useState(false)
   useEffect(() => {
-    if (isScrollToCurrentHeadingHappened) {
-      return
-    }
-    if (!document.location.hash) {
-      setIsScrollToCurrentHeadingHappened(true)
-      return
-    }
     if (currentHeadingSlug) {
-      setIsScrollToCurrentHeadingHappened(true)
       const currentHeadingSlugElem = document.getElementById(
         `link-${currentHeadingSlug}`
       )
       const contentBlockElem = contentBlockRef.current
-      if (currentHeadingSlugElem && contentBlockElem) {
+      if (currentHeadingSlugElem?.parentElement && contentBlockElem) {
         const hasVerticalScrollbar =
           contentBlockElem.scrollHeight > contentBlockElem.clientHeight
         if (hasVerticalScrollbar) {
-          currentHeadingSlugElem.scrollIntoView({
-            block: 'start',
-            inline: 'nearest'
-          })
+          currentHeadingSlugElem.parentElement.scrollTop =
+            currentHeadingSlugElem.offsetTop
         }
       }
     }
-  })
+  }, [currentHeadingSlug])
 
   return (
     <div className={styles.container}>

--- a/src/components/Documentation/RightPanel/styles.module.css
+++ b/src/components/Documentation/RightPanel/styles.module.css
@@ -16,6 +16,7 @@
 }
 
 .contentBlock {
+  position: relative;
   overflow-y: scroll;
   margin-bottom: 27px;
 


### PR DESCRIPTION
This addresses the first item. It makes the right sidebar headings list to scroll along with the main page.

I removed `isScrollToCurrentHeadingHappened` logic. Not sure what the intention of this was, but it was causing the sidebar to only scroll once and not every time the current heading in the main page changed.

`scrollIntoView` had some weird behavior so I am setting `scrollTop` instead.