### PR TITLE
Google Drive remote: add note on required authorization when impersonating users with service account

### DIFF
--- a/content/docs/command-reference/remote/modify.md
+++ b/content/docs/command-reference/remote/modify.md
@@ -531,6 +531,11 @@ more information.
 - `gdrive_service_account_user_email` - email of a user account to
   [impersonate](https://developers.google.com/admin-sdk/directory/v1/guides/delegation)
   with the service account. Optional when `gdrive_use_service_account` is on.
+  DVC requires domain-wide authority delegated to service account to include
+  following OAuth Scopes (authorised in Google Workspace Admin console):
+
+  - `https://www.googleapis.com/auth/drive`
+  - `https://www.googleapis.com/auth/drive.appdata`
 
   ```dvc
   $ dvc remote modify myremote \


### PR DESCRIPTION
Related to: https://github.com/iterative/dvc.org/issues/2593
