### PR TITLE
cleanup remote block headings

### DIFF
--- a/content/docs/command-reference/get-url.md
+++ b/content/docs/command-reference/get-url.md
@@ -81,7 +81,7 @@ $ wget https://example.com/path/to/data.csv
 
 <details>
 
-### Click for Amazon S3 example
+### Amazon S3
 
 This command will copy an S3 object into the current working directory with the
 same file name:
@@ -108,7 +108,7 @@ configuration, you can use the parameters described in `dvc remote modify`.
 
 <details>
 
-### Click for Google Cloud Storage example
+### Google Cloud Storage
 
 ```dvc
 $ dvc get-url gs://bucket/path file
@@ -120,7 +120,7 @@ The above command downloads the `/path` file (or directory) into `./file`.
 
 <details>
 
-### Click for SSH example
+### SSH
 
 ```dvc
 $ dvc get-url ssh://user@example.com/path/to/data
@@ -133,7 +133,7 @@ directory).
 
 <details>
 
-### Click for HDFS example
+### HDFS
 
 ```dvc
 $ dvc get-url hdfs://user@example.com/path/to/file
@@ -143,7 +143,7 @@ $ dvc get-url hdfs://user@example.com/path/to/file
 
 <details>
 
-### Click for HTTP example
+### HTTP
 
 > Both HTTP and HTTPS protocols are supported.
 
@@ -155,7 +155,7 @@ $ dvc get-url https://example.com/path/to/file
 
 <details>
 
-### Click for WebHDFS example
+### WebHDFS
 
 ```dvc
 $ dvc get-url webhdfs://user@example.com/path/to/file
@@ -165,7 +165,7 @@ $ dvc get-url webhdfs://user@example.com/path/to/file
 
 <details>
 
-### Click and expand for a local example
+### local
 
 ```dvc
 $ dvc get-url /local/path/to/data

--- a/content/docs/command-reference/remote/add.md
+++ b/content/docs/command-reference/remote/add.md
@@ -90,7 +90,7 @@ The following are the types of remote storage (protocols) supported:
 
 <details>
 
-### Click for Amazon S3
+### Amazon S3
 
 > 💡 Before adding an S3 remote, be sure to
 > [Create a Bucket](https://docs.aws.amazon.com/AmazonS3/latest/gsg/CreatingABucket.html).
@@ -115,7 +115,7 @@ methods that are performed by DVC (`list_objects_v2` or `list_objects`,
 
 <details>
 
-### Click for S3-compatible storage
+### S3-compatible storage
 
 For object storage that supports an S3-compatible API (e.g.
 [Minio](https://min.io/),
@@ -143,7 +143,7 @@ they're effective depends on each storage platform.
 
 <details>
 
-### Click for Microsoft Azure Blob Storage
+### Microsoft Azure Blob Storage
 
 ```dvc
 $ dvc remote add -d myremote azure://mycontainer/path
@@ -165,7 +165,7 @@ To use a custom authentication method, use the parameters described in
 
 <details>
 
