### PR TITLE
guide: copy edit Comparing Exps

### DIFF
--- a/content/docs/user-guide/experiment-management/comparing-experiments.md
+++ b/content/docs/user-guide/experiment-management/comparing-experiments.md
@@ -1,12 +1,11 @@
-# Comparing Experiments
+# Reviewing and Comparing Experiments
 
-You'll need a way to compare experiment results and track their corresponding
-parameters. DVC provides commands to list, tabulate and contrast them. Let's see
-how they can help you streamline the experimentation process.
+DVC provides commands to list, tabulate and contrast experiments. Let's see how
+they can help you streamline the experimentation process.
 
-## List experiments in the workspace
+## List experiments in the project
 
-You can get a list of existing experiments in the repository with
+You can get a list of existing experiments in the <abbr>repository</abbr> with
 `dvc exp list`. Without any options, this command lists the experiments based on
 the latest commit of the current branch (Git `HEAD`).
 
@@ -17,8 +16,8 @@ refs/tags/baseline-experiment:
         cnn-128
 ```
 
-If you want to list all the experiments in the repository regardless of their
-parent commit, use the `--all` flag.
+If you want to list all the experiments in the repo regardless of their parent
+commit, use the `--all` flag.
 
 ```dvc
 $ dvc exp list --all
@@ -29,11 +28,11 @@ main:
         exp-93150
 ```
 
-## List experiments in another Git remote
+## List experiments saved remotely
 
-As we discuss in [Sharing Experiments], you can use `dvc exp push` to upload
-experiments to Git remotes. `dvc exp list` can be used to list the experiments
-in a Git remote.
+Experiments can be [shared] (with `dvc exp push`) from another location. To
+review experiments uploaded to a remote <abbr>repository</abbr> (which you may
+not have locally), provide a Git remote name to `dvc exp list`.
 
 ```dvc
 $ dvc exp list origin
@@ -42,18 +41,17 @@ refs/tags/baseline-experiment:
         cnn-64
 ```
 
-This command lists the experiments originated from `HEAD`. You can add any other
-options to the remote command, including `--all`. (see previous section).
+This command lists remote experiments originated from `HEAD`. You can add any
+other options to the remote command, including `--all` (see previous section).
 
-[sharing experiments]: /doc/user-guide/experiment-management/sharing-experiments
+[shared]: /doc/user-guide/experiment-management/sharing-experiments
 
 ## List experiment names to use in scripts
 
-`dvc exp list` may be printing more than the necessary information when it comes
-to feed its output to other commands. You can get only the names of the
-experiments via `--names-only` flag.
-
-For example, to get all the experiment names from a Git remote:
+`dvc exp list` may be printing too much information when it comes to feed its
+output to other commands. You can get only the names of the experiments via the
+`--names-only` flag. For example, to get all the experiment names from a remote
+(`origin`):
 
 ```dvc
 $ for experiment in $(dvc exp list origin --names-only --all) ; do
@@ -61,33 +59,25 @@ $ for experiment in $(dvc exp list origin --names-only --all) ; do
 done
 ```
 
-## List experiments based on a specific commit, tag or branch
+## List experiments from a specific project version
 
 The `--rev` option allows to specify a Git commit, tag or branch name to list
-the experiments based on it.
-
-For example, to list of experiments in a Git repository stemmed from a
-particular commit:
+the experiments that are based on it. For example:
 
 ```dvc
+# from a commit:
 $ dvc exp list origin --rev 23ceb4a
 23ceb4a:
         cnn-32
         cnn-96
-```
 
-or a tag:
-
-```dvc
+# from a tag:
 $ dvc exp list origin --rev baseline-experiment
 refs/tags/baseline-experiment:
         cnn-64
         cnn-128
-```
 
-or a fully specified Git reference:
-
-```dvc
+# from a fully specified Git reference:
 $ dvc exp list origin --rev refs/tags/baseline-experiment
 refs/tags/baseline-experiment:
         cnn-64


### PR DESCRIPTION
Rel. https://github.com/iterative/dvc.org/issues/2995

> - [x] Needs detailed copy editing. E.g. [missing "the"](https://github.com/iterative/dvc.org/pull/2862#pullrequestreview-783752862), disjointed paragraphs, unnecessary scrolling blocks, etc.
> - [x] `--sort/order-by/no-timestamp` sections may be too detailed. Hide or just mention + link to ref.
> - [x] Merge JSON and CSV sections somehow
> - [x] Shorten JSON/CSV output sample blocks and remove corresponding schema descriptions (comprehensive examples are enough).
> - [x] Clarify `exp diff` sections to separate cases: workspace vs. `HEAD`, rev A vs rev B, etc.