### PR TITLE
Added hidden `skip to content` for keyboard navigation

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "@octokit/graphql": "^4.8.0",
     "@reach/portal": "^0.16.2",
     "@reach/router": "^1.3.4",
+    "@reach/skip-nav": "^0.16.0",
     "@reach/tooltip": "^0.16.2",
     "algoliasearch": "^4.12.0",
     "classnames": "^2.2.6",

--- a/src/components/DocumentationLayout/index.tsx
+++ b/src/components/DocumentationLayout/index.tsx
@@ -1,10 +1,8 @@
 import React from 'react'
-import { SkipNavContent, SkipNavLink } from '@reach/skip-nav'
-import '@reach/skip-nav/styles.css'
+import { SkipNavContent } from '@reach/skip-nav'
 
 import MainLayout, { LayoutComponent, LayoutModifiers } from '../MainLayout'
 import ThemeDocumentationLayout from 'gatsby-theme-iterative-docs/src/components/Documentation/Layout'
-import * as styles from './styles.module.css'
 
 const Layout: LayoutComponent = ({ children, ...restProps }) => {
   const {
@@ -13,7 +11,6 @@ const Layout: LayoutComponent = ({ children, ...restProps }) => {
 
   return (
     <>
-      <SkipNavLink contentId="main-content" className={styles.skipLink} />
       <MainLayout
         {...restProps}
         modifiers={[LayoutModifiers.Wide, LayoutModifiers.Collapsed]}

--- a/src/components/DocumentationLayout/index.tsx
+++ b/src/components/DocumentationLayout/index.tsx
@@ -1,7 +1,10 @@
 import React from 'react'
+import { SkipNavContent, SkipNavLink } from '@reach/skip-nav'
+import '@reach/skip-nav/styles.css'
 
 import MainLayout, { LayoutComponent, LayoutModifiers } from '../MainLayout'
 import ThemeDocumentationLayout from 'gatsby-theme-iterative-docs/src/components/Documentation/Layout'
+import * as styles from './styles.module.css'
 
 const Layout: LayoutComponent = ({ children, ...restProps }) => {
   const {
@@ -9,14 +12,18 @@ const Layout: LayoutComponent = ({ children, ...restProps }) => {
   } = restProps
 
   return (
-    <MainLayout
-      {...restProps}
-      modifiers={[LayoutModifiers.Wide, LayoutModifiers.Collapsed]}
-    >
-      <ThemeDocumentationLayout currentPath={pathname}>
-        {children}
-      </ThemeDocumentationLayout>
-    </MainLayout>
+    <>
+      <SkipNavLink contentId="main-content" className={styles.skipLink} />
+      <MainLayout
+        {...restProps}
+        modifiers={[LayoutModifiers.Wide, LayoutModifiers.Collapsed]}
+      >
+        <ThemeDocumentationLayout currentPath={pathname}>
+          <SkipNavContent id="main-content" />
+          {children}
+        </ThemeDocumentationLayout>
+      </MainLayout>
+    </>
   )
 }
 

--- a/src/components/DocumentationLayout/styles.module.css
+++ b/src/components/DocumentationLayout/styles.module.css
@@ -1,7 +1,0 @@
-.skipLink {
-  &:focus {
-    z-index: 999;
-    font-size: 1.125rem;
-    top: 8px;
-  }
-}

--- a/src/components/DocumentationLayout/styles.module.css
+++ b/src/components/DocumentationLayout/styles.module.css
@@ -1,0 +1,7 @@
+.skipLink {
+  &:focus {
+    z-index: 999;
+    font-size: 1.125rem;
+    top: 8px;
+  }
+}

--- a/src/components/LayoutHeader/alert.tsx
+++ b/src/components/LayoutHeader/alert.tsx
@@ -12,8 +12,13 @@ const LayoutAlert: React.FC<{ collapsed: boolean }> | false = ({
     <span role="img" aria-label="rocket">
       🚀
     </span>{' '}
-    <Link href="https://studio.iterative.ai">DVC Studio</Link>, the online UI
-    for DVC, is live!{' '}
+    <Link
+      href="https://studio.iterative.ai"
+      tabIndex={collapsed ? -1 : undefined}
+    >
+      DVC Studio
+    </Link>
+    , the online UI for DVC, is live!{' '}
   </div>
 )
 

--- a/src/components/MainLayout/index.tsx
+++ b/src/components/MainLayout/index.tsx
@@ -1,4 +1,6 @@
 import React, { useEffect } from 'react'
+import { SkipNavContent, SkipNavLink } from '@reach/skip-nav'
+import '@reach/skip-nav/styles.css'
 
 import { IPageProps } from '../Page'
 import LayoutHeader from '../LayoutHeader'
@@ -28,7 +30,8 @@ export type LayoutComponent = React.FC<
 const MainLayout: LayoutComponent = ({
   className,
   children,
-  modifiers = []
+  modifiers = [],
+  pageContext
 }) => {
   useEffect(() => {
     if (className) {
@@ -51,11 +54,13 @@ const MainLayout: LayoutComponent = ({
 
   return (
     <>
+      <SkipNavLink contentId="main-content" className={styles.skipLink} />
       <LayoutHeader modifiers={modifiers} />
       <div
         id="layoutContent"
         //  className={styles.pageContent}
       >
+        {!pageContext.isDocs && <SkipNavContent id="main-content" />}
         {children}
       </div>
       <LayoutFooter />

--- a/src/components/MainLayout/index.tsx
+++ b/src/components/MainLayout/index.tsx
@@ -8,6 +8,8 @@ import LayoutFooter from '../LayoutFooter'
 import { handleFirstTab } from 'gatsby-theme-iterative-docs/src/utils/front/accessibility'
 
 import * as styles from './styles.module.css'
+import { logEvent } from 'gatsby-theme-iterative-docs/src/utils/front/plausible'
+import { useLocation } from '@reach/router'
 
 export enum LayoutModifiers {
   Wide,
@@ -33,6 +35,7 @@ const MainLayout: LayoutComponent = ({
   modifiers = [],
   pageContext
 }) => {
+  const location = useLocation()
   useEffect(() => {
     if (className) {
       document.body.classList.add(className)
@@ -54,7 +57,13 @@ const MainLayout: LayoutComponent = ({
 
   return (
     <>
-      <SkipNavLink contentId="main-content" className={styles.skipLink} />
+      <SkipNavLink
+        contentId="main-content"
+        className={styles.skipLink}
+        onClick={() => {
+          logEvent('Skip To Content', { path: location.pathname })
+        }}
+      />
       <LayoutHeader modifiers={modifiers} />
       <div
         id="layoutContent"

--- a/src/components/MainLayout/styles.module.css
+++ b/src/components/MainLayout/styles.module.css
@@ -2,3 +2,11 @@
   font-weight: 400 !important;
   background-color: #fff;
 }
+
+.skipLink {
+  &:focus {
+    z-index: 999;
+    font-size: 1.125rem;
+    top: 8px;
+  }
+}

--- a/src/components/MainLayout/styles.module.css
+++ b/src/components/MainLayout/styles.module.css
@@ -4,9 +4,15 @@
 }
 
 .skipLink {
+  color: var(--color-orange);
+  font-size: 1.25rem;
+  text-decoration: none;
+  border-radius: 4px;
+  box-shadow: rgb(46 41 51 / 8%) 0 2px 4px, rgb(71 63 79 / 16%) 0 4px 8px;
+
   &:focus {
-    z-index: 999;
-    font-size: 1.125rem;
+    z-index: 12;
     top: 8px;
+    left: 1rem;
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2995,6 +2995,14 @@
     prop-types "^15.6.1"
     react-lifecycles-compat "^3.0.4"
 
+"@reach/skip-nav@^0.16.0":
+  version "0.16.0"
+  resolved "https://registry.yarnpkg.com/@reach/skip-nav/-/skip-nav-0.16.0.tgz#dec34f3a40a1e804e05647646aacab0ffd73b24d"
+  integrity sha512-SY4PdNx+hQHbeOr/+qLc+QXdRt9NTVlt0r737bOqY1WURGBIEN9sGgsmIsHluP1/bQuAe0JKdOJ/tXiwQ3Z3ug==
+  dependencies:
+    "@reach/utils" "0.16.0"
+    tslib "^2.3.0"
+
 "@reach/tooltip@^0.16.2":
   version "0.16.2"
   resolved "https://registry.npmjs.org/@reach/tooltip/-/tooltip-0.16.2.tgz"


### PR DESCRIPTION
Added hidden `skip to content`, that can be used by keyboard users for directly navigating to main content. 

Since the `docs` have side navigation as well, I thought it would be better to skip that as well. 

There seems some interference with how we currently handle the scrolling hash link.

Related to #3154 