### PR TITLE
guide: venv `pip` for local dev env setup

### DIFF
--- a/content/docs/user-guide/contributing/core.md
+++ b/content/docs/user-guide/contributing/core.md
@@ -56,13 +56,13 @@ do that, we **strongly** recommend creating a
 $ cd dvc
 $ python3 -m venv .env
 $ source .env/bin/activate
-$ pip install -e ".[all,tests]"
+$ python3 -m pip install -e ".[all,tests]"
 ```
 
 Install coding style pre-commit hooks with:
 
 ```dvc
-$ pip install pre-commit
+$ python3 -m pip install pre-commit
 $ pre-commit install
 ```
 


### PR DESCRIPTION
Shouldn't we use `python3 -m pip` here?