### PR TITLE
Change youtube embed component to only load src on user request

### DIFF
--- a/src/components/Home/UseCases/Video/index.tsx
+++ b/src/components/Home/UseCases/Video/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback } from 'react'
+import React, { useState, useCallback, useRef } from 'react'
 
 import TwoRowsButton from '../../../TwoRowsButton'
 import { logEvent } from '../../../../utils/front/plausible'
@@ -7,10 +7,14 @@ import * as styles from './styles.module.css'
 
 const Video: React.FC<{ id: string }> = ({ id }) => {
   const [isWatching, setWatching] = useState(false)
+  const iframeRef = useRef<HTMLIFrameElement>()
 
   const watchVideo = useCallback(() => {
     logEvent('Button', { Item: 'video' })
     setWatching(true)
+    if (iframeRef.current) {
+      iframeRef.current.src = `https://www.youtube.com/embed/${id}?rel=0&amp;controls=0&amp;showinfo=0;&autoplay=1`
+    }
   }, [])
 
   return (
@@ -34,12 +38,12 @@ const Video: React.FC<{ id: string }> = ({ id }) => {
           </div>
         )}
         <iframe
+          ref={iframeElement => {
+            iframeRef.current = iframeElement
+          }}
           title="Video"
           width="560"
           height="315"
-          src={`https://www.youtube.com/embed/${id}?rel=0&amp;controls=0&amp;showinfo=0;${
-            isWatching ? `&autoplay=1` : ''
-          }`}
           frameBorder="0"
           allow="autoplay; encrypted-media"
           allowFullScreen

--- a/src/components/Home/UseCases/Video/index.tsx
+++ b/src/components/Home/UseCases/Video/index.tsx
@@ -7,7 +7,7 @@ import * as styles from './styles.module.css'
 
 const Video: React.FC<{ id: string }> = ({ id }) => {
   const [isWatching, setWatching] = useState(false)
-  const iframeRef = useRef<HTMLIFrameElement>()
+  const iframeRef = useRef<HTMLIFrameElement | null>()
 
   const watchVideo = useCallback(() => {
     logEvent('Button', { Item: 'video' })


### PR DESCRIPTION
First mentioned in [this comment](https://github.com/iterative/dvc.org/issues/2980#issuecomment-1002224872)

https://user-images.githubusercontent.com/9111807/147594671-99f8f993-07d3-4141-9c7e-fa18af8bd895.mp4

This PR modifies our YouTube embed component such that the `src` is only set after the user clicks a button to watch the video. With this, the embedded site has no way of breaking GDPR compliance through cookies, localStorage, or any other API because the site isn't even loaded until the user wants it to be. I assume we'll probably need to add a message like "By playing this video you accept YouTube's cookies" to be truly GDPR compliant.

We'll have to add our own background images if we want them, but that shouldn't be too difficult given that we can just grab youtube's image and display it on the element- just not as easy to work with should we change the video in the future.