### PR TITLE
updated syntax for dvc import example

### DIFF
--- a/content/docs/command-reference/import.md
+++ b/content/docs/command-reference/import.md
@@ -177,20 +177,12 @@ When using this option, the import `.dvc` file will also have a `rev` subfield
 under `repo`:
 
 ```yaml
-md5: 7ff366c716a376ec009054f1c141dc17
-frozen: true
 deps:
-- path: use-cases/cats-dogs
-  repo:
-    url: git@github.com:iterative/dataset-registry.git
-    rev: cats-dogs-v1
-    ^^^^^^^^^^^^^^^^^
-    rev_lock: 0547f5883fb18e523e35578e2f0d19648c8f2d5c
-outs:
-- md5: b6923e1e4ad16ea1a7e2b328842d56a2.dir
-  size: 41149064
-  nfiles: 1800
-  path: cats-dogs
+  - path: use-cases/cats-dogs
+    repo:
+      url: git@github.com:iterative/dataset-registry.git
+      rev: cats-dogs-v1
+      rev_lock: 0547f5883fb18e523e35578e2f0d19648c8f2d5c
 ```
 
 If `rev` is a Git branch or tag (where the underlying commit changes), the data

--- a/content/docs/command-reference/import.md
+++ b/content/docs/command-reference/import.md
@@ -193,7 +193,7 @@ will not have an effect on the import `.dvc` file. You may force-update it to a
 different commit with `dvc update --rev`:
 
 ```dvc
-$ dvc update --rev cats-dogs-v2 <stage>.dvc
+$ dvc update --rev cats-dogs-v2 cats-dogs.dvc
 ```
 
 > In the above example, the value for `rev` in the new `.dvc` file will be

--- a/content/docs/command-reference/import.md
+++ b/content/docs/command-reference/import.md
@@ -177,12 +177,20 @@ When using this option, the import `.dvc` file will also have a `rev` subfield
 under `repo`:
 
 ```yaml
+md5: 7ff366c716a376ec009054f1c141dc17
+frozen: true
 deps:
-  - path: data/data.xml
-    repo:
-      url: git@github.com:iterative/dataset-registry.git
-      rev: cats-dogs-v1
-      rev_lock: 0547f5883fb18e523e35578e2f0d19648c8f2d5c
+- path: use-cases/cats-dogs
+  repo:
+    url: git@github.com:iterative/dataset-registry.git
+    rev: cats-dogs-v1
+    ^^^^^^^^^^^^^^^^^
+    rev_lock: 0547f5883fb18e523e35578e2f0d19648c8f2d5c
+outs:
+- md5: b6923e1e4ad16ea1a7e2b328842d56a2.dir
+  size: 41149064
+  nfiles: 1800
+  path: cats-dogs
 ```
 
 If `rev` is a Git branch or tag (where the underlying commit changes), the data

--- a/content/docs/command-reference/import.md
+++ b/content/docs/command-reference/import.md
@@ -193,7 +193,7 @@ will not have an effect on the import `.dvc` file. You may force-update it to a
 different commit with `dvc update --rev`:
 
 ```dvc
-$ dvc update --rev cats-dogs-v2
+$ dvc update --rev cats-dogs-v2 <stage>.dvc
 ```
 
 > In the above example, the value for `rev` in the new `.dvc` file will be


### PR DESCRIPTION
From https://discord.com/channels/485586884165107732/485596304961962003/918463103560196116

> Question: I'm reading the documentation and how to use dvc import properly ... under [Importing and updating fixed revisions](https://dvc.org/doc/command-reference/import#example-importing-and-updating-fixed-revisions) that when you have used `dvc import --rev` with a git hash and we want to force-update it to a different commit, we might use `dvc update --rev`, and the example given is: `dvc update --rev cats-dogs-v2`.
Should it not be `dvc update --rev cats-dogs-v2 <stage>.dvc`, though?

> seems like you found a bug in our docs. You are correct that there should be <stage>.dvc in the end of this line.