### PR TITLE
Make YouTube Embeds GDPR compliant

### DIFF
--- a/config/gatsby-remark-embedder/custom-yt-embedder.js
+++ b/config/gatsby-remark-embedder/custom-yt-embedder.js
@@ -1,0 +1,59 @@
+const shouldTransform = url => {
+  const { host, pathname, searchParams } = new URL(url)
+
+  return (
+    host === 'youtu.be' ||
+    (['youtube.com', 'www.youtube.com'].includes(host) &&
+      pathname.includes('/watch') &&
+      Boolean(searchParams.get('v')))
+  )
+}
+
+const getTimeValueInSeconds = timeValue => {
+  if (Number(timeValue).toString() === timeValue) {
+    return timeValue
+  }
+
+  const {
+    2: hours = '0',
+    4: minutes = '0',
+    6: seconds = '0'
+  } = timeValue.match(/((\d*)h)?((\d*)m)?((\d*)s)?/)
+
+  return String((Number(hours) * 60 + Number(minutes)) * 60 + Number(seconds))
+}
+
+const getYouTubeIFrameSrc = urlString => {
+  const url = new URL(urlString)
+  const id =
+    url.host === 'youtu.be' ? url.pathname.slice(1) : url.searchParams.get('v')
+
+  const embedUrl = new URL(
+    `https://www.youtube-nocookie.com/embed/${id}?rel=0&amp;controls=0&amp;showinfo=0;`
+  )
+
+  url.searchParams.forEach((value, name) => {
+    if (name === 'v') {
+      return
+    }
+
+    if (name === 't') {
+      embedUrl.searchParams.append('start', getTimeValueInSeconds(value))
+    } else {
+      embedUrl.searchParams.append(name, value)
+    }
+  })
+  return embedUrl.toString()
+}
+
+// all code above taken from gatsby-remark-embedder (https://github.com/MichaelDeBoey/gatsby-remark-embedder)
+
+const name = 'YouTubeCustom'
+
+const getHTML = url => {
+  const iframeSrc = getYouTubeIFrameSrc(url)
+
+  return `<div class="yt-embed-wrapper"><iframe width="100%" height="315" src="${iframeSrc}" frameBorder="0" allow="autoplay; encrypted-media; gyroscope; picture-in-picture" allowFullScreen></iframe><div className="yt-embed-wrapper__overlay"><span class="yt-embed-wrapper__tooltip">By clicking play, you agree to YouTube&apos;s <a href="https://policies.google.com/u/3/privacy?hl=en">Privacy Policy</a> and <a href="https://www.youtube.com/static?template=terms">Terms of Service</a></span></div></div>`
+}
+
+module.exports = { getHTML, name, shouldTransform }

--- a/config/gatsby-remark-embedder/custom-yt-embedder.js
+++ b/config/gatsby-remark-embedder/custom-yt-embedder.js
@@ -2,9 +2,10 @@ const shouldTransform = url => {
   const { host, pathname, searchParams } = new URL(url)
 
   return (
-    ['youtu.be', 'youtube.com', 'www.youtube.com'].includes(host) &&
-    pathname.includes('/watch') &&
-    Boolean(searchParams.get('v'))
+    host === 'youtu.be' ||
+    (['youtube.com', 'www.youtube.com'].includes(host) &&
+      pathname.includes('/watch') &&
+      Boolean(searchParams.get('v')))
   )
 }
 

