### PR TITLE
Only run merge-scheduler workflow if it's not a fork

### DIFF
--- a/.github/workflows/merge-schedule.yaml
+++ b/.github/workflows/merge-schedule.yaml
@@ -11,7 +11,7 @@ on:
 jobs:
   merge_schedule:
     runs-on: ubuntu-latest
-    if: ${{ github.repository == 'iterative/dvc.org' }}
+    if: ${{ github.repository !== 'iterative/dvc.org' }}
     steps:
       - uses: gr2m/merge-schedule-action@v1
         with:

--- a/.github/workflows/merge-schedule.yaml
+++ b/.github/workflows/merge-schedule.yaml
@@ -11,6 +11,7 @@ on:
 jobs:
   merge_schedule:
     runs-on: ubuntu-latest
+    if: github.repository == 'iterative/dvc.org'
     steps:
       - uses: gr2m/merge-schedule-action@v1
         with:
@@ -18,6 +19,6 @@ jobs:
           # rebase. Default is merge.
           merge_method: squash
           #  Time zone to use. Default is UTC.
-          time_zone: "America/Los_Angeles"
+          time_zone: 'America/Los_Angeles'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/merge-schedule.yaml
+++ b/.github/workflows/merge-schedule.yaml
@@ -11,7 +11,8 @@ on:
 jobs:
   merge_schedule:
     runs-on: ubuntu-latest
-    if: ${{ github.repository != 'iterative/dvc.org' }}
+    if:
+      { { github.event.pull_request.head.repo.full_name == github.repository } }
     steps:
       - uses: gr2m/merge-schedule-action@v1
         with:

--- a/.github/workflows/merge-schedule.yaml
+++ b/.github/workflows/merge-schedule.yaml
@@ -11,7 +11,7 @@ on:
 jobs:
   merge_schedule:
     runs-on: ubuntu-latest
-    if: github.repository == 'iterative/dvc.org'
+    if: ${{ github.repository == 'iterative/dvc.org' }}
     steps:
       - uses: gr2m/merge-schedule-action@v1
         with:

--- a/.github/workflows/merge-schedule.yaml
+++ b/.github/workflows/merge-schedule.yaml
@@ -12,7 +12,7 @@ jobs:
   merge_schedule:
     runs-on: ubuntu-latest
     if:
-      { { github.event.pull_request.head.repo.full_name == github.repository } }
+      ${{ github.event.pull_request.head.repo.full_name == github.repository }}
     steps:
       - uses: gr2m/merge-schedule-action@v1
         with:

--- a/.github/workflows/merge-schedule.yaml
+++ b/.github/workflows/merge-schedule.yaml
@@ -11,7 +11,7 @@ on:
 jobs:
   merge_schedule:
     runs-on: ubuntu-latest
-    if: ${{ github.repository !== 'iterative/dvc.org' }}
+    if: ${{ github.repository != 'iterative/dvc.org' }}
     steps:
       - uses: gr2m/merge-schedule-action@v1
         with:


### PR DESCRIPTION
* As shown by #3215, the merge-schedule workflow only runs for prs that aren't from forks and will fail if it runs on a forked pr.