### PR TITLE
Update admonitions, making `title` optional

### DIFF
--- a/content/docs/index.md
+++ b/content/docs/index.md
@@ -5,6 +5,26 @@ Data Version Control, or DVC, is a data and ML
 advantage of the existing engineering toolset that you're already familiar with
 (Git, CI/CD, etc.).
 
+<admon>
+
+I don't need a title since I'm just a block of text.
+
+</admon>
+
+<admon title type="warn">
+
+- I need
+- a title
+- since I'm a list
+
+</admon>
+
+<admon title="Custom Title" type="tip">
+
+I need a custom title for some reason
+
+</admon>
+
 <cards>
 
   <card href="/doc/start" heading="Get Started">

--- a/content/docs/index.md
+++ b/content/docs/index.md
@@ -5,26 +5,6 @@ Data Version Control, or DVC, is a data and ML
 advantage of the existing engineering toolset that you're already familiar with
 (Git, CI/CD, etc.).
 
-<admon>
-
-I don't need a title since I'm just a block of text.
-
-</admon>
-
-<admon title type="warn">
-
-- I need
-- a title
-- since I'm a list
-
-</admon>
-
-<admon title="Custom Title" type="tip">
-
-I need a custom title for some reason
-
-</admon>
-
 <cards>
 
   <card href="/doc/start" heading="Get Started">

--- a/plugins/gatsby-theme-iterative-docs/src/components/Documentation/Markdown/Admonition/index.tsx
+++ b/plugins/gatsby-theme-iterative-docs/src/components/Documentation/Markdown/Admonition/index.tsx
@@ -32,16 +32,21 @@ const Admonition: React.FC<{
 }> = ({ title, type = defaultType, children, icon = type }) => {
   const setType = genericTitles[type] ? type : defaultType
   const iconContent = icons[icon] || ''
+  const needsTitle = typeof title === 'string'
 
   return (
     <div
       className={cn(styles.admonition, styles[setType])}
       style={{ '--icon': `"${iconContent}"` } as React.CSSProperties}
     >
-      <p className={cn(styles.title, !iconContent && styles.noIcon)}>
-        {title || genericTitles[setType]}
-      </p>
-      <div className={styles.content}>{children}</div>
+      {needsTitle && (
+        <p className={cn(styles.title, !iconContent && styles.noIcon)}>
+          {title || genericTitles[setType]}
+        </p>
+      )}
+      <div className={cn(styles.content, needsTitle && styles.noIcon)}>
+        {children}
+      </div>
     </div>
   )
 }

--- a/plugins/gatsby-theme-iterative-docs/src/components/Documentation/Markdown/Admonition/index.tsx
+++ b/plugins/gatsby-theme-iterative-docs/src/components/Documentation/Markdown/Admonition/index.tsx
@@ -11,11 +11,7 @@ const icons = {
   lady_beetle: '🐞',
   bug: '🐛'
 }
-const genericTitles = {
-  info: 'Info',
-  tip: 'Tip',
-  warn: 'Warning'
-}
+const typeOptions = ['info', 'tip', 'warn']
 const defaultType = 'info'
 
 const Admonition: React.FC<{
@@ -30,21 +26,20 @@ const Admonition: React.FC<{
     | 'lady_beetle'
     | 'bug'
 }> = ({ title, type = defaultType, children, icon = type }) => {
-  const setType = genericTitles[type] ? type : defaultType
+  const setType = typeOptions.includes(type) ? type : defaultType
   const iconContent = icons[icon] || ''
-  const needsTitle = typeof title === 'string'
 
   return (
     <div
       className={cn(styles.admonition, styles[setType])}
       style={{ '--icon': `"${iconContent}"` } as React.CSSProperties}
     >
-      {needsTitle && (
+      {title && (
         <p className={cn(styles.title, !iconContent && styles.noIcon)}>
-          {title || genericTitles[setType]}
+          {title}
         </p>
       )}
-      <div className={cn(styles.content, needsTitle && styles.noIcon)}>
+      <div className={cn(styles.content, title && styles.noIcon)}>
         {children}
       </div>
     </div>

--- a/plugins/gatsby-theme-iterative-docs/src/components/Documentation/Markdown/Admonition/styles.module.css
+++ b/plugins/gatsby-theme-iterative-docs/src/components/Documentation/Markdown/Admonition/styles.module.css
@@ -34,11 +34,16 @@
     margin-right: 0;
   }
 
-  .content {
-    padding: 10px 0 0;
+  .content > *:first-child::before {
+    content: var(--icon);
+    margin-right: 5px;
   }
 
-  .content *:last-child {
+  .content.noIcon > *:first-child::before {
+    display: none;
+  }
+
+  .content > *:last-child {
     margin-bottom: 0;
   }
 }


### PR DESCRIPTION
* makes title optional, taking it off by default

Code Example:

```
<admon>

I don't need a title since I'm just a block of text.

</admon>

<admon title="Custom Title" type="tip">

I need a custom title for some reason

</admon>
```

Result:
<img width="721" alt="image" src="https://user-images.githubusercontent.com/43496356/160861071-6661ae37-7e23-46c4-8fe3-54acab311e34.png">

Fixes #3381 