### PR TITLE
Fix broken "Edit on Github" links

### DIFF
--- a/plugins/gatsby-theme-iterative-docs/src/constants.ts
+++ b/plugins/gatsby-theme-iterative-docs/src/constants.ts
@@ -1,1 +1,1 @@
-export const githubRepo = 'iterative/dvc'
+export const githubRepo = 'iterative/dvc.org'


### PR DESCRIPTION
* fix typo in `gatsby-theme-iterative-docs/src/constants` 
