### PR TITLE
experiment-management: remove warning about no parameter validation

### DIFF
--- a/content/docs/user-guide/experiment-management/running-experiments.md
+++ b/content/docs/user-guide/experiment-management/running-experiments.md
@@ -164,10 +164,6 @@ times:
 $ dvc exp run -S learning_rate=0.001 -S units=128
 ```
 
-> ⚠️ Note that DVC doesn't check whether parameters given to `--set-param` are
-> already in the parameters file. If there is a typo, a new or different param
-> will be added/changed.
-
 ## The experiments queue
 
 The `--queue` option of `dvc exp run` tells DVC to append an experiment for


### PR DESCRIPTION
Covers feature change iterative/dvc#6521. Parameters will now be validated.

Related issue iterative/dvc#5477

> You may disregard these recommendations if you used the **Edit on GitHub** button from dvc.org to improve a doc in place.

❗ Please read the guidelines in the [Contributing to the Documentation](https://dvc.org/doc/user-guide/contributing/docs) list if you make any substantial changes to the documentation or JS engine.

🐛 Please make sure to mention `Fix #issue` (if applicable) in the description of the PR. This causes GitHub to close it automatically when the PR is merged.

Please choose to [allow us](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to edit your branch when creating the PR.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
