### PR TITLE
Take `'=700'` off of documentation images markdown

### DIFF
--- a/content/docs/cml/cml-with-dvc.md
+++ b/content/docs/cml/cml-with-dvc.md
@@ -5,7 +5,7 @@ downloaded from external sources. [DVC](https://dvc.org) is a common way to
 bring data to your CML runner. DVC also lets you visualize how metrics differ
 between commits to make reports like this:
 
-![](/img/dvc_cml_long_report.png '=700')
+![](/img/dvc_cml_long_report.png)
 
 The `.github/workflows/cml.yaml` file to create this report is:
 

--- a/content/docs/cml/start-github.md
+++ b/content/docs/cml/start-github.md
@@ -11,7 +11,7 @@ supported CI systems (with exceptions as noted!).
    [you'll need to create a Personal Access Token](https://github.com/iterative/cml/wiki/CML-with-GitLab#variables)
    for this example to work.
 
-   ![](/img/fork_cml_project.png '=700')
+   ![](/img/fork_cml_project.png)
 
    The following steps can all be done in the GitHub browser interface. However,
    to follow along the commands, we recommend cloning your fork to your local
@@ -58,13 +58,13 @@ supported CI systems (with exceptions as noted!).
 5. In GitHub, open up a Pull Request to compare the `experiment` branch to
    `master`.
 
-   ![](/img/make_pr.png '=700')
+   ![](/img/make_pr.png)
 
    Shortly, you should see a comment from `github-actions` appear in the Pull
    Request with your CML report. This is a result of the function
    `cml-send-comment` in your workflow.
 
-   ![](/img/cml_first_report.png '=700')
+   ![](/img/cml_first_report.png)
 
 This is the gist of the CML workflow: when you push changes to your GitHub
 repository, the workflow in your `.github/workflows/cml.yaml` file gets run and

--- a/content/docs/use-cases/shared-development-server.md
+++ b/content/docs/use-cases/shared-development-server.md
@@ -7,7 +7,7 @@ multiple users or processes. This enables near-instantaneous
 <abbr>workspace</abbr> restoration and switching speeds for everyone – a
 **checkout for data**.
 
-![](/img/shared-server.png '=700') _Data store shared by DVC projects_
+![](/img/shared-server.png) _Data store shared by DVC projects_
 
 ## Preparation
 

--- a/content/docs/use-cases/versioning-data-and-model-files/index.md
+++ b/content/docs/use-cases/versioning-data-and-model-files/index.md
@@ -5,8 +5,7 @@ machine learning models. How do we keep track of changes in data, source code,
 and ML models together? What's the best way to organize and store variations of
 these files and directories?
 
-![](/img/data-ver-complex.png '=700') _Exponential complexity of data science
-projects_
+![](/img/data-ver-complex.png) _Exponential complexity of data science projects_
 
 Another problem in the field has to do with bookkeeping: being able to identify
 past data inputs and processes to understand their results, for knowledge

--- a/content/docs/user-guide/setup-google-drive-remote.md
+++ b/content/docs/user-guide/setup-google-drive-remote.md
@@ -128,7 +128,7 @@ API connections, and its
    ENABLE APIS AND SERVICES**. Find and select the "Google Drive API" in the API
    Library, and click on the **ENABLE** button.
 
-   ![](/img/gdrive-enable-apis-and-services.png '=700')
+   ![](/img/gdrive-enable-apis-and-services.png)
 
 4. Go back to **APIs & Services** in the left sidebar, and select **OAuth
    consent screen**. Chose a **User Type** and click **CREATE**. On the next
@@ -139,7 +139,7 @@ API connections, and its
    credentials** dropdown to select **OAuth client ID**. Chose **Desktop app**
    and click **Create** to proceed with a default client name.
 
-   ![](/img/gdrive-create-credentials.png '=700')
+   ![](/img/gdrive-create-credentials.png)
 
 6. The newly generated **client ID** and **client secret** should be shown to
    you now, and you can always come back to **Credentials** to fetch them.
@@ -199,7 +199,7 @@ authentication is needed.
    Navigate to your Google Drive folder's sharing options and add the service
    account as an editor (read/write) or viewer (read-only):
 
-![](/img/gdrive-share-with-service-account.png '=700')
+![](/img/gdrive-share-with-service-account.png)
 
 ## Authorization
 


### PR DESCRIPTION
* Takes off `=700` off of several documentation images, allowing our `resize-image-plugin` to resize them to a smaller size
* Example: https://dvc-org-take-off-doc-im-curosi.herokuapp.com/doc/cml/start-github