### PR TITLE
Remove deleted tweet embed

### DIFF
--- a/content/blog/2022-1-18-January-22-heartbeat.md
+++ b/content/blog/2022-1-18-January-22-heartbeat.md
@@ -333,10 +333,6 @@ on January 27th! She will be presenting her talk on Using Reproducible
 Experiments To Create Better Machine Learning Models. If you haven't caught this
 talk yet, now's the time!
 
-## Tweet Love ❤️
-
-https://twitter.com/EngNadeau/status/1480962796695310340?s=20
-
 ---
 
 _Have something great to say about our tools? We'd love to hear it! Head to


### PR DESCRIPTION
This PR removes a tweet from the [January '22 Heartbeat](https://dvc.org/blog/January-22-heartbeat) blog post that has recently been deleted. It turns out trying to embed deleted tweets causes the build to fail, so something will have to be done about this even if not an outright deletion like this PR currently does.

In case anyone's wondering, the embed on the production site currently looks like this:
![image](https://user-images.githubusercontent.com/9111807/158216987-8abce3b4-99f8-45b6-8abb-4934065d0eef.png)