### PR TITLE
Fix for edge cases for `id`

### DIFF
--- a/plugins/gatsby-theme-iterative-docs/src/components/Documentation/Markdown/index.tsx
+++ b/plugins/gatsby-theme-iterative-docs/src/components/Documentation/Markdown/index.tsx
@@ -50,11 +50,18 @@ const Details: React.FC<{ slugger: GithubSlugger }> = ({
     firstChild.props.children.length - 1
   ) as ReactNode[]
 
-  let slug = slugger.slug(triggerChildren.toString())
-  if (slug[0] === '️') {
-    slug = slug.slice(1)
-  }
-  const id = slug.startsWith('-') ? slug.slice(1) : slug
+  const title = (triggerChildren as any[]).reduce((acc, cur) => {
+    return (acc +=
+      typeof cur === 'string'
+        ? cur
+        : typeof cur === 'object'
+        ? cur?.props?.children?.toString()
+        : '')
+  }, '')
+
+  let slug = slugger.slug(title)
+  slug = slug.startsWith('-') ? slug.slice(1) : slug
+  const id = slug.endsWith('-') ? slug.slice(0, -1) : slug
 
   useEffect(() => {
     if (location.hash === `#${id}`) {


### PR DESCRIPTION
Fix for titles that use the markdown.
Links with issue: 
- Trialing dash(`-`)
  - https://dvc.org/doc/command-reference/remote#what-is-a-local-remote-
- `object-object`
  - https://dvc.org/doc/user-guide/how-to/stop-tracking-data#expand-to-add-a-sample-data-object-object-file
  - https://dvc.org/doc/user-guide/external-dependencies#expand-to-see-resulting-object-object-file
  - https://dvc.org/doc/user-guide/external-dependencies#expand-to-see-resulting-object-object-file-1
