### PR TITLE
Use `rehype-react` to render blog post content

### DIFF
--- a/src/components/Blog/Post/Markdown/index.tsx
+++ b/src/components/Blog/Post/Markdown/index.tsx
@@ -1,13 +1,21 @@
 import React from 'react'
+import rehypeReact from 'rehype-react'
 
 import * as styles from './styles.module.css'
 
 interface IMarkdownProps {
-  html: string
+  htmlAst: Node
 }
 
-const Markdown: React.FC<IMarkdownProps> = ({ html }) => (
-  <div className={styles.wrapper} dangerouslySetInnerHTML={{ __html: html }} />
-)
+// Rehype's typedefs don't allow for custom components, even though they work
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const renderAst = new (rehypeReact as any)({
+  createElement: React.createElement,
+  Fragment: React.Fragment
+}).Compiler
+
+const Markdown: React.FC<IMarkdownProps> = ({ htmlAst }) => {
+  return <div className={styles.wrapper}>{renderAst(htmlAst)}</div>
+}
 
 export default Markdown

--- a/src/components/Blog/Post/index.tsx
+++ b/src/components/Blog/Post/index.tsx
@@ -22,7 +22,7 @@ import SubscribeSection from '../../SubscribeSection'
 import * as styles from './styles.module.css'
 
 const Post: React.FC<IBlogPostData> = ({
-  html,
+  htmlAst,
   timeToRead,
   title,
   date,
@@ -38,7 +38,6 @@ const Post: React.FC<IBlogPostData> = ({
   const wrapperRef = useRef<HTMLDivElement>(null)
   const { width, height } = useWindowSize()
   const { y } = useWindowScroll()
-
   useCustomYtEmbeds()
 
   const isFixed = useMemo(() => {
@@ -92,7 +91,7 @@ const Post: React.FC<IBlogPostData> = ({
           />
 
           <div className={styles.content}>
-            <Markdown html={html} />
+            <Markdown htmlAst={htmlAst} />
           </div>
           {tags && (
             <div className={styles.tags}>

--- a/src/templates/blog-post.tsx
+++ b/src/templates/blog-post.tsx
@@ -16,6 +16,7 @@ export interface IBlogPostHeroPic {
 export interface IBlogPostData {
   id: string
   html: string
+  htmlAst: Node
   timeToRead: string
   slug: string
   title: string
@@ -98,6 +99,7 @@ export const pageQuery = graphql`
       id
       slug
       html
+      htmlAst
       timeToRead
       title
       date(formatString: "MMMM DD, YYYY")


### PR DESCRIPTION
Fixes #3076 (and allows us to work on #3153)
