### PR TITLE
ref: `exp show --only-changed`

### DIFF
--- a/content/docs/command-reference/exp/show.md
+++ b/content/docs/command-reference/exp/show.md
@@ -175,7 +175,8 @@ $ dvc exp show --include-params=featurize
 └───────────────────────┴──────────────┴─────────┴────────────────────────┴──────────────────┘
 ```
 
-You can also filter out the metrics and parameters that didn't change:
+You can also filter out the metrics and parameters that are the same
+across the shown experiments:
 
 ```dvc
 $ dvc exp show --only-changed

--- a/content/docs/command-reference/exp/show.md
+++ b/content/docs/command-reference/exp/show.md
@@ -175,8 +175,8 @@ $ dvc exp show --include-params=featurize
 └───────────────────────┴──────────────┴─────────┴────────────────────────┴──────────────────┘
 ```
 
-You can also filter out the metrics and parameters that are the same
-across the shown experiments:
+You can also filter out the metrics and parameters that are the same across the
+shown experiments:
 
 ```dvc
 $ dvc exp show --only-changed

--- a/content/docs/command-reference/exp/show.md
+++ b/content/docs/command-reference/exp/show.md
@@ -77,8 +77,8 @@ metric or param.
 - `--only-changed` - show only parameters and metrics with values that vary
   across experiments. Note that this option takes precedence over
   `--include-params` and `--include-metrics`, for example given
-  `--include-params=foo --only-changed`, param `foo` would still be hidden
-  if its value is the same in all experiments.
+  `--include-params=foo --only-changed`, param `foo` would still be hidden if
+  its value is the same in all experiments.
 
 - `--include-params <list>` - show the specified `dvc params` in the table only.
   Accepts a comma-separated `list` of param names. Shell style wildcards

--- a/content/docs/command-reference/exp/show.md
+++ b/content/docs/command-reference/exp/show.md
@@ -76,8 +76,8 @@ metric or param.
 
 - `--only-changed` - Only show metrics/params with values varying across the
   selected experiments. When used along with
-  `--include-params`/`--include-metrics`, this option prevails over the specific
-  values passed to those options. For example, given
+  `--include-params`/`--include-metrics`, `--only-changed` prevails over the
+  specific values passed to `--include`. For example, given
   `--only-changed --include-params=foo`, if `foo` doesn't vary across the
   selected experiments, it won't be shown in the final table.
 

--- a/content/docs/command-reference/exp/show.md
+++ b/content/docs/command-reference/exp/show.md
@@ -74,8 +74,8 @@ metric or param.
 
 - `--param-deps` - include only parameters that are stage dependencies.
 
-- `--only-changed` - Only show metrics/params with values varying across
-  the selected experiments.
+- `--only-changed` - Only show metrics/params with values varying across the
+  selected experiments.
 
 - `--include-params <list>` - show the specified `dvc params` in the table only.
   Accepts a comma-separated `list` of param names. Shell style wildcards

--- a/content/docs/command-reference/exp/show.md
+++ b/content/docs/command-reference/exp/show.md
@@ -15,6 +15,7 @@ usage: dvc exp show [-h] [-q | -v] [-a] [-T] [-A] [-n <num>]
                     [--sort-by <metric/param>]
                     [--sort-order {asc,desc}] [--no-timestamp] [--sha]
                     [--json] [--csv] [--md] [--precision <n>]
+                    [--only-changed]
 ```
 
 ## Description
@@ -72,6 +73,9 @@ metric or param.
   paginator.
 
 - `--param-deps` - include only parameters that are stage dependencies.
+
+- `--only-changed` - Only show metrics/params with values varying across
+  the selected experiments.
 
 - `--include-params <list>` - show the specified `dvc params` in the table only.
   Accepts a comma-separated `list` of param names. Shell style wildcards
@@ -169,6 +173,21 @@ $ dvc exp show --include-params=featurize
 │ ├── exp-1dad0         │ Oct 09, 2020 │ 0.57756 │ 2000                   │ 2                │
 │ └── exp-1df77         │ Oct 09, 2020 │ 0.51676 │ 500                    │ 2                │
 └───────────────────────┴──────────────┴─────────┴────────────────────────┴──────────────────┘
+```
+
+You can also filter out the metrics and parameters that didn't change:
+
+```dvc
+$ dvc exp show --only-changed
+┏━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━┳━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃ Experiment            ┃ Created      ┃     auc ┃ featurize.max_features ┃
+┡━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━╇━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━┩
+│ workspace             │ -            │ 0.61314 │ 1500                   │
+│ 10-bigrams-experiment │ Jun 20, 2020 │ 0.61314 │ 1500                   │
+│ ├── exp-e6c97         │ Oct 21, 2020 │ 0.61314 │ 1500                   │
+│ ├── exp-1dad0         │ Oct 09, 2020 │ 0.57756 │ 2000                   │
+│ └── exp-1df77         │ Oct 09, 2020 │ 0.51676 │ 500                    │
+└───────────────────────┴──────────────┴─────────┴────────────────────────┘
 ```
 
 Sort experiments by the `auc` metric, in ascending order:

--- a/content/docs/command-reference/exp/show.md
+++ b/content/docs/command-reference/exp/show.md
@@ -74,12 +74,11 @@ metric or param.
 
 - `--param-deps` - include only parameters that are stage dependencies.
 
-- `--only-changed` - Only show metrics/params with values varying across the
-  selected experiments. When used along with
-  `--include-params`/`--include-metrics`, `--only-changed` prevails over the
-  specific values passed to `--include`. For example, given
-  `--only-changed --include-params=foo`, if `foo` doesn't vary across the
-  selected experiments, it won't be shown in the final table.
+- `--only-changed` - show only parameters and metrics with values that vary
+  across experiments. Note that this option takes precedence over
+  `--include-params` and `--include-metrics`, for example given
+  `--include-params=foo --only-changed`, param `foo` would still be hidden
+  if its value is the same in all experiments.
 
 - `--include-params <list>` - show the specified `dvc params` in the table only.
   Accepts a comma-separated `list` of param names. Shell style wildcards
@@ -179,7 +178,7 @@ $ dvc exp show --include-params=featurize
 └───────────────────────┴──────────────┴─────────┴────────────────────────┴──────────────────┘
 ```
 
-You can also filter out the metrics and parameters that are the same across the
+You can also filter out any metrics and parameters that do not change across the
 shown experiments:
 
 ```dvc

--- a/content/docs/command-reference/exp/show.md
+++ b/content/docs/command-reference/exp/show.md
@@ -75,7 +75,11 @@ metric or param.
 - `--param-deps` - include only parameters that are stage dependencies.
 
 - `--only-changed` - Only show metrics/params with values varying across the
-  selected experiments.
+  selected experiments. When used along with
+  `--include-params`/`--include-metrics`, this option prevails over the specific
+  values passed to those options. For example, given
+  `--only-changed --include-params=foo`, if `foo` doesn't vary across the
+  selected experiments, it won't be shown in the final table.
 
 - `--include-params <list>` - show the specified `dvc params` in the table only.
   Accepts a comma-separated `list` of param names. Shell style wildcards


### PR DESCRIPTION
docs updates for https://github.com/iterative/dvc/pull/6867

Not sure if this will actually get merged before #2862 but seems relevant to eventually include the option in the guide.