### PR TITLE
Hide DownloadButton dropdown with CSS instead of JS

### DIFF
--- a/src/components/DownloadButton/index.tsx
+++ b/src/components/DownloadButton/index.tsx
@@ -173,14 +173,18 @@ const DownloadButton: React.FC<IDownloadButtonProps> = ({ openTop }) => {
       >
         <img className={styles.triangle} src="/img/triangle.svg" alt="" />
       </TwoRowsButton>
-      {isOpened && (
-        <div className={cn(styles.dropdown, openTop && styles.openTop)}>
-          <DownloadButtonDropdownItems
-            onClick={download}
-            userOS={userOS.current}
-          />
-        </div>
-      )}
+      <div
+        className={cn(
+          styles.dropdown,
+          isOpened && styles.open,
+          openTop && styles.openTop
+        )}
+      >
+        <DownloadButtonDropdownItems
+          onClick={download}
+          userOS={userOS.current}
+        />
+      </div>
     </span>
   )
 }

--- a/src/components/DownloadButton/index.tsx
+++ b/src/components/DownloadButton/index.tsx
@@ -9,6 +9,9 @@ import { logEvent } from '../../utils/front/ga'
 
 import styles from './styles.module.css'
 
+const DVC_PUBLIC_S3_LINK =
+  'https://s3-us-east-2.amazonaws.com/dvc-public/dvc-pkgs'
+const DVC_REPO_S3_LINK = 'https://s3-us-east-2.amazonaws.com/dvc-s3-repo'
 const VERSION = `2.5.4`
 
 enum OS {
@@ -27,22 +30,22 @@ const itemsByOs = {
   },
   [OS.OSX]: {
     title: 'macOS',
-    url: `/osxpkg/dvc-${VERSION}.pkg`,
+    url: `${DVC_PUBLIC_S3_LINK}/osxpkg/dvc-${VERSION}.pkg`,
     download: true
   },
   [OS.WINDOWS]: {
     title: 'Windows',
-    url: `/exe/dvc-${VERSION}.exe`,
+    url: `${DVC_PUBLIC_S3_LINK}/exe/dvc-${VERSION}.exe`,
     download: true
   },
   [OS.LINUX]: {
     title: 'Linux Deb',
-    url: `/deb/pool/stable/d/dv/dvc_${VERSION}_amd64.deb`,
+    url: `${DVC_REPO_S3_LINK}/deb/pool/stable/d/dv/dvc_${VERSION}_amd64.deb`,
     download: true
   },
   [OS.LINUX_RPM]: {
     title: 'Linux RPM',
-    url: `/rpm/dvc-${VERSION}-1.x86_64.rpm`,
+    url: `${DVC_REPO_S3_LINK}/rpm/dvc-${VERSION}-1.x86_64.rpm`,
     download: true
   }
 }

--- a/src/components/DownloadButton/styles.module.css
+++ b/src/components/DownloadButton/styles.module.css
@@ -33,9 +33,18 @@
   right: 0;
   top: calc(100% + 3px);
   display: flex;
+  visibility: hidden;
+  opacity: 0;
   flex-direction: column;
   background-color: #fff;
   box-shadow: 0 2px 3px 0 rgba(0, 0, 0, 0.15);
+  transition: opacity 0.2s ease-in-out, visibility 0.2s ease-in-out;
+
+  &.open {
+    visibility: visible;
+    opacity: 1;
+    z-index: 1;
+  }
 
   &.openTop {
     bottom: calc(100% + 3px);


### PR DESCRIPTION
* Originally, our `DownloadButton` dropdown was hidden by taking it out of the HTML with JS. This stops the dropdown links from being read with a link checker and stops the links from being read by a screen reader.