### PR TITLE
start: rever note on pipeline tracking from Versioning page

### DIFF
--- a/content/docs/start/data-and-model-versioning.md
+++ b/content/docs/start/data-and-model-versioning.md
@@ -85,11 +85,7 @@ outs:
 
 </details>
 
-> Note that there are [other mechanisms] to track data files/dirs besides `.dvc`
-> files.
-
 [format]: /doc/user-guide/project-structure/dvc-files
-[other mechanisms]: https://dvc.org/doc/start/data-pipelines#pipeline-stages
 
 ## Storing and sharing
 


### PR DESCRIPTION
- [x] Revert note on pipeline tracking from Versioning page
- [ ] Does the Pipelines page need clarifying instead?

Per https://github.com/iterative/dvc.org/pull/3289#pullrequestreview-890336021