--- a/config/gatsby-remark-embedder/custom-yt-embedder.js
+++ b/config/gatsby-remark-embedder/custom-yt-embedder.js
@@ -29,7 +29,7 @@ const getYouTubeIFrameSrc = urlString => {
     url.host === 'youtu.be' ? url.pathname.slice(1) : url.searchParams.get('v')
 
   const embedUrl = new URL(
-    `https://www.youtube-nocookie.com/embed/${id}?rel=0&amp;controls=0&amp;showinfo=0;`
+    `https://www.youtube-nocookie.com/embed/${id}?rel=0&amp;&amp;showinfo=0;`
   )
 
   url.searchParams.forEach((value, name) => {

--- a/config/gatsby-remark-embedder/custom-yt-embedder.js
+++ b/config/gatsby-remark-embedder/custom-yt-embedder.js
@@ -2,10 +2,9 @@ const shouldTransform = url => {
   const { host, pathname, searchParams } = new URL(url)
 
   return (
-    host === 'youtu.be' ||
-    (['youtube.com', 'www.youtube.com'].includes(host) &&
-      pathname.includes('/watch') &&
-      Boolean(searchParams.get('v')))
+    ['youtu.be', 'youtube.com', 'www.youtube.com'].includes(host) &&
+    pathname.includes('/watch') &&
+    Boolean(searchParams.get('v'))
   )
 }
 
@@ -15,10 +14,10 @@ const getTimeValueInSeconds = timeValue => {
   }
 
   const {
-    2: hours = '0',
-    4: minutes = '0',
-    6: seconds = '0'
-  } = timeValue.match(/((\d*)h)?((\d*)m)?((\d*)s)?/)
+    1: hours = '0',
+    2: minutes = '0',
+    3: seconds = '0'
+  } = timeValue.match(/(?:(\d*)h)?(?:(\d*)m)?(?:(\d*)s)?/)
 
   return String((Number(hours) * 60 + Number(minutes)) * 60 + Number(seconds))
 }

--- a/config/gatsby-remark-embedder/custom-yt-embedder.js
+++ b/config/gatsby-remark-embedder/custom-yt-embedder.js
@@ -53,7 +53,7 @@ const name = 'YouTubeCustom'
 const getHTML = url => {
   const iframeSrc = getYouTubeIFrameSrc(url)
 
-  return `<div class="yt-embed-wrapper"><iframe width="100%" height="315" src="${iframeSrc}" frameBorder="0" allow="autoplay; encrypted-media; gyroscope; picture-in-picture" allowFullScreen></iframe><div className="yt-embed-wrapper__overlay"><span class="yt-embed-wrapper__tooltip">By clicking play, you agree to YouTube&apos;s <a href="https://policies.google.com/u/3/privacy?hl=en">Privacy Policy</a> and <a href="https://www.youtube.com/static?template=terms">Terms of Service</a></span></div></div>`
+  return `<div class="yt-embed-wrapper"><iframe width="100%" height="315" src="${iframeSrc}" frameBorder="0" allow="autoplay; encrypted-media; gyroscope; picture-in-picture" allowFullScreen></iframe><div className="yt-embed-wrapper__overlay"><span class="yt-embed-wrapper__tooltip">By clicking play, you agree to YouTube&apos;s <a href="https://policies.google.com/u/3/privacy?hl=en" target="_blank" rel="nofollow noopener noreferrer">Privacy Policy</a> and <a href="https://www.youtube.com/static?template=terms" target="_blank" rel="nofollow noopener noreferrer">Terms of Service</a></span></div></div>`
 }
 
 module.exports = { getHTML, name, shouldTransform }

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -7,6 +7,7 @@ require('./config/prismjs/dvc')
 require('./config/prismjs/usage')
 require('./config/prismjs/dvctable')
 
+const customYoutubeTransformer = require('./config/gatsby-remark-embedder/custom-yt-embedder')
 const apiMiddleware = require('./src/server/middleware/api')
 const redirectsMiddleware = require('./src/server/middleware/redirects')
 const makeFeedHtml = require('./plugins/utils/makeFeedHtml')
@@ -70,7 +71,12 @@ const plugins = [
     resolve: 'gatsby-transformer-remark',
     options: {
       plugins: [
-        'gatsby-remark-embedder',
+        {
+          resolve: 'gatsby-remark-embedder',
+          options: {
+            customTransformers: [customYoutubeTransformer]
+          }
+        },
         'gatsby-remark-dvc-linker',
         {
           resolve: 'gatsby-remark-args-linker',

--- a/plugins/gatsby-theme-iterative-docs/src/components/Documentation/Markdown/Main/index.tsx
+++ b/plugins/gatsby-theme-iterative-docs/src/components/Documentation/Markdown/Main/index.tsx
@@ -5,6 +5,7 @@ import { navigate } from '@reach/router'
 import Link from '../../../Link'
 import Tutorials from '../../TutorialsLinks'
 import { getPathWithSource } from '../../../../utils/shared/sidebar'
+import setUpCustomYtEmbeds from '../../../..//utils/front/setUpCustomYtEmbeds'
 
 import 'github-markdown-css/github-markdown-light.css'
 import * as sharedStyles from '../../styles.module.css'
@@ -64,6 +65,8 @@ const Main: React.FC<IMainProps> = ({
   }, [])
 
   useEffect(() => {
+    setUpCustomYtEmbeds()
+
     document.addEventListener('touchstart', onTouchStart, false)
     document.addEventListener('touchend', onTouchEnd, false)
 

--- a/plugins/gatsby-theme-iterative-docs/src/components/Documentation/Markdown/Main/index.tsx
+++ b/plugins/gatsby-theme-iterative-docs/src/components/Documentation/Markdown/Main/index.tsx
@@ -5,7 +5,7 @@ import { navigate } from '@reach/router'
 import Link from '../../../Link'
 import Tutorials from '../../TutorialsLinks'
 import { getPathWithSource } from '../../../../utils/shared/sidebar'
-import setUpCustomYtEmbeds from '../../../..//utils/front/setUpCustomYtEmbeds'
+import useCustomYtEmbeds from '../../../../utils/front/useCustomYtEmbeds'
 
 import 'github-markdown-css/github-markdown-light.css'
 import * as sharedStyles from '../../styles.module.css'
@@ -44,6 +44,7 @@ const Main: React.FC<IMainProps> = ({
   const touchstartXRef = useRef(0)
   const touchendXRef = useRef(0)
   const isCodeBlockRef = useRef(false)
+  useCustomYtEmbeds()
   const handleSwipeGesture = useCallback(() => {
     if (isCodeBlockRef.current) return
 
@@ -65,8 +66,6 @@ const Main: React.FC<IMainProps> = ({
   }, [])
 
   useEffect(() => {
-    setUpCustomYtEmbeds()
-
     document.addEventListener('touchstart', onTouchStart, false)
     document.addEventListener('touchend', onTouchEnd, false)
 

--- a/plugins/gatsby-theme-iterative-docs/src/components/Documentation/Markdown/Main/styles.module.css
+++ b/plugins/gatsby-theme-iterative-docs/src/components/Documentation/Markdown/Main/styles.module.css
@@ -316,7 +316,10 @@
       }
 
       a {
+        @mixin focus;
+
         color: #fff;
+        text-decoration: underline;
 
         &::after {
           display: none;

--- a/plugins/gatsby-theme-iterative-docs/src/components/Documentation/Markdown/Main/styles.module.css
+++ b/plugins/gatsby-theme-iterative-docs/src/components/Documentation/Markdown/Main/styles.module.css
@@ -311,6 +311,10 @@
       text-shadow: 0 1px 0 rgb(33 45 69 / 25%);
       transition: opacity 0.2s ease-in-out;
 
+      &:hover {
+        cursor: auto;
+      }
+
       a {
         color: #fff;
 

--- a/plugins/gatsby-theme-iterative-docs/src/components/Documentation/Markdown/Main/styles.module.css
+++ b/plugins/gatsby-theme-iterative-docs/src/components/Documentation/Markdown/Main/styles.module.css
@@ -273,6 +273,53 @@
     margin-left: 20px;
     margin-right: 10px;
   }
+
+  .yt-embed-wrapper {
+    position: relative;
+    display: flex;
+
+    &:hover &__tooltip {
+      opacity: 1;
+    }
+
+    &__overlay {
+      position: absolute;
+      bottom: 0;
+      left: 0;
+      width: 100%;
+      height: 100%;
+      display: flex;
+      align-items: flex-end;
+
+      &:hover {
+        cursor: pointer;
+      }
+
+      &.hidden {
+        display: none;
+      }
+    }
+
+    &__tooltip {
+      padding: 10px;
+      box-sizing: border-box;
+      color: #fff;
+      opacity: 0;
+      width: 100%;
+      font-size: 16px;
+      background-color: rgb(23 23 23 / 59%);
+      text-shadow: 0 1px 0 rgb(33 45 69 / 25%);
+      transition: opacity 0.2s ease-in-out;
+
+      a {
+        color: #fff;
+
+        &::after {
+          display: none;
+        }
+      }
+    }
+  }
 }
 
 .content {

--- a/plugins/gatsby-theme-iterative-docs/src/utils/front/setUpCustomYtEmbeds.ts
+++ b/plugins/gatsby-theme-iterative-docs/src/utils/front/setUpCustomYtEmbeds.ts
@@ -3,8 +3,12 @@ const setUpCustomYtEmbeds = () => {
   ytEmbeds.forEach(embed => {
     const iframe = embed.querySelector('iframe')
     const overlay = embed.querySelector('.yt-embed-wrapper__overlay')
+    const tooltip = embed.querySelector('.yt-embed-wrapper__tooltip')
 
-    overlay?.addEventListener('click', () => {
+    overlay?.addEventListener('click', event => {
+      if (event.target === tooltip || tooltip?.contains(event.target)) {
+        return
+      }
       if (iframe && iframe.src) {
         iframe.src = iframe?.src + `&autoplay=1`
       }

--- a/plugins/gatsby-theme-iterative-docs/src/utils/front/setUpCustomYtEmbeds.ts
+++ b/plugins/gatsby-theme-iterative-docs/src/utils/front/setUpCustomYtEmbeds.ts
@@ -1,0 +1,16 @@
+const setUpCustomYtEmbeds = () => {
+  const ytEmbeds = document.querySelectorAll('.yt-embed-wrapper')
+  ytEmbeds.forEach(embed => {
+    const iframe = embed.querySelector('iframe')
+    const overlay = embed.querySelector('.yt-embed-wrapper__overlay')
+
+    overlay?.addEventListener('click', () => {
+      if (iframe && iframe.src) {
+        iframe.src = iframe?.src + `&autoplay=1`
+      }
+      overlay.classList.add('hidden')
+    })
+  })
+}
+
+export default setUpCustomYtEmbeds

--- a/plugins/gatsby-theme-iterative-docs/src/utils/front/useCustomYtEmbeds.ts
+++ b/plugins/gatsby-theme-iterative-docs/src/utils/front/useCustomYtEmbeds.ts
@@ -8,7 +8,7 @@ const setUpCustomYtEmbeds = () => {
     const tooltip = embed.querySelector('.yt-embed-wrapper__tooltip')
 
     overlay?.addEventListener('click', event => {
-      if (event.target === tooltip || tooltip?.contains(event.target)) {
+      if (event.target === tooltip || tooltip?.contains(event.target as Node)) {
         return
       }
       if (iframe && iframe.src) {

--- a/plugins/gatsby-theme-iterative-docs/src/utils/front/useCustomYtEmbeds.ts
+++ b/plugins/gatsby-theme-iterative-docs/src/utils/front/useCustomYtEmbeds.ts
@@ -2,26 +2,44 @@ import { useEffect } from 'react'
 
 const setUpCustomYtEmbeds = () => {
   const ytEmbeds = document.querySelectorAll('.yt-embed-wrapper')
+  const removeClickListeners: Array<() => void> = []
+
   ytEmbeds.forEach(embed => {
     const iframe = embed.querySelector('iframe')
     const overlay = embed.querySelector('.yt-embed-wrapper__overlay')
     const tooltip = embed.querySelector('.yt-embed-wrapper__tooltip')
 
-    overlay?.addEventListener('click', event => {
+    const handleOverlayClick = (event: MouseEvent) => {
       if (event.target === tooltip || tooltip?.contains(event.target as Node)) {
         return
       }
       if (iframe && iframe.src) {
         iframe.src = iframe?.src + `&autoplay=1`
       }
-      overlay.classList.add('hidden')
-    })
+      overlay?.classList.add('hidden')
+    }
+
+    const removeListener = () => {
+      overlay?.removeEventListener('click', handleOverlayClick as EventListener)
+    }
+
+    overlay?.addEventListener('click', handleOverlayClick as EventListener)
+
+    removeClickListeners.push(removeListener)
   })
+
+  return () => {
+    removeClickListeners.forEach(rmListener => rmListener())
+  }
 }
 
 const useCustomYtEmbeds = () => {
   useEffect(() => {
-    setUpCustomYtEmbeds()
+    const removeEventListeners = setUpCustomYtEmbeds()
+
+    return () => {
+      removeEventListeners()
+    }
   }, [])
 }
 

--- a/plugins/gatsby-theme-iterative-docs/src/utils/front/useCustomYtEmbeds.ts
+++ b/plugins/gatsby-theme-iterative-docs/src/utils/front/useCustomYtEmbeds.ts
@@ -1,3 +1,5 @@
+import { useEffect } from 'react'
+
 const setUpCustomYtEmbeds = () => {
   const ytEmbeds = document.querySelectorAll('.yt-embed-wrapper')
   ytEmbeds.forEach(embed => {
@@ -17,4 +19,10 @@ const setUpCustomYtEmbeds = () => {
   })
 }
 
-export default setUpCustomYtEmbeds
+const useCustomYtEmbeds = () => {
+  useEffect(() => {
+    setUpCustomYtEmbeds()
+  }, [])
+}
+
+export default useCustomYtEmbeds

--- a/src/components/Blog/Post/Markdown/styles.module.css
+++ b/src/components/Blog/Post/Markdown/styles.module.css
@@ -603,6 +603,10 @@
         text-shadow: 0 1px 0 rgb(33 45 69 / 25%);
         transition: opacity 0.2s ease-in-out;
 
+        &:hover {
+          cursor: auto;
+        }
+
         a {
           color: #fff;
 

--- a/src/components/Blog/Post/Markdown/styles.module.css
+++ b/src/components/Blog/Post/Markdown/styles.module.css
@@ -608,7 +608,18 @@
         }
 
         a {
+          @mixin focus;
+
           color: #fff;
+          text-decoration: underline;
+
+          &:hover {
+            opacity: 1;
+          }
+
+          &:focus {
+            position: static;
+          }
 
           &::after {
             display: none;

--- a/src/components/Blog/Post/Markdown/styles.module.css
+++ b/src/components/Blog/Post/Markdown/styles.module.css
@@ -564,4 +564,53 @@
       border-bottom: none;
     }
   }
+
+  :global {
+    .yt-embed-wrapper {
+      position: relative;
+      display: flex;
+
+      &:hover &__tooltip {
+        opacity: 1;
+      }
+
+      &__overlay {
+        position: absolute;
+        bottom: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+        display: flex;
+        align-items: flex-end;
+
+        &:hover {
+          cursor: pointer;
+        }
+
+        &.hidden {
+          display: none;
+        }
+      }
+
+      &__tooltip {
+        padding: 10px;
+        box-sizing: border-box;
+        color: #fff;
+        opacity: 0;
+        width: 100%;
+        font-size: 16px;
+        background-color: rgb(23 23 23 / 59%);
+        text-shadow: 0 1px 0 rgb(33 45 69 / 25%);
+        transition: opacity 0.2s ease-in-out;
+
+        a {
+          color: #fff;
+
+          &::after {
+            display: none;
+          }
+        }
+      }
+    }
+  }
 }

--- a/src/components/Blog/Post/index.tsx
+++ b/src/components/Blog/Post/index.tsx
@@ -1,6 +1,6 @@
 import cn from 'classnames'
 
-import React, { useMemo, useRef } from 'react'
+import React, { useMemo, useRef, useEffect } from 'react'
 import { useWindowScroll, useWindowSize } from 'react-use'
 
 import { IBlogPostData } from '../../../templates/blog-post'
@@ -8,6 +8,7 @@ import { IBlogPostData } from '../../../templates/blog-post'
 import { useCommentsCount } from 'gatsby-theme-iterative-docs/src/utils/front/api'
 import { pluralizeComments } from 'gatsby-theme-iterative-docs/src/utils/front/i18n'
 import tagToSlug from 'gatsby-theme-iterative-docs/src/utils/shared/tagToSlug'
+import setUpCustomYtEmbeds from 'gatsby-theme-iterative-docs/src/utils/front/setUpCustomYtEmbeds'
 
 import Markdown from './Markdown'
 import FeedMeta from '../FeedMeta'
@@ -37,6 +38,10 @@ const Post: React.FC<IBlogPostData> = ({
   const wrapperRef = useRef<HTMLDivElement>(null)
   const { width, height } = useWindowSize()
   const { y } = useWindowScroll()
+
+  useEffect(() => {
+    setUpCustomYtEmbeds()
+  }, [])
 
   const isFixed = useMemo(() => {
     if (!wrapperRef.current) {

--- a/src/components/Blog/Post/index.tsx
+++ b/src/components/Blog/Post/index.tsx
@@ -1,6 +1,6 @@
 import cn from 'classnames'
 
-import React, { useMemo, useRef, useEffect } from 'react'
+import React, { useMemo, useRef } from 'react'
 import { useWindowScroll, useWindowSize } from 'react-use'
 
 import { IBlogPostData } from '../../../templates/blog-post'
@@ -8,7 +8,7 @@ import { IBlogPostData } from '../../../templates/blog-post'
 import { useCommentsCount } from 'gatsby-theme-iterative-docs/src/utils/front/api'
 import { pluralizeComments } from 'gatsby-theme-iterative-docs/src/utils/front/i18n'
 import tagToSlug from 'gatsby-theme-iterative-docs/src/utils/shared/tagToSlug'
-import setUpCustomYtEmbeds from 'gatsby-theme-iterative-docs/src/utils/front/setUpCustomYtEmbeds'
+import useCustomYtEmbeds from 'gatsby-theme-iterative-docs/src/utils/front/useCustomYtEmbeds'
 
 import Markdown from './Markdown'
 import FeedMeta from '../FeedMeta'
@@ -39,9 +39,7 @@ const Post: React.FC<IBlogPostData> = ({
   const { width, height } = useWindowSize()
   const { y } = useWindowScroll()
 
-  useEffect(() => {
-    setUpCustomYtEmbeds()
-  }, [])
+  useCustomYtEmbeds()
 
   const isFixed = useMemo(() => {
     if (!wrapperRef.current) {

--- a/src/components/Home/UseCases/Video/index.tsx
+++ b/src/components/Home/UseCases/Video/index.tsx
@@ -3,6 +3,8 @@ import React, { useState, useCallback } from 'react'
 import TwoRowsButton from '../../../TwoRowsButton'
 import { logEvent } from 'gatsby-theme-iterative-docs/src/utils/front/plausible'
 
+import Link from 'gatsby-theme-iterative-docs/src/components/Link'
+
 import * as styles from './styles.module.css'
 
 const Video: React.FC<{ id: string }> = ({ id }) => {
@@ -18,19 +20,32 @@ const Video: React.FC<{ id: string }> = ({ id }) => {
       <div className={styles.handler}>
         {!isWatching && (
           <div className={styles.overlay}>
-            <TwoRowsButton
-              mode="azure"
-              title="Watch video"
-              description="How it works"
-              icon={
-                <img
-                  className={styles.buttonIcon}
-                  src="/img/watch_white.svg"
-                  alt="Watch video"
-                />
-              }
-              onClick={watchVideo}
-            />
+            <div className={styles.content}>
+              <TwoRowsButton
+                mode="azure"
+                title="Watch video"
+                description="How it works"
+                className={styles.button}
+                icon={
+                  <img
+                    className={styles.buttonIcon}
+                    src="/img/watch_white.svg"
+                    alt="Watch video"
+                  />
+                }
+                onClick={watchVideo}
+              />
+              <div className={styles.tooltip}>
+                By clicking play, you agree to YouTube&apos;s{' '}
+                <Link href="https://policies.google.com/u/3/privacy?hl=en">
+                  Privacy Policy
+                </Link>{' '}
+                and{' '}
+                <Link href="https://www.youtube.com/static?template=terms">
+                  Terms of Service
+                </Link>
+              </div>
+            </div>
           </div>
         )}
         <iframe

--- a/src/components/Home/UseCases/Video/index.tsx
+++ b/src/components/Home/UseCases/Video/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback } from 'react'
+import React, { useState, useCallback, useEffect } from 'react'
 
 import TwoRowsButton from '../../../TwoRowsButton'
 import { logEvent } from 'gatsby-theme-iterative-docs/src/utils/front/plausible'
@@ -9,10 +9,18 @@ import * as styles from './styles.module.css'
 
 const Video: React.FC<{ id: string }> = ({ id }) => {
   const [isWatching, setWatching] = useState(false)
+  const [hasUserGivenConsent, setHasUserGivenConsent] = useState(false)
+
+  useEffect(() => {
+    const givenConsent = Boolean(localStorage.getItem('yt-embed-consent'))
+
+    setHasUserGivenConsent(givenConsent)
+  }, [])
 
   const watchVideo = useCallback(() => {
     logEvent('Button', { Item: 'video' })
     setWatching(true)
+    localStorage.setItem('yt-embed-consent', 'true')
   }, [])
 
   return (
@@ -35,16 +43,18 @@ const Video: React.FC<{ id: string }> = ({ id }) => {
                 }
                 onClick={watchVideo}
               />
-              <div className={styles.tooltip}>
-                By clicking play, you agree to YouTube&apos;s{' '}
-                <Link href="https://policies.google.com/u/3/privacy?hl=en">
-                  Privacy Policy
-                </Link>{' '}
-                and{' '}
-                <Link href="https://www.youtube.com/static?template=terms">
-                  Terms of Service
-                </Link>
-              </div>
+              {!hasUserGivenConsent && (
+                <div className={styles.tooltip}>
+                  By clicking play, you agree to YouTube&apos;s{' '}
+                  <Link href="https://policies.google.com/u/3/privacy?hl=en">
+                    Privacy Policy
+                  </Link>{' '}
+                  and{' '}
+                  <Link href="https://www.youtube.com/static?template=terms">
+                    Terms of Service
+                  </Link>
+                </div>
+              )}
             </div>
           </div>
         )}

--- a/src/components/Home/UseCases/Video/styles.module.css
+++ b/src/components/Home/UseCases/Video/styles.module.css
@@ -40,7 +40,34 @@
   display: flex;
   align-items: center;
   justify-content: center;
+  flex-direction: column;
   background-color: rgb(23 23 23 / 59%);
+
+  .content {
+    position: absolute;
+    width: 100%;
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    padding-top: calc(50% - 30px);
+
+    &:hover .tooltip {
+      opacity: 1;
+    }
+  }
+
+  .tooltip {
+    margin: 16px 0;
+    opacity: 0;
+    color: #fff;
+    transition: opacity ease-in-out 0.2s;
+    text-shadow: 0 1px 0 rgb(33 45 69 / 25%);
+
+    a {
+      color: #fff;
+    }
+  }
 }
 
 .buttonIcon {

--- a/src/components/Home/UseCases/Video/styles.module.css
+++ b/src/components/Home/UseCases/Video/styles.module.css
@@ -75,6 +75,8 @@
     }
 
     a {
+      @mixin focus;
+
       color: #fff;
     }
   }

--- a/src/components/Home/UseCases/Video/styles.module.css
+++ b/src/components/Home/UseCases/Video/styles.module.css
@@ -58,11 +58,21 @@
   }
 
   .tooltip {
-    margin: 16px 0;
+    margin: 16px 16px 0;
     opacity: 0;
     color: #fff;
     transition: opacity ease-in-out 0.2s;
     text-shadow: 0 1px 0 rgb(33 45 69 / 25%);
+
+    @media (--xs-scr) {
+      margin: 8px 16px 0;
+      font-size: 14px;
+    }
+
+    @media (--xxs-scr) {
+      margin: 2px 16px 0;
+      font-size: 14px;
+    }
 
     a {
       color: #fff;

--- a/src/components/Home/UseCases/Video/styles.module.css
+++ b/src/components/Home/UseCases/Video/styles.module.css
@@ -63,6 +63,7 @@
     color: #fff;
     transition: opacity ease-in-out 0.2s;
     text-shadow: 0 1px 0 rgb(33 45 69 / 25%);
+    font-size: 16px;
 
     @media (--xs-scr) {
       margin: 8px 16px 0;
@@ -71,7 +72,6 @@
 
     @media (--xxs-scr) {
       margin: 2px 16px 0;
-      font-size: 14px;
     }
 
     a {


### PR DESCRIPTION
* adds a message about youtube's policys when a user hovers over a youtube embed. 
* For our video component, I just added  a message below our overlay button. For our markdown, this is done by using a custom `gatsby-remark-embed` transformer and inserting a js script that handles taking off the message when the user has clicked. 

**To Do**

- [x] Review the js implementation I used for the md embeds
- [x] Decide if the design is good enough for a first iteration at least
- [x] Take off the embeds's message across the site if the user has already clicked on play for one of the embeds (we can do something like this with localStorage)