### PR TITLE
ref: Remove outdated SSH default jobs.

### DIFF
--- a/content/docs/command-reference/exp/pull.md
+++ b/content/docs/command-reference/exp/pull.md
@@ -58,10 +58,9 @@ all <abbr>cached</abbr> data associated with the experiment to DVC
   `dvc exp run <stage_name>` is necessary to checkout these files.
 
 - `-j <number>`, `--jobs <number>` - parallelism level for DVC to upload data to
-  remote storage. The default value is `4 * cpu_count()`. For SSH remotes, the
-  default is `4`. Note that the default value can be set using the `jobs` config
-  option with `dvc remote modify`. Using more jobs may improve the overall
-  transfer speed.
+  remote storage. The default value is `4 * cpu_count()`. Note that the default
+  value can be set using the `jobs` config option with `dvc remote modify`.
+  Using more jobs may improve the overall transfer speed.
 
 - `-h`, `--help` - shows the help message and exit.
 

--- a/content/docs/command-reference/exp/push.md
+++ b/content/docs/command-reference/exp/push.md
@@ -54,10 +54,9 @@ This command will also try to [push](/doc/command-reference/push) all
   the `dvc remote`.
 
 - `-j <number>`, `--jobs <number>` - parallelism level for DVC to upload data to
-  remote storage. The default value is `4 * cpu_count()`. For SSH remotes, the
-  default is `4`. Note that the default value can be set using the `jobs` config
-  option with `dvc remote modify`. Using more jobs may improve the overall
-  transfer speed.
+  remote storage. The default value is `4 * cpu_count()`. Note that the default
+  value can be set using the `jobs` config option with `dvc remote modify`.
+  Using more jobs may improve the overall transfer speed.
 
 - `-h`, `--help` - shows the help message and exit.
 

--- a/content/docs/command-reference/fetch.md
+++ b/content/docs/command-reference/fetch.md
@@ -86,10 +86,9 @@ The `dvc remote` used is determined in order, based on
   the remote repository. See the same option in `dvc push`.
 
 - `-j <number>`, `--jobs <number>` - parallelism level for DVC to download data
-  from remote storage. The default value is `4 * cpu_count()`. For SSH remotes,
-  the default is `4`. Note that the default value can be set using the `jobs`
-  config option with `dvc remote modify`. Using more jobs may speed up the
-  operation.
+  from remote storage. The default value is `4 * cpu_count()`. Note that the
+  default value can be set using the `jobs` config option with
+  `dvc remote modify`. Using more jobs may speed up the operation.
 
 - `-a`, `--all-branches` - fetch cache for all Git branches, as well as for the
   workspace. This means DVC may download files needed to reproduce different

--- a/content/docs/command-reference/gc.md
+++ b/content/docs/command-reference/gc.md
@@ -98,10 +98,9 @@ use `--remote` as well.
 
 - `-j <number>`, `--jobs <number>` - parallelism level for DVC to access data
   from remote storage. This only applies when the `--cloud` option is used, or a
-  `--remote` is given. The default value is `4 * cpu_count()`. For SSH remotes,
-  the default is `4`. Note that the default value can be set using the `jobs`
-  config option with `dvc remote modify`. Using more jobs may speed up the
-  operation.
+  `--remote` is given. The default value is `4 * cpu_count()`. Note that the
+  default value can be set using the `jobs` config option with
+  `dvc remote modify`. Using more jobs may speed up the operation.
 
   > For now only some phases of garbage collection are parallel.
 

--- a/content/docs/command-reference/get-url.md
+++ b/content/docs/command-reference/get-url.md
@@ -67,8 +67,8 @@ $ wget https://example.com/path/to/data.csv
 ## Options
 
 - `-j <number>`, `--jobs <number>` - parallelism level for DVC to download data
-  from the source. The default value is `4 * cpu_count()`. For SSH remotes, the
-  default is `4`. Using more jobs may speed up the operation.
+  from the source. The default value is `4 * cpu_count()`. Using more jobs may
+  speed up the operation.
 
 - `-h`, `--help` - prints the usage/help message, and exit.
 

--- a/content/docs/command-reference/get.md
+++ b/content/docs/command-reference/get.md
@@ -66,10 +66,9 @@ name.
   default branch) is used by default when this option is not specified.
 
 - `-j <number>`, `--jobs <number>` - parallelism level for DVC to download data
