### PR TITLE
ref: fix aliasing bugs

### DIFF
--- a/config/prismjs/dvc-commands.js
+++ b/config/prismjs/dvc-commands.js
@@ -34,6 +34,7 @@ module.exports = [
   'metrics',
   'params diff',
   'params',
+  'ls',
   'list',
   'install',
   'init',

--- a/config/prismjs/dvc-commands.js
+++ b/config/prismjs/dvc-commands.js
@@ -56,6 +56,7 @@ module.exports = [
   'exp branch',
   'exp apply',
   'exp',
+  'experiments',
   'doctor',
   'diff',
   'destroy',

--- a/content/docs/command-reference/exp/index.md
+++ b/content/docs/command-reference/exp/index.md
@@ -1,6 +1,6 @@
 # exp
 
-_New in DVC 2.0_
+_New in DVC 2.0 (see `dvc version`)_
 
 A set of commands to generate and manage <abbr>experiments</abbr>:
 [run](/doc/command-reference/exp/run), [show](/doc/command-reference/exp/show),
@@ -12,7 +12,7 @@ A set of commands to generate and manage <abbr>experiments</abbr>:
 [pull](/doc/command-reference/exp/pull), and
 [list](/doc/command-reference/exp/list).
 
-> Aliased to `dvc exp`.
+> Alias of `dvc experiments`.
 
 > Requires that Git is being used to version the project.
 

--- a/content/docs/install/index.md
+++ b/content/docs/install/index.md
@@ -7,6 +7,8 @@
 - [Install on Windows](/doc/install/windows)
 - [Install on Linux](/doc/install/linux)
 
+To check whether DVC is installed or which version you have, use `dvc version`.
+
 ## Install as a Python library
 
 DVC can be used as a Python library, simply install it with a package manager

--- a/content/docs/user-guide/experiment-management/index.md
+++ b/content/docs/user-guide/experiment-management/index.md
@@ -1,6 +1,6 @@
 # Experiment Management
 
-_New in DVC 2.0_
+_New in DVC 2.0 (see `dvc version`)_
 
 Data science and ML are iterative processes that require a large number of
 attempts to reach a certain level of a metric. Experimentation is part of the

--- a/content/docs/user-guide/project-structure/pipelines-files.md
+++ b/content/docs/user-guide/project-structure/pipelines-files.md
@@ -98,7 +98,7 @@ metrics and plots.
 
 ## Templating
 
-_New in DVC 2.0_
+_New in DVC 2.0 (see `dvc version`)_
 
 `dvc.yaml` supports a templating format to insert values from different sources
 in the YAML structure itself. These sources can be
@@ -227,7 +227,7 @@ ${param.list[0]} # List elements via index in [] (square brackets)
 
 ## `foreach` stages
 
-_New in DVC 2.0_
+_New in DVC 2.0 (see `dvc version`)_
 
 You can define more than one stage in a single `dvc.yaml` entry with the
 following syntax. A `foreach` element accepts a list or dictionary with values

--- a/content/linked-terms.js
+++ b/content/linked-terms.js
@@ -22,5 +22,9 @@ module.exports = [
   {
     matches: 'dvc experiments',
     url: '/doc/command-reference/exp'
+  },
+  {
+    matches: 'dvc ls',
+    url: '/doc/command-reference/list'
   }
 ]

--- a/plugins/gatsby-remark-dvc-linker/package.json
+++ b/plugins/gatsby-remark-dvc-linker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gatsby-remark-dvc-linker",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "main": "index.js",
   "author": "Ivan Shcheklein",
   "license": "Apache-2.0"

--- a/redirects-list.json
+++ b/redirects-list.json
@@ -54,6 +54,8 @@
   "^/doc/command-reference/pipeline/list$                                                 /doc/command-reference/dag",
   "^/doc/command-reference/lock$                                                          /doc/command-reference/freeze",
   "^/doc/command-reference/unlock$                                                        /doc/command-reference/unfreeze",
+  "^/doc/command-reference/experiments$                                                   /doc/command-reference/exp",
+  "^/doc/command-reference/ls$                                                            /doc/command-reference/list 303",
 
   "^/doc/cml(/.*)?$                                                                       https://cml.dev/doc$1",
 


### PR DESCRIPTION
per https://github.com/iterative/dvc.org/issues/2989

  > - [x] There are no links to either one (`version/doctor`) from any other docs.
  > - [ ] `ls` not existing seems like a bug ATM (quite inconsisntent)
  > - [x] `experments` not existing is a bug -- as it used to be the path, it should be redirecting to `exp`.
  > - [x] Also, the now `exp` page says it's "aliased to `exp`" which no longer makes sense.

Also
- [x] Missing `ls` and `experiments` from the terminal blocks highlighter

Finally
- [ ] Update https://github.com/iterative/dvc.org/issues/2989 description after merge