### PR TITLE
added height prop to toggle tag

### DIFF
--- a/plugins/gatsby-theme-iterative-docs/src/components/Documentation/Markdown/index.tsx
+++ b/plugins/gatsby-theme-iterative-docs/src/components/Documentation/Markdown/index.tsx
@@ -133,8 +133,9 @@ const ToggleTab: React.FC<{
 }
 
 const Toggle: React.FC<{
+  height?: string
   children: Array<{ props: { title: string } } | string>
-}> = ({ children }) => {
+}> = ({ height, children }) => {
   const [toggleId, setToggleId] = useState('')
   const {
     addNewToggle = (): null => null,
@@ -181,16 +182,19 @@ const Toggle: React.FC<{
           }
           onChange={(): void => updateToggleInd(toggleId, i)}
         >
-          {tab}
+          <div
+            className={cn('tab', styles.tab)}
+            style={{
+              minHeight: height
+            }}
+          >
+            {tab}
+          </div>
         </ToggleTab>
       ))}
     </div>
   )
 }
-
-const Tab: React.FC = ({ children }) => (
-  <div className={cn('tab', styles.tab)}>{children}</div>
-)
 
 // Rehype's typedefs don't allow for custom components, even though they work
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -204,7 +208,7 @@ const renderAst = new (rehypeReact as any)({
     cards: Cards,
     details: Details,
     toggle: Toggle,
-    tab: Tab
+    tab: React.Fragment
   }
 }).Compiler
 


### PR DESCRIPTION
This will be a simple addition to the current toggle tab on markdown.
We can set a height through a `height` prop on the `toggle` component `<toggle height="300px">` which will set height for all the tabs.

Ported from [pull cml#193](https://github.com/iterative/cml.dev/pull/193)

This is added to the `gatsby-plugin-iterative-docs` plugin.

Solves #3179 