-### Click for Google Drive
+### Google Drive
 
 To start using a GDrive remote, first add it with a
 [valid URL format](/doc/user-guide/setup-google-drive-remote#url-format). Then
@@ -199,7 +199,7 @@ modified.
 
 <details>
 
-### Click for Google Cloud Storage
+### Google Cloud Storage
 
 > 💡 Before adding a GC Storage remote, be sure to
 > [Create a storage bucket](https://cloud.google.com/storage/docs/creating-buckets).
@@ -221,7 +221,7 @@ parameters, use the parameters described in `dvc remote modify`.
 
 <details>
 
-### Click for Aliyun OSS
+### Aliyun OSS
 
 First you need to set up OSS storage on Aliyun Cloud. Then, use an S3 style URL
 for OSS storage, and configure the
@@ -263,7 +263,7 @@ $ export OSS_ACCESS_KEY_SECRET='mysecret'
 
 <details>
 
-### Click for SSH
+### SSH
 
 ```dvc
 $ dvc remote add -d myremote ssh://user@example.com/path
@@ -281,7 +281,7 @@ Please check that you are able to connect both ways with tools like `ssh` and
 
 <details>
 
-### Click for HDFS
+### HDFS
 
 ⚠️ Using HDFS with a Hadoop cluster might require additional setup. Our
 assumption is that the client is set up to use it. Specifically, [`libhdfs`]
@@ -303,7 +303,7 @@ $ dvc remote add -d myremote hdfs://user@example.com/path
 
 <details>
 
-### Click for WebHDFS
+### WebHDFS
 
 ⚠️ Using WebHDFS requires to enable REST API access in the cluster: set the
 config property `dfs.webhdfs.enabled` to `true` in `hdfs-site.xml`.
@@ -331,7 +331,7 @@ active kerberos session.
 
 <details>
 
-### Click for HTTP
+### HTTP
 
 ```dvc
 $ dvc remote add -d myremote https://example.com/path
@@ -343,7 +343,7 @@ $ dvc remote add -d myremote https://example.com/path
 
 <details>
 
-### Click for WebDAV
+### WebDAV
 
 ```dvc
 $ dvc remote add -d myremote \
@@ -364,7 +364,7 @@ $ dvc remote add -d myremote \
 
 <details>
 
-### Click for local remote
+### local remote
 
 A "local remote" is a directory in the machine's file system. Not to be confused
 with the `--local` option of `dvc remote` (and other config) commands!

--- a/content/docs/command-reference/remote/modify.md
+++ b/content/docs/command-reference/remote/modify.md
@@ -105,7 +105,7 @@ options:
 
 <details>
 
-### Click for Amazon S3
+### Amazon S3
 
 - `url` - remote location, in the `s3://<bucket>/<key>` format:
 
@@ -333,7 +333,7 @@ For more on the supported env vars, please see the
 
 <details>
 
-### Click for S3-compatible storage
+### S3-compatible storage
 
 - `endpointurl` - URL to connect to the S3-compatible storage server or service
   (e.g. [Minio](https://min.io/),
@@ -352,7 +352,7 @@ storage. Whether they're effective depends on each storage platform.
 
 <details>
 
-### Click for Microsoft Azure Blob Storage
+### Microsoft Azure Blob Storage
 
 > If any values given to the parameters below contain sensitive user info, add
 > them with the `--local` option, so they're written to a Git-ignored config
@@ -535,7 +535,7 @@ can propagate from an Azure configuration file (typically managed with
 
 <details>
 
-### Click for Google Drive
+### Google Drive
 
 > If any values given to the parameters below contain sensitive user info, add
 > them with the `--local` option, so they're written to a Git-ignored config
@@ -638,7 +638,7 @@ more information.
 
 <details>
 
-### Click for Google Cloud Storage
+### Google Cloud Storage
 
 > If any values given to the parameters below contain sensitive user info, add
 > them with the `--local` option, so they're written to a Git-ignored config
@@ -685,7 +685,7 @@ $ export GOOGLE_APPLICATION_CREDENTIALS='.../project-XXX.json'
 
 <details>
 
-### Click for Aliyun OSS
+### Aliyun OSS
 
 > If any values given to the parameters below contain sensitive user info, add
 > them with the `--local` option, so they're written to a Git-ignored config
@@ -731,7 +731,7 @@ $ export OSS_ENDPOINT='endpoint'
 
 <details>
 
-### Click for SSH
+### SSH
 
 > If any values given to the parameters below contain sensitive user info, add
 > them with the `--local` option, so they're written to a Git-ignored config
@@ -824,7 +824,7 @@ $ export OSS_ENDPOINT='endpoint'
 
 <details>
 
-### Click for HDFS
+### HDFS
 
 💡 Using a HDFS cluster as remote storage is also supported via the WebHDFS API.
 Read more about by expanding the WebHDFS section in
@@ -858,7 +858,7 @@ Read more about by expanding the WebHDFS section in
 
 <details>
 
-### Click for WebHDFS
+### WebHDFS
 
 💡 WebHDFS serves as an alternative for using the same remote storage supported
 by HDFS. Read more about by expanding the WebHDFS section in
@@ -947,7 +947,7 @@ by HDFS. Read more about by expanding the WebHDFS section in
 
 <details>
 
-### Click for HTTP
+### HTTP
 
 > If any values given to the parameters below contain sensitive user info, add
 > them with the `--local` option, so they're written to a Git-ignored config
@@ -1039,7 +1039,7 @@ by HDFS. Read more about by expanding the WebHDFS section in
 
 <details>
 
-### Click for WebDAV
+### WebDAV
 
 > If any values given to the parameters below contain sensitive user info, add
 > them with the `--local` option, so they're written to a Git-ignored config

--- a/content/docs/user-guide/contributing/core.md
+++ b/content/docs/user-guide/contributing/core.md
@@ -175,7 +175,7 @@ manipulations below.
 
 <details>
 
-### Click for Amazon S3 instructions
+### Amazon S3
 
 Install
 [aws cli](https://docs.aws.amazon.com/en_us/cli/latest/userguide/cli-chap-install.html)
@@ -194,7 +194,7 @@ $ export DVC_TEST_AWS_REPO_BUCKET="...TEST-S3-BUCKET..."
 
 <details>
 
-### Click for Microsoft Azure Blob Storage instructions
+### Microsoft Azure Blob Storage
 
 Install [Node.js](https://nodejs.org/en/download/) and then install and run
 Azurite:
@@ -216,7 +216,7 @@ $ export AZURE_STORAGE_CONNECTION_STRING="DefaultEndpointsProtocol=http;AccountN
 
 <details>
 
-### Click for Google Drive instructions
+### Google Drive
 
 > 💡 Please remember that Google Drive access tokens are personal credentials
 > and should not be shared with anyone, otherwise risking unauthorized usage of
@@ -237,7 +237,7 @@ $ export GDRIVE_USER_CREDENTIALS_DATA='mysecret'
 
 <details>
 
-### Click for Google Cloud Storage instructions
+### Google Cloud Storage
 
 Go through the [quick start](https://cloud.google.com/sdk/docs/quickstarts) for
 your OS. After that, you should have the `gcloud` command line tool available,
@@ -277,7 +277,7 @@ may use different names.
 
 <details>
 
-### Click for HDFS instructions
+### HDFS
 
 Tests currently only work on Linux. First you need to set up passwordless SSH
 auth to localhost:

--- a/content/docs/user-guide/external-dependencies.md
+++ b/content/docs/user-guide/external-dependencies.md
@@ -42,7 +42,7 @@ downloads a file from an external location, on all the supported location types.
 
 <details>
 
-### Click for Amazon S3
+### Amazon S3
 
 ```dvc
 $ dvc run -n download_file \
@@ -55,7 +55,7 @@ $ dvc run -n download_file \
 
 <details>
 
-### Click for Microsoft Azure Blob Storage
+### Microsoft Azure Blob Storage
 
 ```dvc
 $ dvc run -n download_file \
@@ -72,7 +72,7 @@ $ dvc run -n download_file \
 
 <details>
 
-### Click for Google Cloud Storage
+### Google Cloud Storage
 
 ```dvc
 $ dvc run -n download_file \
@@ -85,7 +85,7 @@ $ dvc run -n download_file \
 
 <details>
 
-### Click for SSH
+### SSH
 
 ```dvc
 $ dvc run -n download_file \
@@ -104,7 +104,7 @@ Please check that you are able to connect both ways with tools like `ssh` and
 
 <details>
 
-### Click for HDFS
+### HDFS
 
 ```dvc
 $ dvc run -n download_file \
@@ -118,7 +118,7 @@ $ dvc run -n download_file \
 
 <details>
 
-### Click for HTTP
+### HTTP
 
 > Including HTTPs
 
@@ -133,7 +133,7 @@ $ dvc run -n download_file \
 
 <details>
 
-### Click for local file system paths
+### local file system paths
 
 ```dvc
 $ dvc run -n download_file \

--- a/content/docs/user-guide/managing-external-data.md
+++ b/content/docs/user-guide/managing-external-data.md
@@ -94,7 +94,7 @@ types:
 
 <details>
 
-### Click for Amazon S3
+### Amazon S3
 
 ```dvc
 $ dvc remote add s3cache s3://mybucket/cache
@@ -112,7 +112,7 @@ $ dvc run -d data.txt \
 
 <details>
 
-### Click for SSH
+### SSH
 
 ```dvc
 $ dvc remote add sshcache ssh://user@example.com/cache
@@ -136,7 +136,7 @@ Please check that you are able to connect both ways with tools like `ssh` and
 
 <details>
 
-### Click for HDFS
+### HDFS
 
 ```dvc
 $ dvc remote add hdfscache hdfs://user@example.com/cache
@@ -159,7 +159,7 @@ it. So systems like Hadoop, Hive, and HBase are supported!
 
 <details>
 
-### Click for WebHDFS
+### WebHDFS
 
 ```dvc
 $ dvc remote add webhdfscache webhdfs://user@example.com/cache
@@ -178,7 +178,7 @@ $ dvc run -d data.txt \
 
 <details>
 
-### Click for local file system paths
+### local file system paths
 
 The default <abbr>cache</abbr> is in `.dvc/cache`, so there is no need to set a
 custom cache location for local paths outside of your project.


### PR DESCRIPTION
Details blocks are `#id` linkable now (#3329) so should have [URL-friendly names](https://github.com/iterative/dvc.org/pull/3299#issuecomment-1048325250)