### PR TITLE
ref: replaced all `dvc run` references with `dvc stage add` in `dvc add`

### DIFF
--- a/content/docs/command-reference/add.md
+++ b/content/docs/command-reference/add.md
@@ -30,7 +30,7 @@ The `targets` are the files or [directories](#adding-entire-directories) to add.
 They get stored in the <abbr>cache</abbr> by default (use the `--no-commit`
 option to avoid this, and `dvc commit` to finish the process when needed).
 
-> See also `dvc.yaml` and `dvc run` for more advanced ways to track and version
+> See also `dvc.yaml` and `dvc n` for more advanced ways to track and version
 > intermediate and final results (like ML models).
 
 After checking that each `target` hasn't been added before (or tracked with
@@ -253,13 +253,13 @@ outs:
 
 This allows us to treat the entire directory structure as a single data
 artifact. For example, you can pass it as a <abbr>dependency</abbr> to a
-`dvc run` stage definition:
+stage definition:
 
 ```dvc
-$ dvc run -n train \
-          -d train.py -d pics \
-          -M metrics.json -o model.h5 \
-          python train.py
+$ dvc stage add -n train \
+                -d train.py -d pics \
+                -M metrics.json -o model.h5 \
+                python train.py
 ```
 
 > To try this example, see the
@@ -292,7 +292,7 @@ pics
 
 Note that no top-level `.dvc` file is generated, which is typically less
 convenient. For example, we cannot use the directory structure as one unit with
-`dvc run` or other commands.
+`dvc stage add` or other commands.
 
 ## Example .dvcignore
 

--- a/content/docs/command-reference/add.md
+++ b/content/docs/command-reference/add.md
@@ -252,8 +252,8 @@ outs:
 > info.
 
 This allows us to treat the entire directory structure as a single data
-artifact. For example, you can pass it as a <abbr>dependency</abbr> to a
-stage definition:
+artifact. For example, you can pass it as a <abbr>dependency</abbr> to a stage
+definition:
 
 ```dvc
 $ dvc stage add -n train \

--- a/content/docs/command-reference/add.md
+++ b/content/docs/command-reference/add.md
@@ -30,8 +30,8 @@ The `targets` are the files or [directories](#adding-entire-directories) to add.
 They get stored in the <abbr>cache</abbr> by default (use the `--no-commit`
 option to avoid this, and `dvc commit` to finish the process when needed).
 
-> See also `dvc.yaml` and `dvc stage add` for more advanced ways to track and version
-> intermediate and final results (like ML models).
+> See also `dvc.yaml` and `dvc stage add` for more advanced ways to track and
+> version intermediate and final results (like ML models).
 
 After checking that each `target` hasn't been added before (or tracked with
 other DVC commands), a few actions are taken under the hood:

--- a/content/docs/command-reference/add.md
+++ b/content/docs/command-reference/add.md
@@ -30,7 +30,7 @@ The `targets` are the files or [directories](#adding-entire-directories) to add.
 They get stored in the <abbr>cache</abbr> by default (use the `--no-commit`
 option to avoid this, and `dvc commit` to finish the process when needed).
 
-> See also `dvc.yaml` and `dvc n` for more advanced ways to track and version
+> See also `dvc.yaml` and `dvc stage add` for more advanced ways to track and version
 > intermediate and final results (like ML models).
 
 After checking that each `target` hasn't been added before (or tracked with


### PR DESCRIPTION
Replaces all `dvc run` examples / mentions with `dvc stage add` in `dvc add` command reference page. 

Closes #3023

