### PR TITLE
Update community.json, fixing broken hero url

### DIFF
--- a/content/community.json
+++ b/content/community.json
@@ -3,7 +3,7 @@
     {
       "pictureDesktop": "/img/community/hiring_da_desktop.png",
       "pictureMobile": "/img/community/hiring_da_mobile.png",
-      "url": "https://docs.google.com/document/d/13r0KaxRdQR6srOZdIzL9ZgBL4eOdPCl7foc3cxx0xjA/edit?usp=sharing",
+      "url": "https://iterative.notion.site/Iterative-ai-is-Hiring-852cb978129645e1906e2c9a878a4d22",
       "expires": false
     }
   ],


### PR DESCRIPTION
The url in our `/community` hero is leading to "Page Not Found":

![image](https://user-images.githubusercontent.com/43496356/145822964-8ef6c17d-a68e-4609-825b-ec8b8d2667da.png)

I updated it to the notion page link that we use for iterative.ai