### PR TITLE
Fix typo in data-registries.md

### DIFF
--- a/content/docs/use-cases/data-registries.md
+++ b/content/docs/use-cases/data-registries.md
@@ -168,7 +168,7 @@ Datasets evolve, and DVC is prepared to handle it. Just change the data in the
 registry, and apply the updates by running `dvc add` again:
 
 ```dvc
-$ cp 1000/more/images/* music/songs/
+$ cp 1000/more/songs/* music/songs/
 $ dvc add music/songs/
 ```
 


### PR DESCRIPTION
I assume in this example it should say `songs` instead of `images`.
