### PR TITLE
start: remove "if you used dvc repro before" hidden section from start

### DIFF
--- a/content/docs/start/experiments.md
+++ b/content/docs/start/experiments.md
@@ -104,24 +104,6 @@ experiment in a separate row, along with the Git commit IDs they are attached
 to. We can see that the experiment we run has a name `exp-6dccf` and was run
 from the commit ID `7317bc6`.
 
-<details>
-
-### ℹ️ If you used `dvc repro` before
-
-Earlier versions of DVC uses `dvc repro` to run the pipeline. If you already
-have a DVC project, you may already be using `dvc repro`.
-
-We use `dvc repro` to run the pipeline as found in the <abbr>workspace</abbr>.
-All the parameters and dependencies are retrieved from the current workspace. It
-doesn't use any specialized mechanism to track experiments.
-
-When you have a large number of experiments that you don't want to commit all to
-Git, it's better to use `dvc exp run`. It allows to change the parameters
-quickly, can track the history of artifacts and has facilities to compare these
-experiments easily.
-
-</details>
-
 Now let's do some more experimentation.
 
 DVC allows to update the parameters defined in the pipeline without modifying


### PR DESCRIPTION

This one removes "If you used DVC repro before" hidden section from the Getting
Started: Experiments document. As we'll introduce `dvc exp init`, dvc repro
becomes less useful and from the input we got so far, this section is
confusing. 

Related #3051
