### PR TITLE
Remove `gatsby-plugin-catch-links`

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -123,7 +123,6 @@ const plugins = [
   },
   'gatsby-transformer-sharp',
   'gatsby-plugin-sharp',
-  'gatsby-plugin-catch-links',
   {
     resolve: 'gatsby-plugin-manifest',
     options: {

--- a/package.json
+++ b/package.json
@@ -114,7 +114,6 @@
     "eslint-plugin-jsx-a11y": "^6.2.3",
     "eslint-plugin-prettier": "^3.1.2",
     "eslint-plugin-react": "^7.19.0",
-    "gatsby-plugin-catch-links": "^2.2.1",
     "gatsby-plugin-feed": "^2.4.1",
     "gatsby-plugin-google-analytics": "^2.2.2",
     "gatsby-plugin-manifest": "2.2.23",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7122,14 +7122,6 @@ gatsby-page-utils@^0.2.7:
     lodash "^4.17.15"
     micromatch "^3.1.10"
 
-gatsby-plugin-catch-links@^2.2.1:
-  version "2.3.2"
-  resolved "https://registry.yarnpkg.com/gatsby-plugin-catch-links/-/gatsby-plugin-catch-links-2.3.2.tgz#c6a24b7c1ea067bc48684db01448d0c44de658c5"
-  integrity sha512-gFZSWOOXj9pMUC7gwogkrKjtjj1qqYjAXlWVtQ9FI1Gcngvi5NNYsWQqTbGpsgyTd2ycyTFIl4YhOyP3oHBgFQ==
-  dependencies:
-    "@babel/runtime" "^7.9.6"
-    escape-string-regexp "^1.0.5"
-
 gatsby-plugin-feed@^2.4.1:
   version "2.5.3"
   resolved "https://registry.yarnpkg.com/gatsby-plugin-feed/-/gatsby-plugin-feed-2.5.3.tgz#4a801599f2a6bcb649d2b0063cfb1fced790de00"


### PR DESCRIPTION
* removes `gatsby-plugin-catch-links` as it breaks our redirect links(see #2659) and makes little difference to our page links
* alternatively we can keep plugin if desired and add a `excludePattern` for redirect links

Fixes #2659