### PR TITLE
start: Replace `dvc run` references in data-pipelines

### DIFF
--- a/content/docs/start/data-pipelines.md
+++ b/content/docs/start/data-pipelines.md
@@ -23,10 +23,10 @@ https://youtu.be/71IGzyH95UY
 
 ## Pipeline stages
 
-Use `dvc run` to create _stages_. These represent processes (source code tracked
-with Git) which form the steps of a _pipeline_. Stages also connect code to its
-corresponding data _input_ and _output_. Let's transform a Python script into a
-[stage](/doc/command-reference/run):
+Use `dvc stage add` to create _stages_. These represent processes (source code
+tracked with Git) which form the steps of a _pipeline_. Stages also connect
+code to its corresponding data _input_ and _output_. Let's transform a Python
+script into a [stage](/doc/command-reference/stage):
 
 <details>
 
@@ -64,11 +64,11 @@ Please also add or commit the source code directory with Git at this point.
 </details>
 
 ```dvc
-$ dvc run -n prepare \
-          -p prepare.seed,prepare.split \
-          -d src/prepare.py -d data/data.xml \
-          -o data/prepared \
-          python src/prepare.py data/data.xml
+$ dvc stage add -n prepare \
+                -p prepare.seed,prepare.split \
+                -d src/prepare.py -d data/data.xml \
+                -o data/prepared \
+                python src/prepare.py data/data.xml
 ```
 
 A `dvc.yaml` file is generated. It includes information about the command we ran
@@ -143,32 +143,31 @@ stages:
       - data/prepared
 ```
 
-Note that upon successful execution, a complementary `dvc.lock` metafile is
-written to track the related data.
-
 </details>
 
-You can use `dvc push` if you wish to save all the data [to remote storage]
+Once you added a stage, you can run the pipeline with `dvc repro`. Next, you
+can use `dvc push` if you wish to save all the data [to remote storage]
 (usually along with `git commit` to version DVC metafiles).
 
 [to remote storage]: /doc/start/data-and-model-versioning#storing-and-sharing
 
 ## Dependency graphs (DAGs)
 
-By using `dvc run` multiple times, and specifying <abbr>outputs</abbr> of a
-stage as <abbr>dependencies</abbr> of another one, we can describe a sequence of
-commands which gets to a desired result. This is what we call a _data pipeline_
-or [_dependency graph_](https://en.wikipedia.org/wiki/Directed_acyclic_graph).
+By using `dvc stage add` multiple times, and specifying <abbr>outputs</abbr> of
+a stage as <abbr>dependencies</abbr> of another one, we can describe a sequence
+of commands which gets to a desired result. This is what we call a _data
+pipeline_ or [_dependency
+graph_](https://en.wikipedia.org/wiki/Directed_acyclic_graph).
 
 Let's create a second stage chained to the outputs of `prepare`, to perform
 feature extraction:
 
 ```dvc
-$ dvc run -n featurize \
-          -p featurize.max_features,featurize.ngrams \
-          -d src/featurization.py -d data/prepared \
-          -o data/features \
-          python src/featurization.py data/prepared data/features
+$ dvc stage add -n featurize \
+                -p featurize.max_features,featurize.ngrams \
+                -d src/featurization.py -d data/prepared \
+                -o data/features \
+                python src/featurization.py data/prepared data/features
 ```
 
 The `dvc.yaml` file is updated automatically and should include two stages now.
@@ -213,11 +212,11 @@ Let's add the training itself. Nothing new this time; just the same `dvc run`
 command with the same set of options:
 
 ```dvc
