### PR TITLE
docs: copy edit DVC 2.0 notes

### DIFF
--- a/content/docs/command-reference/exp/index.md
+++ b/content/docs/command-reference/exp/index.md
@@ -1,6 +1,6 @@
 # experiments
 
-⚠️ This feature is available since DVC 2.0 ⚠️
+⚠️ This feature is available on DVC 2.0 and above ⚠️
 
 A set of commands to generate and manage <abbr>experiments</abbr>:
 [run](/doc/command-reference/exp/run), [show](/doc/command-reference/exp/show),

--- a/content/docs/command-reference/exp/index.md
+++ b/content/docs/command-reference/exp/index.md
@@ -1,6 +1,6 @@
 # experiments
 
-⚠️ This feature is available on DVC 2.0 and above ⚠️
+_New in DVC 2.0_
 
 A set of commands to generate and manage <abbr>experiments</abbr>:
 [run](/doc/command-reference/exp/run), [show](/doc/command-reference/exp/show),

--- a/content/docs/start/experiments.md
+++ b/content/docs/start/experiments.md
@@ -4,7 +4,7 @@ title: 'Get Started: Experiments'
 
 # Get Started: Experiments
 
-⚠️ This feature is available since DVC 2.0 ⚠️
+⚠️ This feature is available on DVC 2.0 and above ⚠️
 
 <abbr>Experiments</abbr> proliferate quickly in ML projects where there are many
 parameters to tune or other permutations of the code. We can organize such

--- a/content/docs/start/experiments.md
+++ b/content/docs/start/experiments.md
@@ -4,7 +4,7 @@ title: 'Get Started: Experiments'
 
 # Get Started: Experiments
 
-⚠️ This feature is available on DVC 2.0 and above ⚠️
+_New in DVC 2.0_
 
 <abbr>Experiments</abbr> proliferate quickly in ML projects where there are many
 parameters to tune or other permutations of the code. We can organize such

--- a/content/docs/user-guide/basic-concepts/experiment.md
+++ b/content/docs/user-guide/basic-concepts/experiment.md
@@ -7,5 +7,5 @@ tooltip: >-
   experiments](/doc/start/experiments), having [built-in
   mechanisms](/doc/user-guide/experiment-management) like the
   [run-cache](/doc/user-guide/project-structure/internal-files#run-cache) and
-  the `dvc experiments` commands (this feature is available since DVC 2.0).
+  the `dvc experiments` commands (available on DVC 2.0 and above).
 ---

--- a/content/docs/user-guide/experiment-management/index.md
+++ b/content/docs/user-guide/experiment-management/index.md
@@ -1,6 +1,6 @@
 # Experiment Management
 
-⚠️ This feature is available since DVC 2.0 ⚠️
+⚠️ This feature is available on DVC 2.0 and above ⚠️
 
 Data science and ML are iterative processes that require a large number of
 attempts to reach a certain level of a metric. Experimentation is part of the

--- a/content/docs/user-guide/experiment-management/index.md
+++ b/content/docs/user-guide/experiment-management/index.md
@@ -1,6 +1,6 @@
 # Experiment Management
 
-⚠️ This feature is available on DVC 2.0 and above ⚠️
+_New in DVC 2.0_
 
 Data science and ML are iterative processes that require a large number of
 attempts to reach a certain level of a metric. Experimentation is part of the

--- a/content/docs/user-guide/project-structure/pipelines-files.md
+++ b/content/docs/user-guide/project-structure/pipelines-files.md
@@ -98,7 +98,7 @@ metrics and plots.
 
 ## Templating
 
-⚠️ This feature is available on DVC 2.0 and above ⚠️
+_New in DVC 2.0_
 
 `dvc.yaml` supports a templating format to insert values from different sources
 in the YAML structure itself. These sources can be
@@ -227,7 +227,7 @@ ${param.list[0]} # List elements via index in [] (square brackets)
 
 ## `foreach` stages
 
-⚠️ This feature is available on DVC 2.0 and above ⚠️
+_New in DVC 2.0_
 
 You can define more than one stage in a single `dvc.yaml` entry with the
 following syntax. A `foreach` element accepts a list or dictionary with values

--- a/content/docs/user-guide/project-structure/pipelines-files.md
+++ b/content/docs/user-guide/project-structure/pipelines-files.md
@@ -98,7 +98,7 @@ metrics and plots.
 
 ## Templating
 
-⚠️ This feature is available since DVC 2.0 ⚠️
+⚠️ This feature is available on DVC 2.0 and above ⚠️
 
 `dvc.yaml` supports a templating format to insert values from different sources
 in the YAML structure itself. These sources can be
@@ -227,7 +227,7 @@ ${param.list[0]} # List elements via index in [] (square brackets)
 
 ## `foreach` stages
 
-⚠️ This feature is available since DVC 2.0 ⚠️
+⚠️ This feature is available on DVC 2.0 and above ⚠️
 
 You can define more than one stage in a single `dvc.yaml` entry with the
 following syntax. A `foreach` element accepts a list or dictionary with values


### PR DESCRIPTION
Follow up to https://github.com/iterative/dvc.org/pull/2663 (copy edit)

"Since" typically refers to a specific time. Reads a but strange for a version number, I think.