### PR TITLE
Added custom code based slugger for making `<details>` blocks linkable

### DIFF
--- a/content/docs/start/data-and-model-versioning.md
+++ b/content/docs/start/data-and-model-versioning.md
@@ -145,7 +145,7 @@ $ dvc push
 Usually, we also want to `git commit` and `git push` the corresponding `.dvc`
 files.
 
-<details>
+<details code="storing and sharing" position="start">
 
 ### 💡 Expand to see what happens under the hood.
 

--- a/plugins/gatsby-theme-iterative-docs/src/utils/front/Slugger.ts
+++ b/plugins/gatsby-theme-iterative-docs/src/utils/front/Slugger.ts
@@ -1,0 +1,49 @@
+class Slugger {
+  separator: string
+  lowercase: boolean
+  codePosition: string
+  slugs: Array<string>
+
+  constructor(options?: {
+    separator?: string
+    lowercase?: boolean
+    codePosition?: string
+  }) {
+    this.separator = options?.separator || '-'
+    this.lowercase = Boolean(options?.lowercase) && true
+    this.codePosition = options?.codePosition || 'end'
+    this.slugs = []
+  }
+
+  slug(str: string, code?: string, position = this.codePosition) {
+    str = typeof str === 'string' ? str : ''
+    let slug = this.slugify(str)
+
+    if (this.lowercase) {
+      slug = slug.toLowerCase()
+    }
+    if (code) {
+      const codeSlug = this.slugify(code)
+      slug =
+        position === 'start'
+          ? `${codeSlug}${this.separator}${slug}`
+          : `${slug}${this.separator}${codeSlug}`
+    }
+    if (this.slugs.includes(slug)) {
+      throw new Error(`Duplicate slug: ${slug} for title:${str}`)
+    }
+    this.slugs.push(slug)
+    return slug
+  }
+  slugify = (str: string) => {
+    return str
+      .replace(/[^\w\s-]/g, '')
+      .trim()
+      .replace(/[-\s]+/g, this.separator)
+      .replace(this.separator + this.separator, this.separator)
+  }
+  reset() {
+    this.slugs = []
+  }
+}
+export default Slugger


### PR DESCRIPTION
This is another solution for making a unique link for the `<details>` block. This uses custom Slugger to provide the custom code/word to make the hash link unique and eliminates the possibility of links pointing to another place if we perform some page updates.

Some considerations with this methods are:
- the code must be provided in case of duplicates titles otherwise development will show an error and the build also fails
- Also, there is also an optional props `position` for the position of the code in the hash link (which is "end" by default, also accepts "start")
 
For an example implementation, I have updated `docs/start/data-and-model-versioning` which had two `<details>` components with the title `Expand to see what happens under the hood.` so I have updated one with `code` and also used optional `positoin` to place the code at the start of the hash id. 

<img width="698" alt="Screen Shot 2022-03-11 at 19 52 14" src="https://user-images.githubusercontent.com/20840228/157883080-9bd3f3db-3693-4d68-8db1-9cf707440efd.png">

The generated link will be `/doc/start/data-and-model-versioning#storing-and-sharing-Expand-to-see-what-happens-under-the-hood`.

Note: This preview deployment may fail since I have not updated all the docs having the same title.

Continue on PR #3329 