-$ dvc run -n train \
-          -p train.seed,train.n_est,train.min_split \
-          -d src/train.py -d data/features \
-          -o model.pkl \
-          python src/train.py data/features model.pkl
+$ dvc stage add -n train \
+                -p train.seed,train.n_est,train.min_split \
+                -d src/train.py -d data/features \
+                -o model.pkl \
+                python src/train.py data/features model.pkl
 ```
 
 Please check the `dvc.yaml` again, it should have one more stage now.
@@ -307,8 +306,8 @@ stages:
 
 </details>
 
-DVC pipelines (`dvc.yaml` file, `dvc run`, and `dvc repro` commands) solve a few
-important problems:
+DVC pipelines (`dvc.yaml` file, `dvc stage run`, and `dvc repro` commands)
+solve a few important problems:
 
 - _Automation_: run a sequence of steps in a "smart" way which makes iterating
   on your project faster. DVC automatically determines which parts of a project

--- a/content/docs/start/data-pipelines.md
+++ b/content/docs/start/data-pipelines.md
@@ -306,7 +306,7 @@ stages:
 
 </details>
 
-DVC pipelines (`dvc.yaml` file, `dvc stage run`, and `dvc repro` commands) solve
+DVC pipelines (`dvc.yaml` file, `dvc stage add`, and `dvc repro` commands) solve
 a few important problems:
 
 - _Automation_: run a sequence of steps in a "smart" way which makes iterating

--- a/content/docs/start/data-pipelines.md
+++ b/content/docs/start/data-pipelines.md
@@ -71,9 +71,9 @@ $ dvc stage add -n prepare \
                 python src/prepare.py data/data.xml
 ```
 
-A `dvc.yaml` file is generated. It includes information about the command we ran
-(`python src/prepare.py data/data.xml`), its <abbr>dependencies</abbr>, and
-<abbr>outputs</abbr>.
+A `dvc.yaml` file is generated. It includes information about the command we
+want to run (`python src/prepare.py data/data.xml`), its
+<abbr>dependencies</abbr>, and <abbr>outputs</abbr>.
 
 DVC uses these metafiles to track the data used and produced by the stage, so
 there's no need to use `dvc add` on `data/prepared`

--- a/content/docs/start/data-pipelines.md
+++ b/content/docs/start/data-pipelines.md
@@ -24,9 +24,9 @@ https://youtu.be/71IGzyH95UY
 ## Pipeline stages
 
 Use `dvc stage add` to create _stages_. These represent processes (source code
-tracked with Git) which form the steps of a _pipeline_. Stages also connect
-code to its corresponding data _input_ and _output_. Let's transform a Python
-script into a [stage](/doc/command-reference/stage):
+tracked with Git) which form the steps of a _pipeline_. Stages also connect code
+to its corresponding data _input_ and _output_. Let's transform a Python script
+into a [stage](/doc/command-reference/stage):
 
 <details>
 
@@ -145,9 +145,9 @@ stages:
 
 </details>
 
-Once you added a stage, you can run the pipeline with `dvc repro`. Next, you
-can use `dvc push` if you wish to save all the data [to remote storage]
-(usually along with `git commit` to version DVC metafiles).
+Once you added a stage, you can run the pipeline with `dvc repro`. Next, you can
+use `dvc push` if you wish to save all the data [to remote storage] (usually
+along with `git commit` to version DVC metafiles).
 
 [to remote storage]: /doc/start/data-and-model-versioning#storing-and-sharing
 
@@ -156,8 +156,8 @@ can use `dvc push` if you wish to save all the data [to remote storage]
 By using `dvc stage add` multiple times, and specifying <abbr>outputs</abbr> of
 a stage as <abbr>dependencies</abbr> of another one, we can describe a sequence
 of commands which gets to a desired result. This is what we call a _data
-pipeline_ or [_dependency
-graph_](https://en.wikipedia.org/wiki/Directed_acyclic_graph).
+pipeline_ or
+[_dependency graph_](https://en.wikipedia.org/wiki/Directed_acyclic_graph).
 
 Let's create a second stage chained to the outputs of `prepare`, to perform
 feature extraction:
@@ -306,8 +306,8 @@ stages:
 
 </details>
 
-DVC pipelines (`dvc.yaml` file, `dvc stage run`, and `dvc repro` commands)
-solve a few important problems:
+DVC pipelines (`dvc.yaml` file, `dvc stage run`, and `dvc repro` commands) solve
+a few important problems:
 
 - _Automation_: run a sequence of steps in a "smart" way which makes iterating
   on your project faster. DVC automatically determines which parts of a project


### PR DESCRIPTION

This replaces `dvc run` examples in `data-pipelines`. 

Related #3309 

