### PR TITLE
Document short aliases `--csv/--json/--md` flags

### DIFF
--- a/content/docs/command-reference/diff.md
+++ b/content/docs/command-reference/diff.md
@@ -9,7 +9,7 @@ workspace.
 ```usage
 usage: dvc diff [-h] [-q | -v]
                 [--targets [<paths> [<paths> ...]]]
-                [--show-json] [--show-hash] [--show-md]
+                [--json] [--show-hash] [--md]
                 [a_rev] [b_rev]
 
 positional arguments:
@@ -30,7 +30,7 @@ branch or tag name, Git commit hash, etc.
 It defaults to comparing the current workspace and the last commit (`HEAD`), if
 arguments `a_rev` and `b_rev` are not specified.
 
-Options `--show-json` and `--show-hash` can be used to modify format of the
+Options `--json` and `--show-hash` can be used to modify format of the
 output of this command. See the [Options](#options) and [Examples](#examples)
 sections below for more details.
 
@@ -56,10 +56,10 @@ for example when `dvc init` was used with the `--no-scm` option.
   $ dvc diff --targets t1.json t2.yaml -- HEAD v1
   ```
 
-- `--show-json` - prints the command's output in easily parsable JSON format,
+- `--json` - prints the command's output in easily parsable JSON format,
   instead of a human-readable table.
 
-- `--show-md` - prints the command's output in Markdown table format.
+- `--md` - prints the command's output in Markdown table format.
 
 - `--show-hash` - print file and directory hash values along with their path.
   Useful for debug purposes.
@@ -188,7 +188,7 @@ Let's use the same command as above, but with JSON output and including hash
 values:
 
 ```dvc
-$ dvc diff --show-json --show-hash \
+$ dvc diff --json --show-hash \
            baseline-experiment bigrams-experiment
 ```
 

--- a/content/docs/command-reference/exp/diff.md
+++ b/content/docs/command-reference/exp/diff.md
@@ -7,7 +7,7 @@ Show changes in [metrics](/doc/command-reference/metrics) and
 
 ```usage
 usage: dvc exp diff [-h] [-q | -v] [--all] [--param-deps]
-                    [--show-json] [--show-md] [--old]
+                    [--json] [--md] [--old]
                     [--no-path] [--precision <n>]
                     [a_rev] [b_rev]
 positional arguments:
@@ -54,10 +54,10 @@ all the current experiments (without comparisons).
 
 - `--param-deps` - include only parameters that are stage dependencies.
 
-- `--show-json` - prints the command's output in easily parsable JSON format,
+- `--json` - prints the command's output in easily parsable JSON format,
   instead of a human-readable table.
 
-- `--show-md` - prints the command's output in the Markdown table format
+- `--md` - prints the command's output in the Markdown table format
   ([GFM](https://github.github.com/gfm/#tables-extension-)).
 
 - `--old` - include the "Old" value column in addition to the new "Value" (and

--- a/content/docs/command-reference/exp/show.md
+++ b/content/docs/command-reference/exp/show.md
@@ -14,7 +14,7 @@ usage: dvc exp show [-h] [-q | -v] [-a] [-T] [-A] [-n <num>]
                     [--exclude-params <params_list>] [--param-deps]
                     [--sort-by <metric/param>]
                     [--sort-order {asc,desc}] [--no-timestamp] [--sha]
-                    [--show-json] [--show-csv] [--precision <n>]
+                    [--json] [--csv] [--precision <n>]
 ```
 
 ## Description
@@ -112,10 +112,10 @@ metric or param.
 - `--sha` - display Git commit (SHA) hashes instead of branch, tag, or
   experiment names.
 
-- `--show-json` - prints the command's output in easily parsable JSON format,
+- `--json` - prints the command's output in easily parsable JSON format,
   instead of a human-readable table.
 
-- `--show-csv` - prints the command's output in CSV format instead of a
+- `--csv` - prints the command's output in CSV format instead of a
   human-readable table.
 
 - `--precision <n>` -

--- a/content/docs/command-reference/list.md
+++ b/content/docs/command-reference/list.md
@@ -9,7 +9,7 @@ and by Git.
 
 ```usage
 usage: dvc list [-h] [-q | -v] [-R] [--dvc-only]
-                [--show-json] [--rev [<commit>]]
+                [--json] [--rev [<commit>]]
                 url [path]
 
 positional arguments:
@@ -65,7 +65,7 @@ accessed with `dvc get`, `dvc import`, or `dvc.api`.
   [Git revision](https://git-scm.com/docs/revisions)) of the repository to list
   content for. The latest commit in `master` (tip of the default branch) is used
   by default when this option is not specified.
-- `--show-json` - prints the command's output in easily parsable JSON format,
+- `--json` - prints the command's output in easily parsable JSON format,
   instead of a human-readable table.
 
 - `-h`, `--help` - prints the usage/help message, and exit.

--- a/content/docs/command-reference/metrics/diff.md
+++ b/content/docs/command-reference/metrics/diff.md
@@ -10,7 +10,7 @@ Compare [metrics](/doc/command-reference/metrics) between two commits in the
 ```usage
 usage: dvc metrics diff [-h] [-q | -v]
                         [--targets [<paths> [<paths> ...]]] [-R]
