### PR TITLE
Add list styling to blog post head description

### DIFF
--- a/src/components/Blog/Post/styles.module.css
+++ b/src/components/Blog/Post/styles.module.css
@@ -82,6 +82,19 @@
     border-radius: 3px;
     background-color: rgba(27, 31, 35, 0.05);
   }
+
+  ul {
+    padding-left: 2em;
+    margin-bottom: 16px;
+  }
+
+  li {
+    margin: 16px 0;
+
+    + li {
+      margin-top: 0.25em;
+    }
+  }
 }
 
 .share {


### PR DESCRIPTION
* styling is based on the docs `ul` and `li` styling

Example on how list styling looks:

![image](https://user-images.githubusercontent.com/43496356/136854973-5de30574-0b26-45ce-81a4-1605980cfad1.png)

Fixes #1224 