### PR TITLE
Fix broken community hero image in safari

### DIFF
--- a/src/components/Community/Hero/styles.module.css
+++ b/src/components/Community/Hero/styles.module.css
@@ -12,6 +12,7 @@
 
 .pictureContainer {
   display: flex;
+  align-items: center;
 }
 
 .picture {


### PR DESCRIPTION
Part of #3084. Forgot that safari (unlike chrome) automatically applies `align-items: stretch` onto flex items.