### PR TITLE
Add shortlinks for running-experiments and pipeline-files.

### DIFF
--- a/redirects-list.json
+++ b/redirects-list.json
@@ -33,6 +33,8 @@
   "^/doc/tutorials/get-started(/.*)?$                                                     /doc/start",
   "^/doc/tutorials/versioning(/.*)?$                                                      /doc/use-cases/versioning-data-and-model-files/tutorial",
   "^/doc/tutorials(/.*)?                                                                  /doc/start",
+  "^/doc/running-experiments$                                                             /doc/user-guide/experiment-management/running-experiments",
+  "^/doc/pipeline-files$                                                                  /doc/user-guide/project-structure/pipelines-files",
 
   "^/doc/use-cases/data-and-model-files-versioning/?$                                     /doc/use-cases/versioning-data-and-model-files",
   "^/doc/doc/use-cases/shared-development-server$                                         /doc/use-cases/fast-data-storage-layer#example-shared-development-server",


### PR DESCRIPTION
These shortlinks will be used for ui messages on `exp init`.

Fixes #2967.
