### PR TITLE
Add `prismjs` `dvctablehorizontals`

### DIFF
--- a/config/prismjs/dvctable.js
+++ b/config/prismjs/dvctable.js
@@ -1,8 +1,11 @@
 /* eslint-env node */
 const Prism = require('prismjs')
 
-const getTableBgColorRegex = color =>
-  new RegExp(String.raw`(?<=[│┃])\s+\*{0,2}${color}:(?:(?![│┃]).)+(?=[│┃])`)
+const getTableCellBgColorRegex = color =>
+  new RegExp(String.raw`(?<=[│┃])\s+${color}:(?:(?![│┃]).)+(?=[│┃])`)
+
+const getTableTextBgColorRegex = color => new RegExp(String.raw`${color}:\S+`)
+
 const boldAndItalicConfig = {
   bold: {
     pattern: /\*\*(?:(?!\*\*).)+\*\*/,
@@ -20,7 +23,7 @@ const boldAndItalicConfig = {
 
 Prism.languages.dvctable = {
   'bg-white': {
-    pattern: getTableBgColorRegex('(white|neutral)'),
+    pattern: getTableCellBgColorRegex('(white|neutral)'),
     inside: {
       hide: {
         pattern: /(white|neutral):/
@@ -29,7 +32,7 @@ Prism.languages.dvctable = {
     }
   },
   'bg-yellow': {
-    pattern: getTableBgColorRegex('(yellow|metric)'),
+    pattern: getTableCellBgColorRegex('(yellow|metric)'),
     inside: {
       hide: {
         pattern: /(yellow|metric):/
@@ -38,7 +41,7 @@ Prism.languages.dvctable = {
     }
   },
   'bg-blue': {
-    pattern: getTableBgColorRegex('(blue|param)'),
+    pattern: getTableCellBgColorRegex('(blue|param)'),
     inside: {
       hide: {
         pattern: /(blue|param):/
@@ -47,4 +50,40 @@ Prism.languages.dvctable = {
     }
   },
   ...boldAndItalicConfig
+}
+
+Prism.languages.dvctablehorizontals = {
+  rows: {
+    pattern: /((?<=^|\n)\s[^─][\s\S]*?(:?\n|$))+/,
+    inside: {
+      'bg-white': {
+        pattern: getTableTextBgColorRegex('(white|neutral)'),
+        inside: {
+          hide: {
+            pattern: /(white|neutral):/
+          },
+          ...boldAndItalicConfig
+        }
+      },
+      'bg-yellow': {
+        pattern: getTableTextBgColorRegex('(yellow|metric)'),
+        inside: {
+          hide: {
+            pattern: /(yellow|metric):/
+          },
+          ...boldAndItalicConfig
+        }
+      },
+      'bg-blue': {
+        pattern: getTableTextBgColorRegex('(blue|param)'),
+        inside: {
+          hide: {
+            pattern: /(blue|param):/
+          },
+          ...boldAndItalicConfig
+        }
+      },
+      ...boldAndItalicConfig
+    }
+  }
 }

--- a/src/components/Documentation/Markdown/Main/styles.module.css
+++ b/src/components/Documentation/Markdown/Main/styles.module.css
@@ -214,6 +214,24 @@
         background-color: #d7feff;
       }
     }
+
+    pre[class*="language-dvctablehorizontals"] {
+      code {
+        display: inline-block;
+        line-height: 20px;
+      }
+
+      .token.rows {
+        background-image: linear-gradient(
+          transparent 50%,
+          rgb(256 256 256 / 10%) 50%
+        );
+        background-size: 100% 40px;
+        display: block;
+        background-origin: content-box;
+        background-attachment: local;
+      }
+    }
   }
 
   details p {


### PR DESCRIPTION
We're [still discussing](https://github.com/iterative/dvc.org/issues/3102) if we want to use this design for our tables, but I went ahead and opened a pull request with the new configuration for code reviews. 

`dvctablehorizontals` markdown:
```
─────────────────────────────────────────────────────────────────────────────────────────────
  white:**Experiment**                white:**Created**           yellow:**loss**      yellow:**acc**   blue:**train.epochs**   blue:**model.conv_units**
 ─────────────────────────────────────────────────────────────────────────────────────────────
  workspace                 -              0.24057   0.9157   10             16
  baseline-experiment       Dec 05, 2021   0.24057   0.9157   10             16
  └── 67d5a70 [exp-c4f81]   Dec 23, 2021   0.24057   0.9157   10             16
 ─────────────────────────────────────────────────────────────────────────────────────────────
```
Output:

![image](https://user-images.githubusercontent.com/43496356/147682836-3ef39687-76f2-44d8-a25c-f83fd934c42d.png)