-  from the remote. The default value is `4 * cpu_count()`. For SSH remotes, the
-  default is `4`. Using more jobs may speed up the operation. Note that the
-  default value can be set in the source repo using the `jobs` config option of
-  `dvc remote modify`.
+  from the remote. The default value is `4 * cpu_count()`. Using more jobs may
+  speed up the operation. Note that the default value can be set in the source
+  repo using the `jobs` config option of `dvc remote modify`.
 
 - `--show-url` - instead of downloading the file or directory, just print the
   storage location (URL) of the target data. If `path` is a Git-tracked file,

--- a/content/docs/command-reference/import-url.md
+++ b/content/docs/command-reference/import-url.md
@@ -150,8 +150,8 @@ produces a regular stage in `dvc.yaml`.
   `--to-remote`).
 
 - `-j <number>`, `--jobs <number>` - parallelism level for DVC to download data
-  from the source. The default value is `4 * cpu_count()`. For SSH remotes, the
-  default is `4`. Using more jobs may speed up the operation.
+  from the source. The default value is `4 * cpu_count()`. Using more jobs may
+  speed up the operation.
 
 - `--desc <text>` - user description of the data (optional). This doesn't  
   affect any DVC operations.

--- a/content/docs/command-reference/import.md
+++ b/content/docs/command-reference/import.md
@@ -106,10 +106,9 @@ To actually [version the data](/doc/start/data-and-model-versioning), `git add`
   want to "DVCfy" this state of the project (see also `dvc commit`).
 
 - `-j <number>`, `--jobs <number>` - parallelism level for DVC to download data
-  from the remote. The default value is `4 * cpu_count()`. For SSH remotes, the
-  default is `4`. Using more jobs may speed up the operation. Note that the
-  default value can be set in the source repo using the `jobs` config option of
-  `dvc remote modify`.
+  from the remote. The default value is `4 * cpu_count()`. Using more jobs may
+  speed up the operation. Note that the default value can be set in the source
+  repo using the `jobs` config option of `dvc remote modify`.
 
 - `--desc <text>` - user description of the data (optional). This doesn't affect
   any DVC operations.

--- a/content/docs/command-reference/pull.md
+++ b/content/docs/command-reference/pull.md
@@ -117,10 +117,9 @@ used to see what files `dvc pull` would download.
   workspace) and update `dvc.lock`.
 
 - `-j <number>`, `--jobs <number>` - parallelism level for DVC to download data
-  from remote storage. The default value is `4 * cpu_count()`. For SSH remotes,
-  the default is `4`. Note that the default value can be set using the `jobs`
-  config option with `dvc remote modify`. Using more jobs may speed up the
-  operation.
+  from remote storage. The default value is `4 * cpu_count()`. Note that the
+  default value can be set using the `jobs` config option with
+  `dvc remote modify`. Using more jobs may speed up the operation.
 
 - `--glob` - allows pulling files and directories that match the
   [pattern](https://docs.python.org/3/library/glob.html) specified in `targets`.

--- a/content/docs/command-reference/push.md
+++ b/content/docs/command-reference/push.md
@@ -94,9 +94,9 @@ in the cache (compared to the default remote.) It can be used to see what files
   the `dvc remote`.
 
 - `-j <number>`, `--jobs <number>` - parallelism level for DVC to upload data to
-  remote storage. The default value is `4 * cpu_count()`. For SSH remotes, the
-  default is `4`. Note that the default value can be set using the `jobs` config
-  option with `dvc remote modify`. Using more jobs may speed up the operation.
+  remote storage. The default value is `4 * cpu_count()`. Note that the default
+  value can be set using the `jobs` config option with `dvc remote modify`.
+  Using more jobs may speed up the operation.
 
 - `--glob` - allows pushing files and directories that match the
   [pattern](https://docs.python.org/3/library/glob.html) specified in `targets`.

--- a/content/docs/command-reference/remote/modify.md
+++ b/content/docs/command-reference/remote/modify.md
@@ -81,7 +81,7 @@ The following config options are available for all remote types:
   [remote storage](/doc/command-reference/remote) synchronization operations
   (see the `--jobs` option of dvc push`, `dvc pull`, `dvc get`, `dvc
   import`, `dvc update`, `dvc add --to-remote`, `dvc gc
-  -c`, etc.). Accepts positive integers. The default is `4 \* cpu_count()`.
+  -c`, etc.). Accepts positive integers. The default is `4 * cpu_count()`.
 
   ```dvc
   $ dvc remote modify myremote jobs 8

--- a/content/docs/command-reference/remote/modify.md
+++ b/content/docs/command-reference/remote/modify.md
@@ -81,9 +81,7 @@ The following config options are available for all remote types:
   [remote storage](/doc/command-reference/remote) synchronization operations
   (see the `--jobs` option of dvc push`, `dvc pull`, `dvc get`, `dvc
   import`, `dvc update`, `dvc add --to-remote`, `dvc gc -c`, etc.). Accepts
-  positive integers.
-
-  The default is `4 * cpu_count()`.
+  positive integers. The default is `4 * cpu_count()`.
 
   ```dvc
   $ dvc remote modify myremote jobs 8

--- a/content/docs/command-reference/remote/modify.md
+++ b/content/docs/command-reference/remote/modify.md
@@ -80,8 +80,10 @@ The following config options are available for all remote types:
 - `jobs` - change the default number of processes for
   [remote storage](/doc/command-reference/remote) synchronization operations
   (see the `--jobs` option of dvc push`, `dvc pull`, `dvc get`, `dvc
-  import`, `dvc update`, `dvc add --to-remote`, `dvc gc
-  -c`, etc.). Accepts positive integers. The default is `4 * cpu_count()`.
+  import`, `dvc update`, `dvc add --to-remote`, `dvc gc -c`, etc.). Accepts
+  positive integers.
+
+  The default is `4 * cpu_count()`.
 
   ```dvc
   $ dvc remote modify myremote jobs 8

