### PR TITLE
ref: alias `ls` for `list`

### DIFF
--- a/content/docs/command-reference/list.md
+++ b/content/docs/command-reference/list.md
@@ -3,6 +3,8 @@
 List project contents, including files, models, and directories tracked by DVC
 and by Git.
 
+> Aliased to `dvc ls`.
+
 > Useful to find data to `dvc get`, `dvc import`, or for `dvc.api` functions.
 
 ## Synopsis


### PR DESCRIPTION
Per https://github.com/iterative/dvc/pull/6683 (added alias to `dvc list` as `dvc ls` to fix https://github.com/iterative/dvc/issues/6651)