### PR TITLE
Search blogs - Partial indexing

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "gatsby-plugin-parent-resolvers": "^1.0.1",
     "github-markdown-css": "^5.0.0",
     "graphql": "^16.0.1",
+    "gray-matter": "^4.0.3",
     "iso-url": "^1.2.1",
     "isomorphic-fetch": "^3.0.0",
     "lodash": "^4.17.21",
@@ -169,7 +170,7 @@
   },
   "husky": {
     "hooks": {
-      "pre-commit": "yarn format-staged && yarn lint-staged"
+      "pre-commit": "bash scripts/pre-commit.sh"
     }
   },
   "lint-staged": {

--- a/scripts/pre-commit.sh
+++ b/scripts/pre-commit.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+git diff --cached --name-status | egrep -i "(A|M).*content\/blog\/.*\.(md|mdx)" | while read a b; do node ./scripts/update-blog-post.js $b; git add $b; done
+yarn format-staged && yarn lint-staged

--- a/scripts/update-blog-post.js
+++ b/scripts/update-blog-post.js
@@ -1,0 +1,15 @@
+const fs = require('fs').promises
+const matter = require('gray-matter')
+
+const filePath = process.argv[2]
+if (filePath) {
+  file = matter.read(filePath)
+  const { data: currentData } = file
+  const updatedData = {
+    ...currentData,
+    updated_at: new Date().toISOString()
+  }
+  file.data = updatedData
+  const updatedFileContent = matter.stringify(file)
+  fs.writeFile(filePath, updatedFileContent)
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -9039,7 +9039,7 @@ graphql@^16.0.1:
 
 gray-matter@^4.0.3:
   version "4.0.3"
-  resolved "https://registry.npmjs.org/gray-matter/-/gray-matter-4.0.3.tgz"
+  resolved "https://registry.yarnpkg.com/gray-matter/-/gray-matter-4.0.3.tgz#e893c064825de73ea1f5f7d88c7a9f7274288798"
   integrity sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q==
   dependencies:
     js-yaml "^3.13.1"


### PR DESCRIPTION
added pre-commit script to run node script to add/update `updated_at` field if blog post(markdown) is added or updated.

The script used the `gray-matter` package to parse the markdown file. Gatsby also uses the same package. It seems like it parses the date field and converts it into a `Date` string. I wouldn't consider that an issue, as it would only affect visually and we may implement tweaks as mentioned on the issue [Disable date parsing](https://github.com/jonschlinkert/gray-matter/issues/62).

If this looks good then we can integrate the partial indexing using the `updated_at` field. 
@iterative/websites 