### PR TITLE
`<details>` blocks linkable

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,6 +100,7 @@
     "@babel/core": "^7.16.0",
     "@svgr/webpack": "^6.0.0",
     "@types/classnames": "^2.2.10",
+    "@types/github-slugger": "^1.3.0",
     "@types/isomorphic-fetch": "^0.0.35",
     "@types/promise-polyfill": "^6.0.3",
     "@types/react": "^17.0.37",

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "react-focus-lock": "^2.6.0",
     "react-ga": "^3.3.0",
     "react-helmet": "^6.1.0",
+    "react-inlinesvg": "^2.3.0",
     "react-instantsearch-dom": "^6.20.0",
     "react-popover": "^0.5.10",
     "react-slick": "^0.28.1",

--- a/package.json
+++ b/package.json
@@ -79,7 +79,6 @@
     "react-focus-lock": "^2.6.0",
     "react-ga": "^3.3.0",
     "react-helmet": "^6.1.0",
-    "react-inlinesvg": "^2.3.0",
     "react-instantsearch-dom": "^6.20.0",
     "react-popover": "^0.5.10",
     "react-slick": "^0.28.1",

--- a/plugins/gatsby-theme-iterative-docs/src/components/Documentation/Markdown/Main/styles.module.css
+++ b/plugins/gatsby-theme-iterative-docs/src/components/Documentation/Markdown/Main/styles.module.css
@@ -79,20 +79,27 @@
       content: unset;
     }
 
