### PR TITLE
Add InvalidMetricTypeError exception

### DIFF
--- a/content/docs/dvclive/api-reference/init.md
+++ b/content/docs/dvclive/api-reference/init.md
@@ -52,7 +52,7 @@ all existing `.tsv` files, `{path}.json` and `{path.html}`.
 
 ## Exceptions
 
-- Currently **None**
+None
 
 [`dvclive.log()`]: /doc/dvclive/api-reference/log
 [`dvclive.next_step()`]: /doc/dvclive/api-reference/next_step

--- a/content/docs/dvclive/api-reference/init.md
+++ b/content/docs/dvclive/api-reference/init.md
@@ -52,7 +52,7 @@ all existing `.tsv` files, `{path}.json` and `{path.html}`.
 
 ## Exceptions
 
-- `dvclive.error.DvcLiveError` - If the directory `path` can't be created.
+- Currently **None**
 
 [`dvclive.log()`]: /doc/dvclive/api-reference/log
 [`dvclive.next_step()`]: /doc/dvclive/api-reference/next_step

--- a/content/docs/dvclive/api-reference/log.md
+++ b/content/docs/dvclive/api-reference/log.md
@@ -51,6 +51,7 @@ environment variables (when used alongside `DVC`).
 
 ## Exceptions
 
-- `dvclive.error.InvalidMetricTypeError` - If the provided `val` has not supported type.
+- `dvclive.error.InvalidMetricTypeError` - thrown if the provided `val` does not
+  have a supported type
 
 [`dvclive.init()`]: /doc/dvclive/api-reference/init

--- a/content/docs/dvclive/api-reference/log.md
+++ b/content/docs/dvclive/api-reference/log.md
@@ -51,6 +51,6 @@ environment variables (when used alongside `DVC`).
 
 ## Exceptions
 
-- `dvclive.error.DvcLiveError` - If the provided `val` has not supported type.
+- `dvclive.error.InvalidMetricTypeError` - If the provided `val` has not supported type.
 
 [`dvclive.init()`]: /doc/dvclive/api-reference/init


### PR DESCRIPTION
Replace `dvclive.error.DvcLiveError` with `dvclive.error.InvalidMetricTypeError`.

> You may disregard these recommendations if you used the **Edit on GitHub** button from dvc.org to improve a doc in place.

Per https://github.com/iterative/dvclive/pull/135