### PR TITLE
doc:  Get Started: Experiments: qualifier for video

### DIFF
--- a/content/docs/start/experiments.md
+++ b/content/docs/start/experiments.md
@@ -9,8 +9,8 @@ rapidly. DVC can track these experiments, list and compare their most relevant
 parameters and metrics, navigate among them, and commit only the ones that we
 need to Git.
 
-(⚠️This video is out-of-date and will be updated soon! Where there are
-discrepancies between docs and video, please follow the docs.)
+> ⚠️This video is out-of-date and will be updated soon! Where there are
+> discrepancies between docs and video, please follow the docs.
 
 https://youtu.be/FHQq_zZz5ms
 


### PR DESCRIPTION
Adding qualifier for out-dated video in Get Started: Experiments.

Fixes https://github.com/iterative/dvc.org/issues/2935