### PR TITLE
Shouldn't tracked file replacement be followed with dvc push? 

### DIFF
--- a/content/docs/user-guide/how-to/update-tracked-data.md
+++ b/content/docs/user-guide/how-to/update-tracked-data.md
@@ -49,6 +49,10 @@ Add the new version of the file back with DVC:
 $ dvc add train.tsv
 $ git add train.tsv.dvc
 $ git commit -m "modify train data"
+
+# If you have remote storage and/or an upstream repo:
+$ dvc push
+$ git push
 ```
 
 ## Replacing files
@@ -75,15 +79,8 @@ And start tracking it again:
 $ dvc add train.tsv
 $ git add train.tsv.dvc .gitignore
 $ git commit -m "new train data"
-```
 
-## If you're using Git and DVC remotes
-
-Don't forget to push your updates to your remote repo for everyone to have the
-latest version of the modified or replaced data.
-
-```dvc
-$ git push
+# If you have remote storage and/or an upstream repo:
 $ dvc push
+$ git push
 ```
-


### PR DESCRIPTION
In my case, only when dvc push was called, the files were actually uploaded. I think it can be misleading for some users
