### PR TITLE
Update GS experiments with `dvc exp init`

### DIFF
--- a/content/docs/start/experiments.md
+++ b/content/docs/start/experiments.md
@@ -138,6 +138,55 @@ Experiment results have been applied to your workspace.
 
 <details>
 
+### ℹ️ More information about (Hyper)parameters and metrics
+
+It's pretty common for data science pipelines to include configuration files
+that define adjustable parameters to train a model, do pre-processing, etc. DVC
+provides a mechanism for stages to depend on the values of specific sections of
+such a file (YAML, JSON, TOML, and Python formats are supported).
+
+The `train` stage is created with the following `dvc stage add` command. Notice
+the arguments with `-p` option (short for `--params`)
+
+```dvc
+dvc stage add -n train \
+                -d data/images/ \
+                -d src/train.py \
+                -p model.conv_units \
+                -p train.epochs \
+                -o models/model.h5 \
+                --live metrics \
+                python3 src/train.py
+```
+
+The `params` section defines the parameter dependencies of the `train` stage. By
+default, DVC reads those values (`model.conv_units` and `train.epochs`) from
+`params.yaml` file. You can also set the parameter file name by supplying it
+before the parameter name, like `-p myparams.json:model.units`.
+
+Here is the contents of `params.yaml` file:
+
+```yaml
+train:
+  epochs: 10
+model:
+  conv_units: 16
+```
+
+When you use `--set-param`option for `dvc exp run`, DVC updates these values
+with the values you set in the command line before running the experiment.
+
+Metrics are what you use to evaluate your models. DVC allows any scalar values
+to be used as metrics. It's able to track the metrics we defined in the code
+with the Keras integration introduced recently. Before that, we were using
+`--metrics` and `--metrics-no-cache` options of `dvc stage add` to define
+metrics to DVC, and write the metrics in the code manually. Please see
+`dvc metrics` for this kind of explicitly defined metrics.
+
+</details>
+
+<details>
+
 ### ⚙️ Run multiple experiments in parallel
 
 Instead of running the experiments one-by-one, we can define them to run in a

--- a/content/docs/start/experiments.md
+++ b/content/docs/start/experiments.md
@@ -19,13 +19,38 @@ the [`example-dvc-experiments`][ede] project.
 
 [ede]: https://github.com/iterative/example-dvc-experiments
 
+## Initializing a project into DVC experiments
+
+If you already have a DVC project, that's great. You can start to use `dvc exp`
+commands right away to create experiments in your project. (See the [user's
+guide] for detailed information.) In this section, we'll focus how to structure
+an ML project into a DVC experiments project with `dvc exp init`.
+
+A typical machine learning project has some data, a set of scripts that trains a
+model, a bunch of hyperparameters that modify these models. DVC makes certain
+assumptions about the names of these elements to initialize an experimentation
+project with:
+
+```dvc
+$ dvc exp init python src/train.py
+```
+
+Here, `python src/train.py` describes how our project runs the training script.
+It could be any other command. For DVC, this defines how you run an experiment.
+
+You can also set code (default: `src`), data (`data/`), models (`models/`),
+hyperparameters (`params.yaml`), metrics (`metrics.json`), and plots (`plots/`)
+dependencies if they differ from the defaults.
+
+We run these experiments in [`example-dvc-experiments`][ede] project, and it's
+structured around these defaults so we don't specify any custom paths.
+
 <details>
 
 ### ⚙️ Installing the example project
 
-These commands are run in the [`example-dvc-experiments`][ede] project. You can
-run the commands in this document after cloning the repository, installing the
-requirements, and pulling the data.
+You can run the commands in this document after cloning the repository,
+installing the requirements, and pulling the data.
 
 #### Clone the project and create virtual environment
 
@@ -42,6 +67,8 @@ $ . .venv/bin/activate
 $ python -m pip install -r requirements.txt
 ```
 
+</details>
+
 #### Get the data set
 
 The repository we cloned doesn't contain the dataset. Instead of storing the
@@ -51,11 +78,6 @@ this case, we use `dvc pull` to update the missing data files.
 ```dvc
 $ dvc pull
 ```
-
-The repository already contains the necessary configuration to run the
-experiments.
-
-</details>
 
 Running the experiment with the default project settings requires only the
 command:
@@ -68,8 +90,8 @@ Experiment results have been applied to your workspace.
 ...
 ```
 
-It runs the specified command (`python train.py`) in `dvc.yaml`. That command
-writes the metrics values to `metrics.json`.
+It runs the command we specified (`python train.py`), and creates models, plots
+and metrics in respective directories.
 
 This experiment is then associated with the values found in the parameters file
 (`params.yaml`), and other dependencies (`data/images/`) with these produced


### PR DESCRIPTION
This one is migrated from Notion. I have added a hidden section on hyperparameters there. 

I have modified here: 

- It starts with `dvc exp init` now. Without mentioning any pipelines stuff or `dvc.yaml`

- I'm planning to remove "If you've run `repro` before" hidden section, the section where we tell how to prepare pipelines for arbitrary projects, and keep the hyperparameter stuff to a minimum. 