-                        [--all] [--show-json] [--show-md] [--no-path]
+                        [--all] [--json] [--md] [--no-path]
                         [--old] [--precision <n>]
                         [a_rev] [b_rev]
 
@@ -66,10 +66,10 @@ all the current metrics (without comparisons).
 
 - `--all` - list all metrics, including those without changes.
 
-- `--show-json` - prints the command's output in JSON format (machine-readable)
+- `--json` - prints the command's output in JSON format (machine-readable)
   instead of a human-readable table.
 
-- `--show-md` - prints the command's output in the Markdown table format
+- `--md` - prints the command's output in the Markdown table format
   ([GFM](https://github.github.com/gfm/#tables-extension-)).
 
 - `--old` - include the "Old" value column in addition to the new "Value" (and

--- a/content/docs/command-reference/metrics/show.md
+++ b/content/docs/command-reference/metrics/show.md
@@ -6,7 +6,7 @@ Print [metrics](/doc/command-reference/metrics), with optional formatting.
 
 ```usage
 usage: dvc metrics show [-h] [-q | -v] [-a] [-T] [--all-commits]
-                        [--show-json] [--show-md] [-R]
+                        [--json] [--md] [-R]
                         [targets [targets ...]]
 
 positional arguments:
@@ -44,10 +44,10 @@ compares them with a previous version.
   well as in the workspace. This prints metrics in the entire commit history of
   the project.
 
-- `--show-json` - prints the command's output in easily parsable JSON format,
+- `--json` - prints the command's output in easily parsable JSON format,
   instead of a human-readable table.
 
-- `--show-md` - prints the command's output in Markdown table format.
+- `--md` - prints the command's output in Markdown table format.
 
 - `-R`, `--recursive` - determines the metrics files to show by searching each
   target directory and its subdirectories for `dvc.yaml` files to inspect. If

--- a/content/docs/command-reference/params/diff.md
+++ b/content/docs/command-reference/params/diff.md
@@ -11,7 +11,7 @@ the <abbr>DVC repository</abbr>, or between a commit and the
 ```usage
 usage: dvc params diff [-h] [-q | -v]
                        [--targets [<paths> [<paths> ...]]] [--all]
-                       [--deps] [--show-json] [--show-md] [--no-path]
+                       [--deps] [--json] [--md] [--no-path]
 
 positional arguments:
   a_rev          Old Git commit to compare (defaults to HEAD)
@@ -62,10 +62,10 @@ specified with the `--targets` option.
 
 - `--deps` - include only parameters that are stage dependencies.
 
-- `--show-json` - prints the command's output in easily parsable JSON format,
+- `--json` - prints the command's output in easily parsable JSON format,
   instead of a human-readable table.
 
-- `--show-md` - prints the command's output in the Markdown table format.
+- `--md` - prints the command's output in the Markdown table format.
 
 - `-h`, `--help` - prints the usage/help message, and exit.
 

--- a/content/docs/command-reference/status.md
+++ b/content/docs/command-reference/status.md
@@ -9,7 +9,7 @@ and remote storage.
 
 ```usage
 usage: dvc status [-h] [-v] [-j <number>] [-q] [-c] [-r <name>] [-a] [-T]
-                  [--all-commits] [-d] [-R] [--show-json]
+                  [--all-commits] [-d] [-R] [--json]
                   [targets [targets ...]]
 
 positional arguments:
@@ -142,7 +142,7 @@ that.
   [remote storage](/doc/command-reference/remote) to compare against (see
   `dvc remote list`. Implies `--cloud`.
 
-- `--show-json` - prints the command's output in easily parsable JSON format,
+- `--json` - prints the command's output in easily parsable JSON format,
   instead of a human-readable table.
 
 - `-j <number>`, `--jobs <number>` - parallelism level for DVC to access data


### PR DESCRIPTION
We replaced `--show-csv`/`--show-json`/`--show-md` with short aliases `--csv/`--json`/`--md` respectively in https://github.com/iterative/dvc/pull/6711. Though even if the `--show-*` are still supported, I am removing those mentions from the docs, as it may confuse users. I did not touch blogs when making the changes.

The change is not released yet, so we may want to wait for merging this.

