### PR TITLE
Update stale CML container images

### DIFF
--- a/content/blog/2020-07-07-cml-release.md
+++ b/content/blog/2020-07-07-cml-release.md
@@ -121,7 +121,7 @@ stages:
 
 cml:
   stage: cml_run
-  image: dvcorg/cml-py3:latest
+  image: iterativeai/cml:0-dvc2-base1
   script:
     - dvc pull data --run-cache
 
@@ -142,9 +142,9 @@ cml:
 ![Hyperparameter change with a result image in GitHub Pull request report](/uploads/images/2020-07-07/cml-report-params.png)
 
 In this example all the CML functions are defined in the **docker images** that
-is used in the workflow - `dvcorg/cml-py3`. Users can specify any docker image.
-The only restriction is that the CML library need to be installed to enable all
-the CML commands for the reporting and graphs:
+is used in the workflow - `iterativeai/cml:0-dvc2-base1`. Users can specify any
+docker image. The only restriction is that the CML library need to be installed
+to enable all the CML commands for the reporting and graphs:
 
 ```bash
 npm i @dvcorg/cml

--- a/content/blog/2020-07-16-devops-for-data-scientists.md
+++ b/content/blog/2020-07-16-devops-for-data-scientists.md
@@ -258,7 +258,7 @@ on: [push]
 jobs:
   run:
     runs-on: [ubuntu-latest]
-    container: docker://dvcorg/cml-py3:latest
+    container: iterativeai/cml:0-dvc2-base1
     steps:
       - uses: actions/checkout@v2
       - name: training

--- a/content/blog/2020-08-07-cml-self-hosted-runners-on-demand-with-gpus.md
+++ b/content/blog/2020-08-07-cml-self-hosted-runners-on-demand-with-gpus.md
@@ -75,7 +75,7 @@ $ curl -s -L https://nvidia.GitHub.io/nvidia-docker/gpgkey | sudo apt-key add - 
 You can test that your gpus are up and running with the following command:
 
 ```dvc
-$ docker run --gpus all dvcorg/cml-py3 nvidia-smi
+$ docker run --gpus all iterativeai/cml:0-dvc2-base1-gpu nvidia-smi
 ```
 
 We should see something like this:
@@ -83,15 +83,10 @@ We should see something like this:
 
 ### 2) Start your self-hosted runner
 
-With CML docker images launching your own self-hosted runner is very easy. They
-comes in two flavours, depending if you need python 2 or 3:
-
-- dvcorg/cml:latest
-- dvcorg/cml-py3:latest
-
-These images have CML and DVC preinstalled (among other perks), plus CUDA
-drivers. That's all. You can clone these images and add your own dependencies to
-better mimic your own production environment.
+With CML docker images launching your own self-hosted runner is very easy. These
+images have CML and DVC preinstalled (among other perks), plus CUDA drivers.
+That's all. You can clone these images and add your own dependencies to better
+mimic your own production environment.
 
 ```dvc
 $ docker run --name myrunner -d --gpus all \
@@ -99,7 +94,7 @@ $ docker run --name myrunner -d --gpus all \
     -e RUNNER_LABELS=cml,gpu \
     -e RUNNER_REPO=$my_repo_url \
     -e repo_token=$my_repo_token \
-    dvcorg/cml-py3
+    iterativeai/cml:0-dvc2-base1-gpu
 ```
 
 where:

--- a/content/blog/2020-11-25-november-20-community-gems.md
+++ b/content/blog/2020-11-25-november-20-community-gems.md
@@ -189,7 +189,7 @@ $ sudo docker run --name myrunner -d --gpus all \
   -e RUNNER_REPO=$CI_SERVER_UR \
   -e repo_token=$REGISTRATION_TOKEN \
   -e RUNNER_DRIVER=gitlab \
-  dvcorg/cml-py3
+  iterativeai/cml:0-dvc2-base1-gpu
 ```
 
 We did this so you'll avoid running up GPU hours and a big bill. If you're not

--- a/content/blog/2021-03-03-dvc-2-0-release.md
+++ b/content/blog/2021-03-03-dvc-2-0-release.md
@@ -79,8 +79,8 @@ library:
 $ pip install --upgrade dvc
 ```
 
-CML is pre-installed in the CML docker containers `dvcorg/cml` &
-`dvcorg/cml-py3` and also available as an NPM package:
+CML is pre-installed in the CML docker containers (e.g.
+`iterativeai/cml:0-dvc2-base1`) and also available as an NPM package:
 
 ```dvc
 $ npm i -g @dvcorg/cml


### PR DESCRIPTION
Closes #3373. Doesn't include references to the [current container image documentation](https://cml.dev/doc/self-hosted-runners#docker-images) because it's (potentially) going to be moved to a separate section as per https://github.com/iterative/cml.dev/issues/102.