### PR TITLE
fix: correct argument order

### DIFF
--- a/content/docs/command-reference/remote/index.md
+++ b/content/docs/command-reference/remote/index.md
@@ -136,7 +136,7 @@ endpointurl = https://object-storage.example.com
 specific subcommand for this:
 
 ```dvc
-$ dvc remote rename newremote oldremote
+$ dvc remote rename oldremote newremote
 ```
 
 ## Example: Remove a remote


### PR DESCRIPTION
The order of arguments for `dvc remote rename` is reversed in the old version. 
According to the page @ `dvc remote rename -h`, the old remote `name` comes first followed by the `new` remote name argument.

> You may disregard these recommendations if you used the **Edit on GitHub** button from dvc.org to improve a doc in place.

❗ Please read the guidelines in the [Contributing to the Documentation](https://dvc.org/doc/user-guide/contributing/docs) list if you make any substantial changes to the documentation or JS engine.

🐛 Please make sure to mention `Fix #issue` (if applicable) in the description of the PR. This causes GitHub to close it automatically when the PR is merged.

Please choose to [allow us](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to edit your branch when creating the PR.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
