### PR TITLE
Fix incorrect `/community` events dates

### DIFF
--- a/src/components/Community/Events/index.tsx
+++ b/src/components/Community/Events/index.tsx
@@ -76,7 +76,8 @@ const Event: React.FC<IEvent> = ({
       <div className={cn(sharedStyles.meta, styles.meta)}>
         <div className={sharedStyles.line}>{description}</div>
         <div className={sharedStyles.line}>
-          {city}, {format(new Date(date), 'MMMM d')}
+          {city},{' '}
+          {format(new Date(date.slice(0, 10).replace(/-/g, '/')), 'MMMM d')}
         </div>
       </div>
     </Block>


### PR DESCRIPTION
* Event dates are one day off due to how `new Date()` [creates dates in production](https://dev.to/zachgoll/a-complete-guide-to-javascript-dates-and-why-your-date-is-off-by-1-day-fi1). 