### PR TITLE
guide: update Node version (docs contrib)

### DIFF
--- a/content/docs/user-guide/contributing/docs.md
+++ b/content/docs/user-guide/contributing/docs.md
@@ -57,7 +57,7 @@ the website engine itself. Source code and content files need to be properly
 formatted and linted as well, which is also ensured by the full setup below.
 
 Make sure you have [Python](https://www.python.org/downloads/) 3.7+, a recent
-LTS version of [Node.js](https://nodejs.org/en/) (`>=14.0.0`, `<=17.x`), and
+LTS version of [Node.js](https://nodejs.org/en/) (`>=14.0.0`, `<=16.x`), and
 install [Yarn](https://yarnpkg.com/):
 
 > In Windows, you may need to install [Visual Studio Build Tools], and the

--- a/content/docs/user-guide/contributing/docs.md
+++ b/content/docs/user-guide/contributing/docs.md
@@ -57,7 +57,7 @@ the website engine itself. Source code and content files need to be properly
 formatted and linted as well, which is also ensured by the full setup below.
 
 Make sure you have [Python](https://www.python.org/downloads/) 3.7+, a recent
-LTS version of [Node.js](https://nodejs.org/en/) (`>=12.0.0`, `<=15.x`), and
+LTS version of [Node.js](https://nodejs.org/en/) (`>=14.0.0`, `<=17.x`), and
 install [Yarn](https://yarnpkg.com/):
 
 > In Windows, you may need to install [Visual Studio Build Tools], and the

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   },
   "homepage": "https://github.com/iterative/dvc.org#readme",
   "engines": {
-    "node": "<=16.x"
+    "node": ">=14.x <=16.x"
   },
   "dependencies": {
     "@hapi/wreck": "^17.0.0",


### PR DESCRIPTION
`yarn` started failing for me today. It wanted node 14+ I think (I closed the terminal, oops).