--- a/content/docs/command-reference/remote/modify.md
+++ b/content/docs/command-reference/remote/modify.md
@@ -81,7 +81,7 @@ The following config options are available for all remote types:
   [remote storage](/doc/command-reference/remote) synchronization operations
   (see the `--jobs` option of dvc push`, `dvc pull`, `dvc get`, `dvc
   import`, `dvc update`, `dvc add --to-remote`, `dvc gc
-  -c`, etc.). Accepts positive integers. The default is typically `4`.
+  -c`, etc.). Accepts positive integers. The default is `4 \* cpu_count()`.
 
   ```dvc
   $ dvc remote modify myremote jobs 8

--- a/content/docs/command-reference/remote/modify.md
+++ b/content/docs/command-reference/remote/modify.md
@@ -80,8 +80,8 @@ The following config options are available for all remote types:
 - `jobs` - change the default number of processes for
   [remote storage](/doc/command-reference/remote) synchronization operations
   (see the `--jobs` option of dvc push`, `dvc pull`, `dvc get`, `dvc
-  import`, `dvc update`, `dvc add --to-remote`, `dvc gc -c`, etc.). Accepts
-  positive integers. The default is `4 * cpu_count()`.
+  import`, `dvc update`, `dvc add --to-remote`, `dvc gc
+  -c`, etc.). Accepts positive integers. The default is `4 \* cpu_count()`.
 
   ```dvc
   $ dvc remote modify myremote jobs 8

--- a/content/docs/command-reference/status.md
+++ b/content/docs/command-reference/status.md
@@ -145,10 +145,9 @@ that.
 
 - `-j <number>`, `--jobs <number>` - parallelism level for DVC to access data
   from remote storage. This only applies when the `--cloud` option is used, or a
-  `--remote` is given. The default value is `4 * cpu_count()`. For SSH remotes,
-  the default is `4`. Note that the default value can be set using the `jobs`
-  config option with `dvc remote modify`. Using more jobs may speed up the
-  operation.
+  `--remote` is given. The default value is `4 * cpu_count()`. Note that the
+  default value can be set using the `jobs` config option with
+  `dvc remote modify`. Using more jobs may speed up the operation.
 
 - `-h`, `--help` - prints the usage/help message, and exit.
 

--- a/content/docs/command-reference/update.md
+++ b/content/docs/command-reference/update.md
@@ -60,8 +60,8 @@ $ dvc update --rev master
   `--to-remote`).
 
 - `-j <number>`, `--jobs <number>` - parallelism level for DVC to download data
-  from the source. The default value is `4 * cpu_count()`. For SSH remotes, the
-  default is `4`. Using more jobs may speed up the operation.
+  from the source. The default value is `4 * cpu_count()`. Using more jobs may
+  speed up the operation.
 
 - `-h`, `--help` - prints the usage/help message, and exit.
 


### PR DESCRIPTION
The default to `4` is no longer True.

Per https://github.com/iterative/dvc/pull/7339