### PR TITLE
dvc 2.9.4

### DIFF
--- a/src/components/DownloadButton/index.tsx
+++ b/src/components/DownloadButton/index.tsx
@@ -9,7 +9,7 @@ import { logEvent } from 'gatsby-theme-iterative-docs/src/utils/front/plausible'
 
 import * as styles from './styles.module.css'
 
-const VERSION = `2.9.5`
+const VERSION = `2.9.4`
 
 enum OS {
   UNKNOWN = 'unknown',


### PR DESCRIPTION
- partially reverts #3294 (so effectively bump `2.9.3`->`2.9.4` rather than `2.9.3`->`2.9.5`)
- fixes #3334