### PR TITLE
Fix Broken Anchor Links in `/command-reference/exp/show`

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -115,7 +115,8 @@ const plugins = [
           options: {
             maxWidth: BLOG.imageMaxWidth,
             withWebp: true,
-            quality: 90
+            quality: 90,
+            loading: 'auto'
           }
         },
         'gatsby-remark-responsive-iframe',


### PR DESCRIPTION
* adds `loading: auto` to gatsby-remark-images options, which turns off lazy loading on doc images and blog images