### PR TITLE
Update dvc download link href

### DIFF
--- a/redirects-list.json
+++ b/redirects-list.json
@@ -20,6 +20,10 @@
   "^/((?:exe|osxpkg)/.+)                                                                  https://s3-us-east-2.amazonaws.com/dvc-public/dvc-pkgs/$1 303",
   "^/((?:deb|rpm)/.+)                                                                     https://s3-us-east-2.amazonaws.com/dvc-s3-repo/$1 303",
   "^/(?:help|chat)/?$                                                                     https://discordapp.com/invite/dvwXA2N 303",
+  "^/download/osx/dvc-(.+)$                                                               https://s3-us-east-2.amazonaws.com/dvc-public/dvc-pkgs/osxpkg/dvc-$1.pkg 303",
+  "^/download/win/dvc-(.+)$                                                               https://s3-us-east-2.amazonaws.com/dvc-public/dvc-pkgs/exe/dvc-$1.exe 303",
+  "^/download/linux-deb/dvc-(.+)$                                                         https://s3-us-east-2.amazonaws.com/dvc-s3-repo/deb/pool/stable/d/dv/dvc_$1_amd64.deb 303",
+  "^/download/linux-rpm/dvc-(.+)$                                                         https://s3-us-east-2.amazonaws.com/dvc-s3-repo/rpm/dvc-$1-1.x86_64.rpm 303",
   "^/(?:docs|documentation)(/.*)?$                                                        /doc$1",
 
   "^/doc/get-started(/.*)?$                                                               /doc/start",

--- a/src/components/DownloadButton/index.tsx
+++ b/src/components/DownloadButton/index.tsx
@@ -27,22 +27,22 @@ const itemsByOs = {
   },
   [OS.OSX]: {
     title: 'macOS',
-    url: `/osxpkg/dvc-${VERSION}.pkg`,
+    url: `/download/osx/dvc-${VERSION}`,
     download: true
   },
   [OS.WINDOWS]: {
     title: 'Windows',
-    url: `/exe/dvc-${VERSION}.exe`,
+    url: `/download/win/dvc-${VERSION}`,
     download: true
   },
   [OS.LINUX]: {
     title: 'Linux Deb',
-    url: `/deb/pool/stable/d/dv/dvc_${VERSION}_amd64.deb`,
+    url: `/download/linux-deb/dvc-${VERSION}`,
     download: true
   },
   [OS.LINUX_RPM]: {
     title: 'Linux RPM',
-    url: `/rpm/dvc-${VERSION}-1.x86_64.rpm`,
+    url: `/download/linux-rpm/dvc-${VERSION}`,
     download: true
   }
 }


### PR DESCRIPTION
* simplify download links to `/download/{OS}/dvc-{VERSION}`
* if you have an idea on a better format for the download links, please let me know!

Fixes #2691
