### PR TITLE
Fix broken link to Azure authentication examples

### DIFF
--- a/content/docs/command-reference/remote/add.md
+++ b/content/docs/command-reference/remote/add.md
@@ -159,7 +159,7 @@ a Microsoft application.
 
 To use a custom authentication method, use the parameters described in
 `dvc remote modify`. See some
-[examples](#example-some-azure-authentication-methods).
+[examples](/doc/command-reference/remote/modify#example-some-azure-authentication-methods).
 
 </details>
 


### PR DESCRIPTION
In the section https://dvc.org/doc/command-reference/remote/add#supported-storage-types, there is a broken link on "Click for Microsoft Azure Blob Storage". The link should point to: https://dvc.org/doc/command-reference/remote/modify#example-some-azure-authentication-methods.