-    li .anchor svg {
+    li,
+    .collapsableDiv .anchor svg {
       visibility: hidden;
     }
 
-    li:hover .anchor svg {
+    li,
+    .collapsableDiv:hover .anchor svg {
       visibility: visible;
     }
 
-    li .anchor:focus svg {
+    li,
+    .collapsableDiv .anchor:focus svg {
       visibility: visible;
     }
 
     li .anchor {
       line-height: unset;
+    }
+
+    .collapsableDiv .anchor {
+      line-height: 2.5;
     }
 
     .anchor {

--- a/plugins/gatsby-theme-iterative-docs/src/components/Documentation/Markdown/index.tsx
+++ b/plugins/gatsby-theme-iterative-docs/src/components/Documentation/Markdown/index.tsx
@@ -49,7 +49,7 @@ const Details: React.FC<{ slugger: GithubSlugger }> = ({
     firstChild.props.children.length - 1
   ) as ReactNode[]
 
-  let slug = slugger.slug(triggerChildren.toString(), true)
+  let slug = slugger.slug(triggerChildren.toString())
   if (slug[0] === '️') {
     slug = slug.slice(1)
   }

--- a/plugins/gatsby-theme-iterative-docs/src/components/Documentation/Markdown/index.tsx
+++ b/plugins/gatsby-theme-iterative-docs/src/components/Documentation/Markdown/index.tsx
@@ -48,7 +48,7 @@ const Details: React.FC<Record<string, never>> = ({ children }) => {
     .replace(/[^a-zA-Z ]/g, '')
     .toLowerCase()
     .trim()
-    .replaceAll(' ', '_')
+    .replaceAll(' ', '-')
 
   useEffect(() => {
     if (location.hash === `#${id}`) {

--- a/plugins/gatsby-theme-iterative-docs/src/components/Documentation/Markdown/index.tsx
+++ b/plugins/gatsby-theme-iterative-docs/src/components/Documentation/Markdown/index.tsx
@@ -19,7 +19,6 @@ import Tooltip from './Tooltip'
 import * as styles from './styles.module.css'
 import { TogglesContext, TogglesProvider } from './ToggleProvider'
 import { linkIcon } from '../../../../../../static/icons'
-import SVG from 'react-inlinesvg'
 import { useLocation } from '@reach/router'
 
 const Details: React.FC<Record<string, never>> = ({ children }) => {
@@ -71,7 +70,7 @@ const Details: React.FC<Record<string, never>> = ({ children }) => {
         aria-label={triggerChildren.toString()}
         className="anchor after"
       >
-        <SVG src={linkIcon} />
+        <span dangerouslySetInnerHTML={{ __html: linkIcon }}></span>
       </Link>
       <Collapsible
         open={isOpen}

--- a/plugins/gatsby-theme-iterative-docs/src/components/Documentation/Markdown/index.tsx
+++ b/plugins/gatsby-theme-iterative-docs/src/components/Documentation/Markdown/index.tsx
@@ -66,13 +66,13 @@ const Details: React.FC<Record<string, never>> = ({ children }) => {
    */
   return (
     <div id={id} className="collapsableDiv">
-      <a
+      <Link
         href={`#${id}`}
         aria-label={triggerChildren.toString()}
         className="anchor after"
       >
         <SVG src={linkIcon} />
-      </a>
+      </Link>
       <Collapsible
         open={isOpen}
         trigger={triggerChildren as unknown as ReactElement}

--- a/plugins/gatsby-theme-iterative-docs/src/components/Documentation/Markdown/index.tsx
+++ b/plugins/gatsby-theme-iterative-docs/src/components/Documentation/Markdown/index.tsx
@@ -18,8 +18,13 @@ import Tooltip from './Tooltip'
 
 import * as styles from './styles.module.css'
 import { TogglesContext, TogglesProvider } from './ToggleProvider'
+import { linkIcon } from '../../../../../../static/icons'
+import SVG from 'react-inlinesvg'
+import { globalHistory as history } from '@reach/router'
 
 const Details: React.FC<Record<string, never>> = ({ children }) => {
+  const [isOpen, setIsOpen] = useState(false)
+  const { location } = history
   const filteredChildren: ReactNode[] = (
     children as Array<{ props: { children: ReactNode } } | string>
   ).filter(child => child !== '\n')
@@ -38,18 +43,44 @@ const Details: React.FC<Record<string, never>> = ({ children }) => {
     0,
     firstChild.props.children.length - 1
   ) as ReactNode[]
+  const id = triggerChildren
+    .toString()
+    .replace(/[^a-zA-Z ]/g, '')
+    .toLowerCase()
+    .trim()
+    .replaceAll(' ', '_')
+
+  useEffect(() => {
+    if (location.hash === `#${id}`) {
+      setIsOpen(true)
+    }
+
+    return () => {
+      setIsOpen(false)
+    }
+  }, [location.hash])
 
   /*
      Collapsible's trigger type wants ReactElement, so we force a TS cast from
      ReactNode here.
    */
   return (
-    <Collapsible
-      trigger={triggerChildren as unknown as ReactElement}
-      transitionTime={200}
-    >
-      {filteredChildren.slice(1)}
-    </Collapsible>
+    <div id={id} className="collapsableDiv">
+      <a
+        href={`#${id}`}
+        aria-label={triggerChildren.toString()}
+        className="anchor after"
+      >
+        <SVG src={linkIcon} />
+      </a>
+      <Collapsible
+        open={isOpen}
+        trigger={triggerChildren as unknown as ReactElement}
+        transitionTime={200}
+      >
+        {filteredChildren.slice(1)}
+      </Collapsible>
+    </div>
   )
 }
 

--- a/plugins/gatsby-theme-iterative-docs/src/components/Documentation/Markdown/index.tsx
+++ b/plugins/gatsby-theme-iterative-docs/src/components/Documentation/Markdown/index.tsx
@@ -21,9 +21,13 @@ import { TogglesContext, TogglesProvider } from './ToggleProvider'
 import { linkIcon } from '../../../../../../static/icons'
 import { useLocation } from '@reach/router'
 
+import GithubSlugger from 'github-slugger'
+const slugger = new GithubSlugger()
+
 const Details: React.FC<Record<string, never>> = ({ children }) => {
   const [isOpen, setIsOpen] = useState(false)
   const location = useLocation()
+
   const filteredChildren: ReactNode[] = (
     children as Array<{ props: { children: ReactNode } } | string>
   ).filter(child => child !== '\n')
@@ -42,12 +46,12 @@ const Details: React.FC<Record<string, never>> = ({ children }) => {
     0,
     firstChild.props.children.length - 1
   ) as ReactNode[]
-  const id = triggerChildren
-    .toString()
-    .replace(/[^a-zA-Z ]/g, '')
-    .toLowerCase()
-    .trim()
-    .replaceAll(' ', '-')
+
+  let slug = slugger.slug(triggerChildren.toString())
+  if (slug[0] === '️') {
+    slug = slug.slice(1)
+  }
+  const id = slug.startsWith('-') ? slug.slice(1) : slug
 
   useEffect(() => {
     if (location.hash === `#${id}`) {

--- a/plugins/gatsby-theme-iterative-docs/src/components/Documentation/Markdown/index.tsx
+++ b/plugins/gatsby-theme-iterative-docs/src/components/Documentation/Markdown/index.tsx
@@ -20,11 +20,11 @@ import * as styles from './styles.module.css'
 import { TogglesContext, TogglesProvider } from './ToggleProvider'
 import { linkIcon } from '../../../../../../static/icons'
 import SVG from 'react-inlinesvg'
-import { globalHistory as history } from '@reach/router'
+import { useLocation } from '@reach/router'
 
 const Details: React.FC<Record<string, never>> = ({ children }) => {
   const [isOpen, setIsOpen] = useState(false)
-  const { location } = history
+  const location = useLocation()
   const filteredChildren: ReactNode[] = (
     children as Array<{ props: { children: ReactNode } } | string>
   ).filter(child => child !== '\n')
@@ -226,6 +226,9 @@ const Toggle: React.FC<{
     </div>
   )
 }
+const Tab: React.FC = ({ children }) => {
+  return <React.Fragment>{children}</React.Fragment>
+}
 
 // Rehype's typedefs don't allow for custom components, even though they work
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -239,7 +242,7 @@ const renderAst = new (rehypeReact as any)({
     cards: Cards,
     details: Details,
     toggle: Toggle,
-    tab: React.Fragment
+    tab: Tab
   }
 }).Compiler
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -7428,11 +7428,6 @@ execall@^2.0.0:
   dependencies:
     clone-regexp "^2.1.0"
 
-exenv@^1.2.2:
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/exenv/-/exenv-1.2.2.tgz#2ae78e85d9894158670b03d47bec1f03bd91bb9d"
-  integrity sha1-KueOhdmJQVhnCwPUe+wfA72Ru50=
-
 exif-parser@^0.1.12:
   version "0.1.12"
   resolved "https://registry.npmjs.org/exif-parser/-/exif-parser-0.1.12.tgz"
@@ -13925,11 +13920,6 @@ react-focus-lock@^2.6.0:
     use-callback-ref "^1.2.5"
     use-sidecar "^1.0.5"
 
-react-from-dom@^0.6.0:
-  version "0.6.1"
-  resolved "https://registry.yarnpkg.com/react-from-dom/-/react-from-dom-0.6.1.tgz#6740f5a3d79e0c354703e5c096b8fdfe0db71b0f"
-  integrity sha512-7aAZx7LhRnmR51W5XtmTBYHGFl2n1AdEk1uoXLuzHa1OoGXrxOW/iwLcudvgp6BGX/l4Yh1rtMrIzvhlvbVddg==
-
 react-ga@^3.3.0:
   version "3.3.0"
   resolved "https://registry.npmjs.org/react-ga/-/react-ga-3.3.0.tgz"
@@ -13944,14 +13934,6 @@ react-helmet@^6.1.0:
     prop-types "^15.7.2"
     react-fast-compare "^3.1.1"
     react-side-effect "^2.1.0"
-
-react-inlinesvg@^2.3.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/react-inlinesvg/-/react-inlinesvg-2.3.0.tgz#62283c0ce7e9d11d8190ec3e89589102288830fd"
-  integrity sha512-fEGOdDf4k4bcveArbEpj01pJcH8pOCKLxmSj2POFdGvEk5YK0NZVnH6BXpW/PzACHPRsuh1YKAhNZyFnD28oxg==
-  dependencies:
-    exenv "^1.2.2"
-    react-from-dom "^0.6.0"
 
 react-instantsearch-core@^6.20.0:
   version "6.20.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7428,6 +7428,11 @@ execall@^2.0.0:
   dependencies:
     clone-regexp "^2.1.0"
 
+exenv@^1.2.2:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/exenv/-/exenv-1.2.2.tgz#2ae78e85d9894158670b03d47bec1f03bd91bb9d"
+  integrity sha1-KueOhdmJQVhnCwPUe+wfA72Ru50=
+
 exif-parser@^0.1.12:
   version "0.1.12"
   resolved "https://registry.npmjs.org/exif-parser/-/exif-parser-0.1.12.tgz"
@@ -13920,6 +13925,11 @@ react-focus-lock@^2.6.0:
     use-callback-ref "^1.2.5"
     use-sidecar "^1.0.5"
 
+react-from-dom@^0.6.0:
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/react-from-dom/-/react-from-dom-0.6.1.tgz#6740f5a3d79e0c354703e5c096b8fdfe0db71b0f"
+  integrity sha512-7aAZx7LhRnmR51W5XtmTBYHGFl2n1AdEk1uoXLuzHa1OoGXrxOW/iwLcudvgp6BGX/l4Yh1rtMrIzvhlvbVddg==
+
 react-ga@^3.3.0:
   version "3.3.0"
   resolved "https://registry.npmjs.org/react-ga/-/react-ga-3.3.0.tgz"
@@ -13934,6 +13944,14 @@ react-helmet@^6.1.0:
     prop-types "^15.7.2"
     react-fast-compare "^3.1.1"
     react-side-effect "^2.1.0"
+
+react-inlinesvg@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/react-inlinesvg/-/react-inlinesvg-2.3.0.tgz#62283c0ce7e9d11d8190ec3e89589102288830fd"
+  integrity sha512-fEGOdDf4k4bcveArbEpj01pJcH8pOCKLxmSj2POFdGvEk5YK0NZVnH6BXpW/PzACHPRsuh1YKAhNZyFnD28oxg==
+  dependencies:
+    exenv "^1.2.2"
+    react-from-dom "^0.6.0"
 
 react-instantsearch-core@^6.20.0:
   version "6.20.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3386,6 +3386,11 @@
   resolved "https://registry.npmjs.org/@types/get-port/-/get-port-3.2.0.tgz"
   integrity sha512-TiNg8R1kjDde5Pub9F9vCwZA/BNW9HeXP5b9j7Qucqncy/McfPZ6xze/EyBdXS5FhMIGN6Fx3vg75l5KHy3V1Q==
 
+"@types/github-slugger@^1.3.0":
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/@types/github-slugger/-/github-slugger-1.3.0.tgz#16ab393b30d8ae2a111ac748a015ac05a1fc5524"
+  integrity sha512-J/rMZa7RqiH/rT29TEVZO4nBoDP9XJOjnbbIofg7GQKs4JIduEO3WLpte+6WeUz/TcrXKlY+bM7FYrp8yFB+3g==
+
 "@types/glob@*", "@types/glob@^7.1.1":
   version "7.1.4"
   resolved "https://registry.npmjs.org/@types/glob/-/glob-7.1.4.tgz"


### PR DESCRIPTION
Made the `<details>` block linkable and will auto expand when the link is opened through the hashed links.

Some considerations and possible issues:
- I have used the details `title` for the `id` attribute which seems to be a good solution until there are [some pages that have the same titles in multiple places](https://dvc.org/doc/start/data-and-model-versioning) particularly ` Expand to see what happens under the hood.`

Fix for #3314 