### PR TITLE
Close open redirect

### DIFF
--- a/redirects-list.json
+++ b/redirects-list.json
@@ -59,5 +59,5 @@
 
   "^/doc/studio/view-settings$                                                            /doc/studio/user-guide/views/view-settings",
 
-  "^/([^/].+)/$                                                                           /$1"
+  "^/(.+)/$                                                                               /$1"
 ]

--- a/redirects-list.json
+++ b/redirects-list.json
@@ -59,5 +59,5 @@
 
   "^/doc/studio/view-settings$                                                            /doc/studio/user-guide/views/view-settings",
 
-  "^/(.+)/$                                                                               /$1"
+  "^/([^/].+)/$                                                                           /$1"
 ]

--- a/src/utils/shared/redirects.js
+++ b/src/utils/shared/redirects.js
@@ -53,7 +53,7 @@ const matchRedirectList = (host, pathname) => {
   for (const { matchPathname, regex, replace, code } of getRedirects()) {
     const matchTarget = matchPathname ? pathname : wholeUrl
     if (regex.test(matchTarget)) {
-      return [code, matchTarget.replace(regex, replace)]
+      return [code, matchTarget.replace(regex, replace).replace(/^\/+/, '/')]
     }
   }
 

--- a/src/utils/shared/redirects.test.js
+++ b/src/utils/shared/redirects.test.js
@@ -241,9 +241,8 @@ describe('getRedirects', () => {
   })
 
   describe('Does not accidentally redirect to an external site', () => {
-    itRedirects('https://dvc.org//google.com/', '/google.com')
     itRedirects('//google.com/', '/google.com')
-    itRedirects('///evil.com/', '/evil.com')
+    itRedirects('https://dvc.org//google.com/', '/google.com')
     itRedirects('/////////evil.com/', '/evil.com')
   })
 })

--- a/src/utils/shared/redirects.test.js
+++ b/src/utils/shared/redirects.test.js
@@ -239,4 +239,8 @@ describe('getRedirects', () => {
       '/doc/use-cases/versioning-data-and-model-files'
     )
   })
+
+  describe('Does not have an open redirect bug on trailing slash removal', () => {
+    itRedirects('//google.com/', '/google.com')
+  })
 })

--- a/src/utils/shared/redirects.test.js
+++ b/src/utils/shared/redirects.test.js
@@ -240,7 +240,8 @@ describe('getRedirects', () => {
     )
   })
 
-  describe('Does not have an open redirect bug on trailing slash removal', () => {
+  describe('Does not accidentally redirect to an external site', () => {
     itRedirects('//google.com/', '/google.com')
+    itRedirects('///evil.com/', '/evil.com')
   })
 })

--- a/src/utils/shared/redirects.test.js
+++ b/src/utils/shared/redirects.test.js
@@ -241,7 +241,9 @@ describe('getRedirects', () => {
   })
 
   describe('Does not accidentally redirect to an external site', () => {
+    itRedirects('https://dvc.org//google.com/', '/google.com')
     itRedirects('//google.com/', '/google.com')
     itRedirects('///evil.com/', '/evil.com')
+    itRedirects('/////////evil.com/', '/evil.com')
   })
 })


### PR DESCRIPTION
Fixes #2749 

This PR tweaks our "trim trailing slashes" redirect entry to not apply to root-relative links that start with two slashes, which should close the open redirect bug since single slashes should only redirect to our site.