### PR TITLE
Use `cml runner` instead of `cml` alone

### DIFF
--- a/content/blog/2020-08-07-cml-self-hosted-runners-on-demand-with-gpus.md
+++ b/content/blog/2020-08-07-cml-self-hosted-runners-on-demand-with-gpus.md
@@ -94,7 +94,7 @@ $ docker run --name myrunner -d --gpus all \
     -e RUNNER_LABELS=cml,gpu \
     -e RUNNER_REPO=$my_repo_url \
     -e repo_token=$my_repo_token \
-    iterativeai/cml:0-dvc2-base1-gpu
+    iterativeai/cml:0-dvc2-base1-gpu runner
 ```
 
 where:

--- a/content/blog/2020-11-25-november-20-community-gems.md
+++ b/content/blog/2020-11-25-november-20-community-gems.md
@@ -189,7 +189,7 @@ $ sudo docker run --name myrunner -d --gpus all \
   -e RUNNER_REPO=$CI_SERVER_UR \
   -e repo_token=$REGISTRATION_TOKEN \
   -e RUNNER_DRIVER=gitlab \
-  iterativeai/cml:0-dvc2-base1-gpu
+  iterativeai/cml:0-dvc2-base1-gpu runner
 ```
 
 We did this so you'll avoid running up GPU hours and a big bill. If you're not


### PR DESCRIPTION
Related to #3375; fixes https://discuss.dvc.org/t/cml-self-hosted-runners-on-demand-with-gpus/462