### PR TITLE
Remove `npm install` from contributing docs

### DIFF
--- a/content/docs/user-guide/contributing/docs.md
+++ b/content/docs/user-guide/contributing/docs.md
@@ -70,12 +70,6 @@ project dependencies with Yarn:
 $ yarn
 ```
 
-You may need to resolve dependencies at this point by running:
-
-```dvc
-$ npm install
-```
-
 Launch the server locally with:
 
 ```dvc


### PR DESCRIPTION
dvc.org is a yarn project, so this line is incorrect as far as I can tell

The run of `yarn` on the previous line should do what this line is suggesting, so we can just completely remove the section and the instructions still hold true.