### PR TITLE
dvctable: Add `violet` for `dep` columns.

### DIFF
--- a/config/prismjs/dvctable.js
+++ b/config/prismjs/dvctable.js
@@ -49,6 +49,15 @@ Prism.languages.dvctable = {
           ...boldAndItalicConfig
         }
       },
+      'bg-violet': {
+        pattern: getTableTextBgColorRegex('(violet|dep)'),
+        inside: {
+          hide: {
+            pattern: /(violet|dep):/
+          },
+          ...boldAndItalicConfig
+        }
+      },
       ...boldAndItalicConfig
     }
   }

--- a/src/components/Documentation/Markdown/Main/styles.module.css
+++ b/src/components/Documentation/Markdown/Main/styles.module.css
@@ -234,6 +234,11 @@
         color: #000;
         background-color: #d7feff;
       }
+
+      .token.bg-violet {
+        color: #000;
+        background-color: #d7afff;
+      }
     }
 
     pre[class*="language-dvctable"] {


### PR DESCRIPTION
Closes #3202
