### PR TITLE
Stop list item markers from appearing in Google Chrome's auto dark mode

### DIFF
--- a/src/components/LayoutHeader/Nav/styles.module.css
+++ b/src/components/LayoutHeader/Nav/styles.module.css
@@ -4,6 +4,10 @@
   flex-direction: row;
   align-items: center;
 
+  ul {
+    list-style-type: none;
+  }
+
   @media (--xs-scr) {
     display: none;
   }


### PR DESCRIPTION
* hides the nav's list item markers
* fixes the last bug mentioned in #2794

Fixes #2794 