### PR TITLE
Fix site crashing with certain anchor links

### DIFF
--- a/src/components/Link/index.tsx
+++ b/src/components/Link/index.tsx
@@ -4,6 +4,7 @@ import { useLocation } from '@reach/router'
 import GatsbyLink from 'gatsby-link'
 import { getRedirect } from '../../utils/shared/redirects'
 import { scrollIntoLayout, getScrollNode } from '../../utils/front/scroll'
+import safeQuerySelector from '../../utils/front/safeQuerySelector'
 
 export type ILinkProps = {
   children: React.ReactNode
@@ -77,8 +78,8 @@ const ResultLinkComponent: React.FC<ILinkProps> = ({
 }
 
 const scrollToHash = (hash: string, scrollOptions = {}): void => {
-  if (hash && /^#[A-Za-z][-A-Za-z0-9_:.]*$/.test(hash)) {
-    scrollIntoLayout(document.querySelector(hash), {
+  if (hash) {
+    scrollIntoLayout(safeQuerySelector(hash), {
       waitImages: true,
       ...scrollOptions
     })

--- a/src/components/Link/index.tsx
+++ b/src/components/Link/index.tsx
@@ -77,7 +77,7 @@ const ResultLinkComponent: React.FC<ILinkProps> = ({
 }
 
 const scrollToHash = (hash: string, scrollOptions = {}): void => {
-  if (hash && /^[A-Za-z][-A-Za-z0-9_:.]*$/.test(hash)) {
+  if (hash && /^#[A-Za-z][-A-Za-z0-9_:.]*$/.test(hash)) {
     scrollIntoLayout(document.querySelector(hash), {
       waitImages: true,
       ...scrollOptions

--- a/src/components/Link/index.tsx
+++ b/src/components/Link/index.tsx
@@ -77,7 +77,7 @@ const ResultLinkComponent: React.FC<ILinkProps> = ({
 }
 
 const scrollToHash = (hash: string, scrollOptions = {}): void => {
-  if (hash) {
+  if (hash && /^[A-Za-z][-A-Za-z0-9_:.]*$/.test(hash)) {
     scrollIntoLayout(document.querySelector(hash), {
       waitImages: true,
       ...scrollOptions

--- a/src/components/Page/utils.ts
+++ b/src/components/Page/utils.ts
@@ -3,6 +3,7 @@ import { useLocation } from '@reach/router'
 
 import { handleFrontRedirect } from '../../utils/shared/redirects'
 import { scrollIntoLayout, getScrollNode } from '../../utils/front/scroll'
+import safeQuerySelector from '../../utils/front/safeQuerySelector'
 
 import * as styles from './styles.module.css'
 
@@ -10,8 +11,8 @@ export const useAnchorNavigation = (): void => {
   const location = useLocation()
 
   useEffect(() => {
-    if (location.hash && /^#[A-Za-z][-A-Za-z0-9_:.]*$/.test(location.hash)) {
-      const node = document.querySelector(location.hash)
+    if (location.hash) {
+      const node = safeQuerySelector(location.hash)
 
       if (node) {
         scrollIntoLayout(node, { waitImages: true })

--- a/src/components/Page/utils.ts
+++ b/src/components/Page/utils.ts
@@ -10,7 +10,7 @@ export const useAnchorNavigation = (): void => {
   const location = useLocation()
 
   useEffect(() => {
-    if (location.hash) {
+    if (location.hash && /^[A-Za-z][-A-Za-z0-9_:.]*$/.test(location.hash)) {
       const node = document.querySelector(location.hash)
 
       if (node) {

--- a/src/components/Page/utils.ts
+++ b/src/components/Page/utils.ts
@@ -10,7 +10,7 @@ export const useAnchorNavigation = (): void => {
   const location = useLocation()
 
   useEffect(() => {
-    if (location.hash && /^[A-Za-z][-A-Za-z0-9_:.]*$/.test(location.hash)) {
+    if (location.hash && /^#[A-Za-z][-A-Za-z0-9_:.]*$/.test(location.hash)) {
       const node = document.querySelector(location.hash)
 
       if (node) {

--- a/src/utils/front/safeQuerySelector.ts
+++ b/src/utils/front/safeQuerySelector.ts
@@ -1,0 +1,10 @@
+const safeQuerySelector = (query: string): null | Element => {
+  try {
+    const el = document.querySelector(query)
+    return el
+  } catch (err) {
+    return null
+  }
+}
+
+export default safeQuerySelector


### PR DESCRIPTION
* stop code from running `querySelector` on invalid id strings

Fixes #2395 

