### PR TITLE
Update Link and DownloadButton components

### DIFF
--- a/src/components/DownloadButton/index.tsx
+++ b/src/components/DownloadButton/index.tsx
@@ -9,9 +9,6 @@ import { logEvent } from '../../utils/front/ga'
 
 import styles from './styles.module.css'
 
-const DVC_PUBLIC_S3_LINK =
-  'https://s3-us-east-2.amazonaws.com/dvc-public/dvc-pkgs'
-const DVC_REPO_S3_LINK = 'https://s3-us-east-2.amazonaws.com/dvc-s3-repo'
 const VERSION = `2.5.4`
 
 enum OS {
@@ -30,22 +27,22 @@ const itemsByOs = {
   },
   [OS.OSX]: {
     title: 'macOS',
-    url: `${DVC_PUBLIC_S3_LINK}/osxpkg/dvc-${VERSION}.pkg`,
+    url: `/osxpkg/dvc-${VERSION}.pkg`,
     download: true
   },
   [OS.WINDOWS]: {
     title: 'Windows',
-    url: `${DVC_PUBLIC_S3_LINK}/exe/dvc-${VERSION}.exe`,
+    url: `/exe/dvc-${VERSION}.exe`,
     download: true
   },
   [OS.LINUX]: {
     title: 'Linux Deb',
-    url: `${DVC_REPO_S3_LINK}/deb/pool/stable/d/dv/dvc_${VERSION}_amd64.deb`,
+    url: `/deb/pool/stable/d/dv/dvc_${VERSION}_amd64.deb`,
     download: true
   },
   [OS.LINUX_RPM]: {
     title: 'Linux RPM',
-    url: `${DVC_REPO_S3_LINK}/rpm/dvc-${VERSION}-1.x86_64.rpm`,
+    url: `/rpm/dvc-${VERSION}-1.x86_64.rpm`,
     download: true
   }
 }
@@ -109,6 +106,7 @@ const DownloadButtonDropdownItems: React.FC<IDownloadButtonDropdownItemsProps> =
               'link-with-focus'
             )}
             href={item.url}
+            optOutPreRedirect={true}
             onClick={(): void => onClick(os)}
           >
             {item.title}

--- a/src/components/Link/index.tsx
+++ b/src/components/Link/index.tsx
@@ -12,6 +12,7 @@ export type ILinkProps = {
   target?: undefined | '_blank'
   state?: unknown
   scrollOptions?: object
+  optOutPreRedirect?: undefined | true
 } & React.AnchorHTMLAttributes<HTMLAnchorElement>
 
 const PROTOCOL_REGEXP = /^https?:\/\//
@@ -23,6 +24,7 @@ const ResultLinkComponent: React.FC<ILinkProps> = ({
   children,
   rel,
   target,
+  download = false,
   ...restProps
 }) => {
   // Handle all situations where a basic `a` must be used over Gatsby Link
@@ -34,6 +36,7 @@ const ResultLinkComponent: React.FC<ILinkProps> = ({
   const hrefIsRelativeFragment = href.startsWith('#')
 
   if (
+    download ||
     !hrefIsRelative ||
     hrefIsMailto ||
     hrefHasTarget ||
@@ -54,7 +57,13 @@ const ResultLinkComponent: React.FC<ILinkProps> = ({
     }
 
     return (
-      <a href={href} rel={rel} target={target} {...restProps}>
+      <a
+        download={download}
+        href={href}
+        rel={rel}
+        target={target}
+        {...restProps}
+      >
         {children}
       </a>
     )
@@ -76,8 +85,14 @@ const scrollToHash = (hash: string, scrollOptions = {}): void => {
   }
 }
 
-const Link: React.FC<ILinkProps> = ({ href, scrollOptions, ...restProps }) => {
+const Link: React.FC<ILinkProps> = ({
+  href,
+  scrollOptions,
+  optOutPreRedirect,
+  ...restProps
+}) => {
   const currentLocation = useLocation()
+
   const onClick = useCallback(
     (e: React.MouseEvent<HTMLAnchorElement>) => {
       if (restProps.onClick) {
@@ -103,7 +118,7 @@ const Link: React.FC<ILinkProps> = ({ href, scrollOptions, ...restProps }) => {
 
   const location = new URL(href)
 
-  if (location.host === currentLocation.host) {
+  if (location.host === currentLocation.host && !optOutPreRedirect) {
     // Replace link href with redirect if it exists
     const [, redirectUrl] = getRedirect(location.host, location.pathname)
 


### PR DESCRIPTION
* adds `optOutPredirect` prop to `Link`, stopping links from being pre redirected if desired
* ~~have Link render on mount, stopping any href changes due to hydration(fixes "CML" link shows 404 page bug mentioned in #2659)~~
* converts DownloadButton download absolute links to relative links

Fixes #2668