### PR TITLE
blog/cml: fix tutorials

### DIFF
--- a/content/blog/2020-07-07-cml-release.md
+++ b/content/blog/2020-07-07-cml-release.md
@@ -134,9 +134,9 @@ cml:
 
     # Visualize loss function diff
     - dvc plots diff --target loss.csv --show-vega master > vega.json
-    - vl2png vega.json | cml-publish --md >> report.md
+    - vl2png vega.json | cml publish --md >> report.md
     - dvc push data --run-cache
-    - cml-send-comment report.md
+    - cml send-comment report.md
 ```
 
 ![Hyperparameter change with a result image in GitHub Pull request report](/uploads/images/2020-07-07/cml-report-params.png)

--- a/content/blog/2020-07-16-devops-for-data-scientists.md
+++ b/content/blog/2020-07-16-devops-for-data-scientists.md
@@ -265,8 +265,7 @@ jobs:
         env:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
         run: |
-
-          # train.py outputs metrics.txt and confusion_matrix.png  
+          # train.py outputs metrics.txt and plot.png
           pip3 install -r requirements.txt          
           python train.py                    
 
@@ -274,7 +273,7 @@ jobs:
           cat metrics.txt >> report.md      
 
           # add our confusion matrix to report.md
-          cml-publish confusion_matrix.png --md >> report.md 
+          cml publish plot.png --md >> report.md
 
           # send the report to GitHub for display  
           cml-send-comment report.md

--- a/content/blog/2020-07-16-devops-for-data-scientists.md
+++ b/content/blog/2020-07-16-devops-for-data-scientists.md
@@ -276,7 +276,7 @@ jobs:
           cml publish plot.png --md >> report.md
 
           # send the report to GitHub for display  
-          cml-send-comment report.md
+          cml send-comment report.md
 ```
 
 You can see the entire

--- a/content/blog/2020-08-07-cml-self-hosted-runners-on-demand-with-gpus.md
+++ b/content/blog/2020-08-07-cml-self-hosted-runners-on-demand-with-gpus.md
@@ -125,30 +125,25 @@ train:
   tags:
     - cml
     - gpu
-
   script:
     - echo 'Hi from CML!' >> report.md
-    - cml-send-comment report.md
+    - cml send-comment report.md
 ```
 
 GitHub
 
 ```yaml
 name: train-my-model
-
 on: [push]
-
 jobs:
   train:
     runs-on: [self-hosted, cml, gpu]
-
     steps:
       - uses: actions/checkout@v2
-
       - name: cml_run
         run: |
           echo 'Hi from CML!' >> report.md
-          cml-send-comment report.md
+          cml send-comment report.md
 ```
 
 Congrats! At this point you have done all the steps to have your GPUs up and

--- a/content/blog/2020-08-27-august-20-community-gems.md
+++ b/content/blog/2020-08-27-august-20-community-gems.md
@@ -176,7 +176,7 @@ model metrics instead of code. We made a video about how to do this in CML!
 
 https://youtu.be/xPncjKH6SPk
 
-### [Q: In the function `cml-publish`, it looks like you're uploading published files to `https://asset.cml.dev`. Why don't you just save images in the Git repository?](https://discordapp.com/channels/485586884165107732/728693131557732403/745168931521822740)
+### [Q: In the function `cml publish`, it looks like you're uploading published files to `https://asset.cml.dev`. Why don't you just save images in the Git repository?](https://discordapp.com/channels/485586884165107732/728693131557732403/745168931521822740)
 
 If an image file is created as part of your workflow, it's ephemeral- it doesn't
 exist outside of your CI runner, and will disappear when your runner is shut
@@ -190,5 +190,5 @@ store to share the file with you.
 
 This covers a lot of cases, but if the files you wish to publish can't be shared
 with our service for security or privacy reasons, you can emulate the
-`cml-publish` function with your own storage. You would push your file to
+`cml publish` function with your own storage. You would push your file to
 storage and include a link to its address in your markdown report.

--- a/content/blog/2020-10-26-october-20-community-gems.md
+++ b/content/blog/2020-10-26-october-20-community-gems.md
@@ -96,9 +96,9 @@ for multiple projects and users respectively.
 
 ## CML Questions
 
-### [Q: What's the file size limit for publishing files with `cml-publish`?](https://discordapp.com/channels/485586884165107732/728693131557732403/751001285100306502)
+### [Q: What's the file size limit for publishing files with `cml publish`?](https://discordapp.com/channels/485586884165107732/728693131557732403/751001285100306502)
 
-`cml-publish` is a service for hosting files that are embedded in CML reports,
+`cml publish` is a service for hosting files that are embedded in CML reports,
 like images, audio files, and GIFS. By default, we have a limit of 2 MB per
 upload.
 
