### PR TITLE
ref: move Alias notes before cmd def.

### DIFF
--- a/content/docs/command-reference/exp/index.md
+++ b/content/docs/command-reference/exp/index.md
@@ -2,6 +2,8 @@
 
 _New in DVC 2.0 (see `dvc version`)_
 
+> Alias of `dvc experiments`.
+
 A set of commands to generate and manage <abbr>experiments</abbr>:
 [init](/doc/command-reference/exp/init), [run](/doc/command-reference/exp/run),
 [show](/doc/command-reference/exp/show),
@@ -12,8 +14,6 @@ A set of commands to generate and manage <abbr>experiments</abbr>:
 [gc](/doc/command-reference/exp/gc), [push](/doc/command-reference/exp/list),
 [pull](/doc/command-reference/exp/pull), and
 [list](/doc/command-reference/exp/list).
-
-> Alias of `dvc experiments`.
 
 > Requires that Git is being used to version the project.
 

--- a/content/docs/command-reference/list.md
+++ b/content/docs/command-reference/list.md
@@ -1,9 +1,9 @@
 # list
 
+> Aliased to `dvc ls`.
+
 List project contents, including files, models, and directories tracked by DVC
 and by Git.
-
-> Aliased to `dvc ls`.
 
 > Useful to find data to `dvc get`, `dvc import`, or for `dvc.api` functions.
 


### PR DESCRIPTION
For consistency and readability.