### PR TITLE
redirects: add man.dvc.org/completion

### DIFF
--- a/redirects-list.json
+++ b/redirects-list.json
@@ -56,6 +56,7 @@
   "^/doc/user-guide/dvcignore$                                                            /doc/user-guide/project-structure/dvcignore-files",
   "^/doc/understanding-dvc(/.*)?$                                                         /doc/user-guide/what-is-dvc",
   "^/doc/commands-reference(/.*)?$                                                        /doc/command-reference$1",
+  "^/doc/command-reference/completion$                                                    /doc/install/completion",
   "^/doc/command-reference/plot$                                                          /doc/command-reference/plots",
   "^/doc/command-reference/pipeline$                                                      /doc/command-reference/dag",
   "^/doc/command-reference/pipeline/show$                                                 /doc/command-reference/dag",


### PR DESCRIPTION
Fixes 404 on https://man.dvc.org/completion
