### PR TITLE
add note regarding hook revision to install section

### DIFF
--- a/content/docs/command-reference/install.md
+++ b/content/docs/command-reference/install.md
@@ -101,9 +101,11 @@ repos:
         stages:
           - post-checkout
     repo: https://github.com/iterative/dvc
-    # use a specific version (e.g. 1.8.1) instead of master if you don't want
-    # to use the upstream version
-    rev: master
+    rev: main
+    # rev should be set to a specific revision (e.g. 2.9.5) since pre-commit
+    # does not allow using mutable references.
+    # If using `main`, see pre-commit guide:
+    #    https://pre-commit.com/#using-the-latest-version-for-a-repository
 ```
 
 Note that by default, the pre-commit tool only installs `pre-commit` hooks. To


### PR DESCRIPTION
If installing the `pre-commit` hook following the guide (using `rev: main` revision for the hook), the following warning is printed
whenever running `git commit`

> [WARNING] The 'rev' field of repo 'https://github.com/iterative/dvc' appears to be a mutable reference (moving tag / branch).  Mutable references are never updated after first install and are not supported.  See https://pre-commit.com/#using-the-latest-version-for-a-repository for more details.  Hint: `pre-commit autoupdate` often fixes this.