### PR TITLE
Fix broken tab order on docs sidebar menu

### DIFF
--- a/src/components/Documentation/Layout/SidebarMenu/index.tsx
+++ b/src/components/Documentation/Layout/SidebarMenu/index.tsx
@@ -75,11 +75,6 @@ const SidebarMenuItem: React.FC<ISidebarMenuItemProps> = ({
     onClick(isLeafItem)
   }
 
-  const bulletIconClick = (event: SyntheticEvent<HTMLSpanElement>): void => {
-    event.preventDefault()
-    setIsExpanded(!isExpanded)
-  }
-
   // Fetch a special icon if one is defined
   const IconComponent = icon && ICONS[icon]
   const iconElement = IconComponent ? (
@@ -131,13 +126,7 @@ const SidebarMenuItem: React.FC<ISidebarMenuItemProps> = ({
         {iconElement ? (
           iconElement
         ) : (
-          <span
-            className={bulletIconClassName}
-            onClick={bulletIconClick}
-            onKeyDown={bulletIconClick}
-            role="button"
-            tabIndex={0}
-          ></span>
+          <span className={bulletIconClassName}></span>
         )}
         {label}
       </Link>

--- a/src/components/Documentation/Layout/SidebarMenu/index.tsx
+++ b/src/components/Documentation/Layout/SidebarMenu/index.tsx
@@ -105,7 +105,7 @@ const SidebarMenuItem: React.FC<ISidebarMenuItemProps> = ({
     isLeafItem && styles.sidebarLeafBullet
   )
 
-  const buttonIconJSX = isLeafItem ? (
+  const bulletIconJSX = isLeafItem ? (
     <span className={bulletIconClassName}></span>
   ) : (
     <button onClick={bulletIconClick} className={bulletIconClassName}></button>
@@ -134,7 +134,7 @@ const SidebarMenuItem: React.FC<ISidebarMenuItemProps> = ({
         className={className}
         onClick={currentLevelOnClick}
       >
-        {iconElement ? iconElement : buttonIconJSX}
+        {iconElement ? iconElement : bulletIconJSX}
         {label}
       </Link>
     )

--- a/src/components/Documentation/Layout/SidebarMenu/index.tsx
+++ b/src/components/Documentation/Layout/SidebarMenu/index.tsx
@@ -75,6 +75,11 @@ const SidebarMenuItem: React.FC<ISidebarMenuItemProps> = ({
     onClick(isLeafItem)
   }
 
+  const bulletIconClick = (event: SyntheticEvent<HTMLSpanElement>): void => {
+    event.preventDefault()
+    setIsExpanded(!isExpanded)
+  }
+
   // Fetch a special icon if one is defined
   const IconComponent = icon && ICONS[icon]
   const iconElement = IconComponent ? (
@@ -100,6 +105,12 @@ const SidebarMenuItem: React.FC<ISidebarMenuItemProps> = ({
     isLeafItem && styles.sidebarLeafBullet
   )
 
+  const buttonIconJSX = isLeafItem ? (
+    <span className={bulletIconClassName}></span>
+  ) : (
+    <button onClick={bulletIconClick} className={bulletIconClassName}></button>
+  )
+
   const parentElement =
     type === 'external' ? (
       <Link
@@ -123,11 +134,7 @@ const SidebarMenuItem: React.FC<ISidebarMenuItemProps> = ({
         className={className}
         onClick={currentLevelOnClick}
       >
-        {iconElement ? (
-          iconElement
-        ) : (
-          <span className={bulletIconClassName}></span>
-        )}
+        {iconElement ? iconElement : buttonIconJSX}
         {label}
       </Link>
     )

--- a/src/components/Documentation/Layout/SidebarMenu/styles.module.css
+++ b/src/components/Documentation/Layout/SidebarMenu/styles.module.css
@@ -96,13 +96,14 @@
   left: 0;
   top: 9px;
   display: block;
+  border: none;
   height: 8px;
   width: 8px;
   background: url("/img/triangle_dark.svg") no-repeat center center;
-  transition: 0.5s all;
+  transition: 0.5s transform;
 
   &:focus {
-    outline: none;
+    outline-color: var(--color-gray-light);
   }
 
   &:hover {

--- a/src/components/Documentation/Layout/SidebarMenu/styles.module.css
+++ b/src/components/Documentation/Layout/SidebarMenu/styles.module.css
@@ -104,7 +104,7 @@
 
   &:focus {
     outline-color: var(--color-gray-light);
-    outline-offset: 1px;
+    outline-offset: 0;
   }
 
   &:hover {

--- a/src/components/Documentation/Layout/SidebarMenu/styles.module.css
+++ b/src/components/Documentation/Layout/SidebarMenu/styles.module.css
@@ -104,6 +104,7 @@
 
   &:focus {
     outline-color: var(--color-gray-light);
+    outline-offset: 1px;
   }
 
   &:hover {


### PR DESCRIPTION
* Turn the menu's dropdown bullet points into buttons, allowing keyboard users to tab over them (if you try to tab through a docs page inside dvc.org, you'll get stuck on a dropdown)

Part of #1149 