### PR TITLE
Add excludePattern to `gatsby-plugin-catch-links` config

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -123,7 +123,12 @@ const plugins = [
   },
   'gatsby-transformer-sharp',
   'gatsby-plugin-sharp',
-  'gatsby-plugin-catch-links',
+  {
+    resolve: 'gatsby-plugin-catch-links',
+    options: {
+      excludePattern: /\/doc\/cml/
+    }
+  },
   {
     resolve: 'gatsby-plugin-manifest',
     options: {


### PR DESCRIPTION
* adds an `excludePattern` to `gatsby-plugin-catch-links`, stopping our Doc "CML" link from showing a 404 page(mentioned in #2659)