### PR TITLE
Fix: keyboard interaction for dropdown

### DIFF
--- a/src/components/LayoutHeader/Nav/LinkItems/index.tsx
+++ b/src/components/LayoutHeader/Nav/LinkItems/index.tsx
@@ -20,6 +20,7 @@ const docsPage = getFirstPage()
 
 import * as styles from './styles.module.css'
 import { ReactComponent as EllipsisIcon } from '../../../../../static/img/ellipsis.svg'
+import onSelectKey from '../../../../utils/onSelectKey'
 
 type PopupName = 'communityPopup' | 'otherToolsPopup' | 'otherPopup'
 
@@ -117,6 +118,7 @@ const LinkItems: React.FC = () => {
                 <button
                   aria-label={item.ariaLabel}
                   onPointerUp={popup?.toggle}
+                  onKeyUp={onSelectKey(popup?.toggle)}
                   className={cn(
                     styles.link,
                     popup?.isOpen && styles.open,

--- a/src/utils/onSelectKey.ts
+++ b/src/utils/onSelectKey.ts
@@ -1,0 +1,10 @@
+import { KeyboardEvent, KeyboardEventHandler } from 'react'
+
+const onSelectKey = (handler: KeyboardEventHandler<HTMLButtonElement>) => {
+  return (event: KeyboardEvent<HTMLButtonElement>) => {
+    if (event.key === 'Enter' || event.key === ' ') {
+      handler(event)
+    }
+  }
+}
+export default onSelectKey


### PR DESCRIPTION
>I just realized that by using onPointerUp, keyboard users are not able to click on the dropdown. 

Added keyboard support for the dropdown. Update on #3317 