### PR TITLE
better GCP service account links

### DIFF
--- a/content/docs/command-reference/remote/modify.md
+++ b/content/docs/command-reference/remote/modify.md
@@ -608,7 +608,7 @@ more information.
   ```
 
 - `gdrive_service_account_json_file_path` - path to the Google Project's
-  [service account `.json` key file (credentials)](https://cloud.google.com/docs/authentication/getting-started#creating_a_service_account).
+  service account `.json` [key file](https://cloud.google.com/docs/authentication/getting-started#creating_a_service_account) (credentials).
 
   ```dvc
   $ dvc remote modify --local myremote \

--- a/content/docs/command-reference/remote/modify.md
+++ b/content/docs/command-reference/remote/modify.md
@@ -607,8 +607,8 @@ more information.
   $ dvc remote modify myremote gdrive_use_service_account true
   ```
 
-- `gdrive_service_account_json_file_path` - path to the Google Project's service
-  account `.json` key file (credentials).
+- `gdrive_service_account_json_file_path` - path to the Google Project's
+  [service account `.json` key file (credentials)](https://cloud.google.com/docs/authentication/getting-started#creating_a_service_account).
 
   ```dvc
   $ dvc remote modify --local myremote \
@@ -663,7 +663,7 @@ a specific user. Please refer to
 more information.
 
 - `credentialpath` - path to the file that contains the
-  [service account key](/doc/user-guide/setup-google-drive-remote#using-service-accounts).
+  [service account key](https://cloud.google.com/docs/authentication/getting-started#creating_a_service_account).
   Make sure that the service account has read/write access (as needed) to the
   file structure in the remote `url`.
 

--- a/content/docs/command-reference/remote/modify.md
+++ b/content/docs/command-reference/remote/modify.md
@@ -607,8 +607,10 @@ more information.
   $ dvc remote modify myremote gdrive_use_service_account true
   ```
 
-- `gdrive_service_account_json_file_path` - path to the Google Project's
-  service account `.json` [key file](https://cloud.google.com/docs/authentication/getting-started#creating_a_service_account) (credentials).
+- `gdrive_service_account_json_file_path` - path to the Google Project's service
+  account `.json`
+  [key file](https://cloud.google.com/docs/authentication/getting-started#creating_a_service_account)
+  (credentials).
 
   ```dvc
   $ dvc remote modify --local myremote \


### PR DESCRIPTION
GCP Cloud shouldn't really link to Google Drive setup.

See https://github.com/iterative/terraform-provider-iterative/pull/402#discussion_r810441655.