### PR TITLE
Fix #1333

### DIFF
--- a/src/components/Documentation/RightPanel/styles.module.css
+++ b/src/components/Documentation/RightPanel/styles.module.css
@@ -21,12 +21,25 @@
 
   &::-webkit-scrollbar {
     -webkit-appearance: none;
-    width: 7px;
+    width: 0px;
   }
 
   &::-webkit-scrollbar-thumb {
     border-radius: 5px;
     background-color: #7e7e7e;
+  }
+
+  &.overflowTop {
+    box-shadow: inset 0px 5px 10px -10px #7e7e7e;
+  }
+
+  &.overflowBottom {
+    box-shadow: inset 0px -5px 10px -10px #7e7e7e;
+  }
+
+  &.overflowTopBottom {
+    box-shadow: inset 0px 5px 10px -10px #7e7e7e,
+      inset 0px -5px 10px -10px #7e7e7e;
   }
 }
 


### PR DESCRIPTION
* Generalizes the scroll function to automatically scroll any element, even nested ones, when given a valid parent node.
* Automatically scroll the menu at the right panel when scrolling the main content accordingly to which part the user in reading in the moment.
* Exhibits a shadow on the top and below the right panel when there are available elements overflowing the content.
* These shadows are dinamic and change when there are no more elements avaiable to the top or the bottom when scrolling.