@@ -110,18 +110,18 @@ we recently implemented a CML flag (`--gitlab-uploads`) to streamline the
 process:
 
 ```dvc
-$ cml-publish movie.mov --md --gitlab-uploads > report.md
+$ cml publish movie.mov --md --gitlab-uploads > report.md
 ```
 
 Note that we don't currently have an analagous solution for GitHub, because
 GitHub artifacts expire after 90 days (whereas they're permanent in GitLab).
 
-### [Q: I'm getting a mysterious error message, `Failed guessing mime type of file`, when I try to use `cml-publish`. What's going on?](https://discordapp.com/channels/485586884165107732/728693131557732403/763840404675756042)
+### [Q: I'm getting a mysterious error message, `Failed guessing mime type of file`, when I try to use `cml publish`. What's going on?](https://discordapp.com/channels/485586884165107732/728693131557732403/763840404675756042)
 
-This error message usually means that the target of `cml-publish`- for example,
+This error message usually means that the target of `cml publish`- for example,
 
 ```dvc
-$ cml-publish <target file>
+$ cml publish <target file>
 ```
 
 is not found. Check for typos in the target filename and ensure that the file

--- a/content/blog/2020-12-30-december-20-community-gems.md
+++ b/content/blog/2020-12-30-december-20-community-gems.md
@@ -166,8 +166,8 @@ To install CML as an `npm` package on your runner, we recommend:
 npm i -g @dvcorg/cml
 ```
 
-Once this is done, you should be able to execute functions like `cml-publish`
-and `cml-send-comment` on your runner.
+Once this is done, you should be able to execute functions like `cml publish`
+and `cml send-comment` on your runner.
 
 For more tips about using CML without Docker,
 [see our docs](https://github.com/iterative/cml#install-cml-as-a-package).

--- a/content/blog/2021-02-22-cml-runner-prerelease.md
+++ b/content/blog/2021-02-22-cml-runner-prerelease.md
@@ -34,7 +34,7 @@ Here's what's in today's pre-release:
 
 After the initial CML release, we found ways to significantly simplify the
 process of allocating resources in CI/CD. We developed a brand new CML command
-`cml-runner` that hides much of the complexity of configuring and provisioning
+`cml runner` that hides much of the complexity of configuring and provisioning
 an instance, keeping your workflows free of `bash` scripting clutter (until the
 official release, docs are
 [in development here](https://github.com/iterative/cml/blob/c2b96c461011f01ab2476e1542fb89d7229d150d/README.md)).
@@ -62,7 +62,7 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         run: |
-          cml-runner \
+          cml runner \
           --cloud aws \
           --cloud-region us-west \
           --cloud-type=t2.micro \
@@ -84,7 +84,7 @@ jobs:
 If you use CML functions in the `train-model` step, you can go even further and
 get a closed loop—sending model training results from the EC2 instance to your
 pull request or merge request! For example, if we expand the `train-model` step
-to incorporate functions like `cml-publish` and `cml-send-comment`:
+to incorporate functions like `cml publish` and `cml send-comment`:
 
 ```yaml
 train-model:
@@ -118,7 +118,7 @@ All the code to replicate this example is up on a
 
 ### Our favorite details
 
-The new `cml-runner` function lets you turn on instances, including GPU,
+The new `cml runner` function lets you turn on instances, including GPU,
 high-memory and spot instances, and kick off a new workflow using the hardware
 and environment of your choice—and of course, it'll turn _off_ those instances
 after a configurable timeout! In the first CML release, this took
@@ -132,13 +132,13 @@ instance. In the above example, we use our
 choose, we highly recommend containerizing your environment for ultimate
 reproducibility and security with CML.
 
-You can also use the new `cml-runner` function to set up a
+You can also use the new `cml runner` function to set up a
 [local self-hosted runner](https://docs.github.com/en/actions/hosting-your-own-runners/about-self-hosted-runners).
 On your local machine or on-premise GPU cluster, you'll install CML as a package
 and then run:
 
 ```bash
-$ cml-runner \
+$ cml runner \
     --repo $your_project_repository_url \
     --token=$personal_access_token \
     --labels tf \
@@ -155,7 +155,7 @@ Action helps you setup CML, giving you one more way to mix and match the CML
 suite of functions with your preferred environment.
 
 The new Action is designed to be a straightforward, all-in-one install that
-gives you immediate use of functions like `cml-publish` and `cml-runner`. You'll
+gives you immediate use of functions like `cml publish` and `cml runner`. You'll
 add this step to your workflow:
 
 ```yaml

--- a/content/blog/2021-02-22-cml-runner-prerelease.md
+++ b/content/blog/2021-02-22-cml-runner-prerelease.md
@@ -105,8 +105,8 @@ train-model:
 
         echo "## Report from your EC2 Instance" > report.md
         cat metrics.txt >> report.md
-        cml-publish "confusion_matrix.png" --md >> report.md
-        cml-send-comment report.md
+        cml publish "plot.png" --md >> report.md
+        cml send-comment report.md
 ```
 
 You'll get a pull request that looks something like this:

--- a/content/blog/2021-02-26-february-21-community-gems.md
+++ b/content/blog/2021-02-26-february-21-community-gems.md
@@ -107,16 +107,16 @@ is the address of that directory.
 ### [Q: I heard there's a new CML feature using Terraform to provision runners. When is this coming out?](https://discord.com/channels/485586884165107732/728693131557732403/812069229473562624)
 
 You're in luck, because we just shared this feature as part of the CML 0.3.0
-pre-release! The pre-release introduced a new function, `cml-runner`, which
+pre-release! The pre-release introduced a new function, `cml runner`, which
 upgraded our
 [previous method for launching instances in the cloud from a CI workflow using Docker Machine](https://github.com/iterative/cml_cloud_case/blob/b76aba13791ce18c5715f464f58877ffa10d4cfa/.github/workflows/cml.yaml).
-In the new `cml-runner` function built on Terraform, you can deploy instances in
+In the new `cml runner` function built on Terraform, you can deploy instances in
 AWS and Azure with a single command (it used to take about 30 lines of code!).
 For example, to launch a `t2.micro` instance on AWS from your GitHub Actions or
 GitLab CI workflow, you'll run:
 
 ```bash
-cml-runner \
+cml runner \
 	--cloud aws \
 	--cloud-region us-west \
 	--cloud-type=t2.micro \
@@ -132,7 +132,7 @@ to get started.
 
 By default, files that are created in a GitHub Actions or GitLab CI workflow
 only exist on the runner- as soon as the runner turns off, they vanish.
-Functions like `cml-publish` and `cml-send-comment` create persistent links to
+Functions like `cml publish` and `cml send-comment` create persistent links to
 data visualizations, tables, and other outputs of your workflow so you can view
 them long after your run ends. However, by design, CML doesn't commit files to
 your repository (not all users want this!)

--- a/content/blog/2021-03-03-dvc-2-0-release.md
+++ b/content/blog/2021-03-03-dvc-2-0-release.md
@@ -616,7 +616,7 @@ stages:
 ## New method to provision cloud compute in new CML release
 
 We are releasing new CML release 0.3 together with DVC 2.0. We developed a brand
-new CML command `cml-runner` that hides much of the complexity of configuring
+new CML command `cml runner` that hides much of the complexity of configuring
 and provisioning an instance, keeping your workflows free of bash scripting
 clutter.
 
@@ -645,7 +645,7 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         run: |
-          cml-runner \
+          cml runner \
           --cloud aws \
           --cloud-region us-west \
           --cloud-type=t2.micro \
@@ -683,7 +683,7 @@ Action helps you setup CML, giving you one more way to mix and match the CML
 suite of functions with your preferred environment.
 
 The new Action is designed to be a straightforward, all-in-one install that
-gives you immediate use of functions like `cml-publish` and `cml-runner`. You'll
+gives you immediate use of functions like `cml publish` and `cml runner`. You'll
 add this step to your workflow:
 
 ```yaml

--- a/content/blog/2021-07-27-july-21-dvc-community-gems.md
+++ b/content/blog/2021-07-27-july-21-dvc-community-gems.md
@@ -18,7 +18,7 @@ tags:
   - DVC
 ---
 
-### [Q: I'm trying to use the `--reuse` option of `cml-runner`. If I launch 2 CML experiments in parallel, will CML use the same runner or spin up another one if the existing one is in use?](https://discord.com/channels/485586884165107732/728693131557732403/850340190434492445)
+### [Q: I'm trying to use the `--reuse` option of `cml runner`. If I launch 2 CML experiments in parallel, will CML use the same runner or spin up another one if the existing one is in use?](https://discord.com/channels/485586884165107732/728693131557732403/850340190434492445)
 
 If you don't reuse the runner and you have set up a deploy job, that deploy job
 will launch two cloud runners. With `--reuse` it will check if the runner with
@@ -43,12 +43,12 @@ A great question from @Corentin in the Discord community!
 
 ### [Q: How can I run self-hosted runners on an on-premise machine indefinitely?](https://discord.com/channels/485586884165107732/728693131557732403/851923384613994496)
 
-You can achieve this by passing the `--idle-timeout=0` option to `cml-runner` in
+You can achieve this by passing the `--idle-timeout=0` option to `cml runner` in
 order to disable the timeout.
 
 Thanks @achbogga!
 
-### [Q: How can I change the default VPC to a different one with `cml-cloudrunner` for AWS?](https://discord.com/channels/485586884165107732/728693131557732403/857940793616498738)
+### [Q: How can I change the default VPC to a different one with `cml-runner` for AWS?](https://discord.com/channels/485586884165107732/728693131557732403/857940793616498738)
 
 Great gem from @krish98409!
 

--- a/content/blog/2021-08-31-august-21-community-gems.md
+++ b/content/blog/2021-08-31-august-21-community-gems.md
@@ -112,7 +112,7 @@ The main difference now is that we restart workflows with unfinished jobs.
 
 Thanks for such a good question @andee96!
 
-### [Q: Can I change an endpoint that is being? Or does `cml-publish` always save the artifacts on this endpoint?](https://discord.com/channels/485586884165107732/728693131557732403/864444303169421322)
+### [Q: Can I change an endpoint that is being? Or does `cml publish` always save the artifacts on this endpoint?](https://discord.com/channels/485586884165107732/728693131557732403/864444303169421322)
 
 Good question @Nwp8nice!
 


### PR DESCRIPTION
- `p0`: fix tutorials (part of iterative/cml.dev#211)
- `p2`: update hyphenation/spacing