### PR TITLE
DVCLive: Deprecate `live` section of `dvc.yaml`.

### DIFF
--- a/content/docs/command-reference/exp/init.md
+++ b/content/docs/command-reference/exp/init.md
@@ -11,7 +11,7 @@ Quickly setup any project to use [DVC Experiments].
 usage: dvc exp init [-h] [-q | -v] [--run] [--interactive] [-f]
                     [--explicit] [--name NAME] [--code CODE]
                     [--data DATA] [--models MODELS] [--params PARAMS]
-                    [--metrics METRICS] [--plots PLOTS]
+                    [--metrics METRICS] [--plots PLOTS] [--live LIVE]
                     [--type {default,dl}]
                     [command]
 ```
@@ -127,6 +127,10 @@ $ dvc exp init './another_script.sh $MYENVVAR'
 - `--plots` - set the path to the file or directory where the plots produced by
   your experiment can be found (if any). Overrides other configuration and
   default value (`plots/`).
+
+- `--live` - use the given path to set up `metrics` and `plots` as in
+  [DVCLive with DVC](/doc/dvclive/dvclive-with-dvc). Overrides other
+  configuration and default value (`dvclive/`).
 
 - `--explicit` - do not assume default locations of project dependencies and
   outputs. You'll have to provide specific locations via other options or

--- a/content/docs/command-reference/exp/init.md
+++ b/content/docs/command-reference/exp/init.md
@@ -128,9 +128,9 @@ $ dvc exp init './another_script.sh $MYENVVAR'
   your experiment can be found (if any). Overrides other configuration and
   default value (`plots/`).
 
-- `--live` - use the given path to set up `metrics` and `plots` as in
-  [DVCLive with DVC](/doc/dvclive/dvclive-with-dvc). Overrides other
-  configuration and default value (`dvclive/`).
+- `--live` - set the path to the directory where the metrics and plots
+  [produced by DVCLive](https://dvc.org/doc/dvclive/dvclive-with-dvc#outputs)
+  will be found. Overrides other configuration and default value (`dvclive/`).
 
 - `--explicit` - do not assume default locations of project dependencies and
   outputs. You'll have to provide specific locations via other options or

--- a/content/docs/command-reference/exp/init.md
+++ b/content/docs/command-reference/exp/init.md
@@ -130,7 +130,7 @@ $ dvc exp init './another_script.sh $MYENVVAR'
 
 - `--live` - set the path to the directory where the metrics and plots
   [produced by DVCLive](https://dvc.org/doc/dvclive/dvclive-with-dvc#outputs)
-  will be found. Overrides other configuration and default value (`dvclive/`).
+  will be found.
 
 - `--explicit` - do not assume default locations of project dependencies and
   outputs. You'll have to provide specific locations via other options or

--- a/content/docs/command-reference/exp/init.md
+++ b/content/docs/command-reference/exp/init.md
@@ -11,7 +11,7 @@ Quickly setup any project to use [DVC Experiments].
 usage: dvc exp init [-h] [-q | -v] [--run] [--interactive] [-f]
                     [--explicit] [--name NAME] [--code CODE]
                     [--data DATA] [--models MODELS] [--params PARAMS]
-                    [--metrics METRICS] [--plots PLOTS] [--live LIVE]
+                    [--metrics METRICS] [--plots PLOTS]
                     [--type {default,dl}]
                     [command]
 ```
@@ -127,12 +127,6 @@ $ dvc exp init './another_script.sh $MYENVVAR'
 - `--plots` - set the path to the file or directory where the plots produced by
   your experiment can be found (if any). Overrides other configuration and
   default value (`plots/`).
-
-- `--live` - configure the `path` directory for [DVCLive](/doc/dvclive). This is
-  where experiment logs will be written. Overrides other configuration and
-  default value (`dvclive/`).
-
-  > This only has an effect when used with `--type=dl`.
 
 - `--explicit` - do not assume default locations of project dependencies and
   outputs. You'll have to provide specific locations via other options or

--- a/content/docs/command-reference/run.md
+++ b/content/docs/command-reference/run.md
@@ -13,9 +13,7 @@ usage: dvc run [-h] [-q | -v] [-n <name>] [-f]
                [--outs-persist-no-cache <filename>]
                [-m <path>] [-M <path>]
                [--plots <path>] [--plots-no-cache <path>]
-               [--live <path>] [--live-no-cache <path>]
-               [--live-no-html] [-w <path>]
-               [--always-changed] [--desc <text>]
+               [-w <path>] [--always-changed] [--desc <text>]
                [--no-exec] [--no-commit] [--no-run-cache]
                command
 
@@ -268,16 +266,6 @@ $ dvc run -n second_stage './another_script.sh $MYENVVAR'
 
 - `--desc <text>` - user description of the stage (optional). This doesn't  
   affect any DVC operations.
-
-- `--live <path>` - specify the directory `path` for
-  [DVCLive](/doc/dvclive/dvclive-with-dvc) to write logs in. `path` will be
-  tracked (<abbr>cached</abbr>) by DVC. Saved in the `live` field of `dvc.yaml`.
-
-- `--live-no-cache <path>` - the same as `--live` except that the `path` is not
-  tracked by DVC. Useful if you prefer to track it with Git.
-
-- `--live-no-html` - deactivates DVCLive
-  [HTML report](/doc/dvclive/dvclive-with-dvc#html-report) generation.
 
 - `-h`, `--help` - prints the usage/help message, and exit.
 

--- a/content/docs/command-reference/stage/add.md
+++ b/content/docs/command-reference/stage/add.md
@@ -12,9 +12,7 @@ usage: dvc stage add [-h] [-q | -v] -n <name> [-f]
                  [--outs-persist-no-cache <filename>]
                  [-m <path>] [-M <path>]
                  [--plots <path>] [--plots-no-cache <path>]
-                 [--live <path>] [--live-no-cache <path>]
-                 [--live-no-html] [-w <path>]
-                 [--always-changed] [--desc <text>]
+                 [-w <path>] [--always-changed] [--desc <text>]
                  command
 
 positional arguments:
@@ -245,16 +243,6 @@ data science experiments.
 
 - `--desc <text>` - user description of the stage (optional). This doesn't  
   affect any DVC operations.
-
-- `--live <path>` - specify the directory `path` for
-  [DVCLive](/doc/dvclive/dvclive-with-dvc) to write logs in. `path` will be
-  tracked (<abbr>cached</abbr>) by DVC. Saved in the `live` field of `dvc.yaml`.
-
-- `--live-no-cache <path>` - the same as `--live` except that the `path` is not
-  tracked by DVC. Useful if you prefer to track it with Git.
-
-- `--live-no-html` - deactivates DVCLive
-  [HTML report](/doc/dvclive/dvclive-with-dvc#html-report) generation.
 
 - `-h`, `--help` - prints the usage/help message, and exit.
 

--- a/content/docs/dvclive/api-reference/live/index.md
+++ b/content/docs/dvclive/api-reference/live/index.md
@@ -64,10 +64,10 @@ other metadata.
   </admon>
 
 - `report` - If `html`, DVCLive will call `Live.make_report()` on each step
-  update . _Default_: `html`.
+  update. _Default_: `html`.
 
 - `auto_open` - If `True`, on the first `Live.make_report()` call, DVCLive will
-  automatically open `html_path` in a browser. _Default_: `True`.
+  automatically open `html_path` in a browser. _Default_: `False`.
 
 ## Methods
 

--- a/content/docs/dvclive/api-reference/live/index.md
+++ b/content/docs/dvclive/api-reference/live/index.md
@@ -40,10 +40,10 @@ other metadata.
   [outputs](/doc/dvclive/get-started#outputs).
 
 - `summary_path` - `{dir}.json`. Location of the
-  [summary](/doc/dvclive/api-reference/log##description).
+  [summary](/doc/dvclive/api-reference/live/log#description).
 
 - `html_path` - `{dir}/report.html`. Location of the
-  [html report](/doc/dvclive/api-reference/make_report##description).
+  [html report](/doc/dvclive/api-reference/live/make_report#description).
 
 ## Parameters
 

--- a/content/docs/dvclive/api-reference/live/index.md
+++ b/content/docs/dvclive/api-reference/live/index.md
@@ -10,7 +10,6 @@ class Live:
         path: Optional[str] = None,
         resume: bool = False,
         report: Optional[str] = "html",
-        auto_open: bool = False,
     ):
 ```
 

--- a/content/docs/dvclive/api-reference/live/index.md
+++ b/content/docs/dvclive/api-reference/live/index.md
@@ -10,7 +10,7 @@ class Live:
         path: Optional[str] = None,
         resume: bool = False,
         report: Optional[str] = "html",
-        auto_open: bool = True,
+        auto_open: bool = False,
     ):
 ```
 

--- a/content/docs/dvclive/api-reference/live/index.md
+++ b/content/docs/dvclive/api-reference/live/index.md
@@ -9,6 +9,8 @@ class Live:
         self,
         path: Optional[str] = None,
         resume: bool = False,
+        report: Optional[str] = "html",
+        auto_open: bool = True,
     ):
 ```
 
@@ -36,10 +38,12 @@ other metadata.
 
 - `dir` - Location of the directory to store
   [outputs](/doc/dvclive/get-started#outputs).
-- `summary_path` - Location of the
-  [summary](/doc/dvclive/api-reference/live/#parameters).
-- `html_path` - Location of the
-  [html report](/doc/dvclive/dvclive-with-dvc#html-report).
+
+- `summary_path` - `{dir}.json`. Location of the
+  [summary](/doc/dvclive/api-reference/log##description).
+
+- `html_path` - `{dir}/report.html`. Location of the
+  [html report](/doc/dvclive/api-reference/make_report##description).
 
 ## Parameters
 
@@ -59,17 +63,18 @@ other metadata.
 
   </admon>
 
-## Exceptions
+- `report` - If `html`, DVCLive will call `Live.make_report()` on each step
+  update . _Default_: `html`.
 
-- `dvclive.error.ConfigMismatchError` - thrown if the provided `path` does not
-  match with the one set in DVC (see
-  [DVCLive with DVC](/docs/dvclive/dvclive-with-dvc))
+- `auto_open` - If `True`, on the first `Live.make_report()` call, DVCLive will
+  automatically open `html_path` in a browser. _Default_: `True`.
 
 ## Methods
 
 - `Live.log()`
 - `Live.log_image()`
 - `Live.log_plot()`
+- `Live.make_report()`
 - `Live.get_step()`
 - `Live.next_step()`
 - `Live.set_step()`

--- a/content/docs/dvclive/api-reference/live/make_report.md
+++ b/content/docs/dvclive/api-reference/live/make_report.md
@@ -25,7 +25,7 @@ HTML report and save it in `{dir}/report.html`.
 
 <admon type="info">
 
-This function gets automatically called on each `step` update, unless
-`report=None` was passed to `Live()`
+This function gets called internally on each `step` update by default
+(unless `report` is passed to `Live()` with a value other than `"html"`).
 
 </admon>

--- a/content/docs/dvclive/api-reference/live/make_report.md
+++ b/content/docs/dvclive/api-reference/live/make_report.md
@@ -25,7 +25,7 @@ HTML report and save it in `{dir}/report.html`.
 
 <admon type="info">
 
-This function gets automatically called on each `step` update, if
-`report="html"` was passed to `Live()`
+This function gets automatically called on each `step` update, unless
+`report=None` was passed to `Live()`
 
 </admon>

--- a/content/docs/dvclive/api-reference/live/make_report.md
+++ b/content/docs/dvclive/api-reference/live/make_report.md
@@ -25,7 +25,7 @@ HTML report and save it in `{dir}/report.html`.
 
 <admon type="info">
 
-This function gets called internally on each `step` update by default
-(unless `report` is passed to `Live()` with a value other than `"html"`).
+This function gets called internally on each `step` update by default (unless
+`report` is passed to `Live()` with a value other than `"html"`).
 
 </admon>

--- a/content/docs/dvclive/api-reference/live/make_report.md
+++ b/content/docs/dvclive/api-reference/live/make_report.md
@@ -1,0 +1,31 @@
+# Live.make_report()
+
+Generates an HTML Report from the logged data.
+
+```py
+def make_report()
+```
+
+#### Usage:
+
+```py
+from dvclive import Live
+
+live = Live()
+live.log_plot("confusion_matrix", [0, 0, 1, 1], [1, 0, 0, 1])
+live.make_report()
+```
+
+## Description
+
+On each call, DVCLive will collect all the data logged in `{dir}`, generate an
+HTML report and save it in `{dir}/report.html`.
+
+![](/img/dvclive-html.gif)
+
+<admon type="info">
+
+This function gets automatically called on each `step` update, if
+`report="html"` was passed to `Live()`
+
+</admon>

--- a/content/docs/dvclive/api-reference/live/next_step.md
+++ b/content/docs/dvclive/api-reference/live/next_step.md
@@ -30,8 +30,8 @@ will be associated to the updated `step` value.
 
 <admon type="info">
 
-If `report="html"` was passed to `Live()`, each `Live.next_step()` will also
-call `Live.make_report()`.
+Each `Live.next_step()` will call `Live.make_report()` internally by default
+(unless `report` is passed to `Live()` with a value other than `"html"`).
 
 </admon>
 

--- a/content/docs/dvclive/api-reference/live/next_step.md
+++ b/content/docs/dvclive/api-reference/live/next_step.md
@@ -41,6 +41,6 @@ When `dvclive` is used alongside `DVC`, each `Live.next_step()` call will have
 additional effects.
 
 When [checkpoints](/doc/user-guide/experiment-management/checkpoints) are
-enabled in the <abbr>pipeline</abbr>, `DVC` will
+enabled in the <abbr>pipeline</abbr>, DVC will
 [create a new checkpoint](/doc/dvclive/dvclive-with-dvc#checkpoints) on each
 `Live.next_step()` call.

--- a/content/docs/dvclive/api-reference/live/next_step.md
+++ b/content/docs/dvclive/api-reference/live/next_step.md
@@ -28,17 +28,19 @@ You can use `Live.next_step()` to increase the `step` by 1 (one).
 Each metric logged in between `Live.next_step()` (or `Live.set_step()`) calls
 will be associated to the updated `step` value.
 
+<admon type="info">
+
+If `report="html"` was passed to `Live()`, each `Live.next_step()` will also
+call `Live.make_report()`.
+
+</admon>
+
 ### DVC integration
 
 When `dvclive` is used alongside `DVC`, each `Live.next_step()` call will have
 additional effects.
 
-By default, on each `Live.next_step()` call, `DVC` will prepare an
-[HTML report](/doc/dvclive/dvclive-with-dvc#html-report) with the
-[metrics history](/doc/dvclive/get-started#history).
-
-In addition, when
-[checkpoints](/doc/user-guide/experiment-management/checkpoints) are enabled in
-the <abbr>pipeline</abbr>, `DVC` will
+When [checkpoints](/doc/user-guide/experiment-management/checkpoints) are
+enabled in the <abbr>pipeline</abbr>, `DVC` will
 [create a new checkpoint](/doc/dvclive/dvclive-with-dvc#checkpoints) on each
 `Live.next_step()` call.

--- a/content/docs/dvclive/api-reference/live/set_step.md
+++ b/content/docs/dvclive/api-reference/live/set_step.md
@@ -31,8 +31,8 @@ will be associated to the provided `step` value.
 
 <admon type="info">
 
-If `report="html"` was passed to `Live()`, each `Live.next_step()` will also
-call `Live.make_report()`.
+Each `Live.set_step()` will call `Live.make_report()` internally by default
+(unless `report` is passed to `Live()` with a value other than `"html"`).
 
 </admon>
 

--- a/content/docs/dvclive/api-reference/live/set_step.md
+++ b/content/docs/dvclive/api-reference/live/set_step.md
@@ -42,7 +42,7 @@ When `dvclive` is used alongside `DVC`, each `Live.set_step()` call will have
 additional effects.
 
 When [checkpoints](/doc/user-guide/experiment-management/checkpoints) are
-enabled in the <abbr>pipeline</abbr>, `DVC` will
+enabled in the <abbr>pipeline</abbr>, DVC will
 [create a new checkpoint](/doc/dvclive/dvclive-with-dvc#checkpoints) on each
 `Live.set_step()` call.
 

--- a/content/docs/dvclive/api-reference/live/set_step.md
+++ b/content/docs/dvclive/api-reference/live/set_step.md
@@ -29,18 +29,20 @@ You can use `Live.set_step()` to set `step` to any value.
 Each metric logged in between `Live.set_step()` (or `Live.next_step()`) calls
 will be associated to the provided `step` value.
 
+<admon type="info">
+
+If `report="html"` was passed to `Live()`, each `Live.next_step()` will also
+call `Live.make_report()`.
+
+</admon>
+
 ### DVC integration
 
 When `dvclive` is used alongside `DVC`, each `Live.set_step()` call will have
 additional effects.
 
-By default, on each `Live.set_step()` call, `DVC` will prepare an
-[HTML report](/doc/dvclive/dvclive-with-dvc#html-report) with the
-[metrics history](/doc/dvclive/get-started#lhistory).
-
-In addition, when
-[checkpoints](/doc/user-guide/experiment-management/checkpoints) are enabled in
-the <abbr>pipeline</abbr>, `DVC` will
+When [checkpoints](/doc/user-guide/experiment-management/checkpoints) are
+enabled in the <abbr>pipeline</abbr>, `DVC` will
 [create a new checkpoint](/doc/dvclive/dvclive-with-dvc#checkpoints) on each
 `Live.set_step()` call.
 

--- a/content/docs/dvclive/dvclive-with-dvc.md
+++ b/content/docs/dvclive/dvclive-with-dvc.md
@@ -98,14 +98,14 @@ $ tree
 ```
 
 The [metrics summary](/doc/dvclive/api-reference/live/log#description)
-`training_metrics.json` can be used by `dvc metrics` and visualized with
+in `training_metrics.json` can be used by `dvc metrics` and visualized with
 `dvc exp show`/`dvc exp diff`.
 
 The [metrics history](/doc/dvclive/api-reference/live/log#step-updates)
 `training_metrics/scalars` can be visualized with `dvc plots`.
 
-The [HTML report](/doc/dvclive/api-reference/live/make_report##description)
-`training_metrics/report.html` will contain all the logged data and will be
+The [HTML report](/doc/dvclive/api-reference/live/make_report#description)
+in `training_metrics/report.html` will contain all the logged data and will be
 automatically updated during training on each `step` update!
 
 ![](/img/dvclive-html.gif)

--- a/content/docs/dvclive/dvclive-with-dvc.md
+++ b/content/docs/dvclive/dvclive-with-dvc.md
@@ -97,15 +97,15 @@ $ tree
 └── train.py
 ```
 
-The [metrics summary](/doc/dvclive/api-reference/live/log#description)
-in `training_metrics.json` can be used by `dvc metrics` and visualized with
+The [metrics summary](/doc/dvclive/api-reference/live/log#description) in
+`training_metrics.json` can be used by `dvc metrics` and visualized with
 `dvc exp show`/`dvc exp diff`.
 
 The [metrics history](/doc/dvclive/api-reference/live/log#step-updates)
 `training_metrics/scalars` can be visualized with `dvc plots`.
 
-The [HTML report](/doc/dvclive/api-reference/live/make_report#description)
-in `training_metrics/report.html` will contain all the logged data and will be
+The [HTML report](/doc/dvclive/api-reference/live/make_report#description) in
+`training_metrics/report.html` will contain all the logged data and will be
 automatically updated during training on each `step` update!
 
 ![](/img/dvclive-html.gif)

--- a/content/docs/dvclive/dvclive-with-dvc.md
+++ b/content/docs/dvclive/dvclive-with-dvc.md
@@ -14,6 +14,13 @@ ways:
 
 We will refer to a training script (`train.py`) already using `dvclive`:
 
+<admon type="tip">
+
+If you use one of the supported [ML Frameworks](/doc/dvclive/ml-frameworks), you
+can jump to its corresponding page to find an example usage.
+
+</admon>
+
 ```python
 # train.py
 
@@ -46,7 +53,7 @@ python train.py
 <admon type="exclamation">
 
 Note that the paths indicated in the `metrics` and `plots` options match the
-`path` passed to `Live()` in the Python code.
+`path` passed to `Live()` in the Python code (`"training_metrics"`).
 
 </admon>
 

--- a/content/docs/dvclive/dvclive-with-dvc.md
+++ b/content/docs/dvclive/dvclive-with-dvc.md
@@ -46,7 +46,7 @@ $ dvc stage add \
 --name train \
 --deps train.py \
 --metrics-no-cache training_metrics.json \
---plots training_metrics/scalars \
+--plots-no-cache training_metrics/scalars \
 python train.py
 ```
 
@@ -70,7 +70,8 @@ stages:
       - training_metrics.json:
           cache: false
     plots:
-      - training_metrics/scalars
+      - training_metrics/scalars:
+          cache: false
 ```
 
 Run the training with `dvc repro` or `dvc exp run`:

--- a/content/docs/dvclive/dvclive-with-dvc.md
+++ b/content/docs/dvclive/dvclive-with-dvc.md
@@ -50,7 +50,7 @@ $ dvc stage add \
 python train.py
 ```
 
-<admon type="exclamation">
+<admon type="warn">
 
 Note that the paths indicated in the `metrics` and `plots` options match the
 `path` passed to `Live()` in the Python code (`"training_metrics"`).

--- a/content/docs/dvclive/dvclive-with-dvc.md
+++ b/content/docs/dvclive/dvclive-with-dvc.md
@@ -1,6 +1,6 @@
 # DVCLive with DVC
 
-Even though DVCLive does not require DVC, they can integrate in several useful
+Even though DVCLive does not require DVC, they can integrate in a couple useful
 ways:
 
 - The [outputs](#outputs) DVCLive produces are recognized by `dvc exp`,

--- a/content/docs/dvclive/dvclive-with-dvc.md
+++ b/content/docs/dvclive/dvclive-with-dvc.md
@@ -7,9 +7,6 @@ ways:
   `dvc metrics` and `dvc plots`. Those same outputs can be visualized in
   [Iterative Studio](#iterative-studio).
 
-- You can monitor model performance in realtime with the
-  [HTML report](#html-report) that DVCLive generates when used alongside DVC.
-
 - DVCLive is also capable of generating [checkpoint](#checkpoints) signal files
   used by DVC <abbr>experiments<abbr>.
 
@@ -22,7 +19,7 @@ We will refer to a training script (`train.py`) already using `dvclive`:
 
 from dvclive import Live
 
-live = Live()
+live = Live("training_metrics")
 
 for epoch in range(NUM_EPOCHS):
     train_model(...)
@@ -38,12 +35,23 @@ Let's use `dvc stage add` to create a stage to wrap this code (don't forget to
 `dvc init` first):
 
 ```dvc
-$ dvc stage add -n train --live training_metrics
-                -d train.py python train.py
+$ dvc stage add \
+--name train \
+--deps train.py \
+--metrics-no-cache training_metrics.json \
+--plots training_metrics/scalars \
+python train.py
 ```
 
-`dvc.yaml` will contain a new `train` stage with the DVCLive configuration (in
-the `live` field):
+<admon type="exclamation">
+
+Note that the paths indicated in the `metrics` and `plots` options match the
+`path` passed to `Live()` in the Python code.
+
+</admon>
+
+`dvc.yaml` will contain a new `train` stage using the DVCLive outputs as
+`dvc metrics` and `dvc plots`:
 
 ```yaml
 stages:
@@ -51,22 +59,12 @@ stages:
     cmd: python train.py
     deps:
       - train.py
-    live:
-      training_metrics:
-        summary: true
-        html: true
+    metrics:
+      - training_metrics.json:
+          cache: false
+    plots:
+      - training_metrics/scalars
 ```
-
-The value passed to `--live` (`training_metrics`) became the directory `path`
-for DVCLive to write logs in, and DVC will now
-[track](/doc/use-cases/versioning-data-and-model-files) it. Other supported
-command options for the DVC integration:
-
-- `--live-no-cache <path>` - specify a DVCLive log directory `path` but don't
-  track it with DVC. Useful if you prefer to track it with Git.
-- `--live-no-html` - deactivates [HTML report](#html-report) generation.
-
-> Note that DVC will not track summary files or the HTML report.
 
 Run the training with `dvc repro` or `dvc exp run`:
 
@@ -83,6 +81,7 @@ $ tree
 ├── dvc.lock
 ├── dvc.yaml
 ├── training_metrics
+│   ├── report.html
 │   └── scalars
 │       ├── acc.tsv
 │       └── loss.tsv
@@ -94,9 +93,21 @@ The [metrics summary](/doc/dvclive/api-reference/live/log#description)
 `training_metrics.json` can be used by `dvc metrics` and visualized with
 `dvc exp show`/`dvc exp diff`.
 
-In addition, the
-[metrics history](/doc/dvclive/api-reference/live/log#step-updates) generated
-under `training_metrics/scalars` can be visualized with `dvc plots`.
+The [metrics history](/doc/dvclive/api-reference/live/log#step-updates)
+`training_metrics/scalars` can be visualized with `dvc plots`.
+
+The [HTML report](/doc/dvclive/api-reference/live/make_report##description)
+`training_metrics/report.html` will contain all the logged data and will be
+automatically updated during training on each `step` update!
+
+![](/img/dvclive-html.gif)
+
+<admon type="info">
+
+If you don't update the step number, the HTML report won't be generated unless
+you call `Live.make_report()` directly.
+
+</admon>
 
 ### Iterative Studio
 
@@ -106,21 +117,6 @@ by DVCLive, allowing to
 experiments using DVCLive in Iterative Studio.
 
 ![](/img/dvclive-studio-plots.png)
-
-### HTML report
-
-When `html: true`, DVC generates an _HTML report_.
-
-If you open `training_metrics_dvc_plots/index.html` in a browser, you'll see a
-plot for the logged data automatically updated during the model training!
-
-![](/img/dvclive-html.gif)
-
-<admon type="info">
- 
-If you don't update the step number, the HTML report won't be generated.
-
-</admon>
 
 ### Checkpoints
 

--- a/content/docs/dvclive/get-started.md
+++ b/content/docs/dvclive/get-started.md
@@ -111,10 +111,8 @@ See `Live.log()`, `Live.log_image()` and `Live.log_plot()` for more details.
 
 ### HTML report
 
-By default, DVCLive generates an HTML report in `dvclive/report.html`.
-
-This report will contain all the logged data and will be automatically updated
-during training on each `step` update!
+If and when `step` is updated, DVCLive generates or updates an HTML report in
+`dvclive/report.html` which will contain all the logged data.
 
 ![](/img/dvclive-html.gif)
 

--- a/content/docs/dvclive/get-started.md
+++ b/content/docs/dvclive/get-started.md
@@ -109,6 +109,22 @@ not.
 
 See `Live.log()`, `Live.log_image()` and `Live.log_plot()` for more details.
 
+### HTML report
+
+By default, DVCLive generates an HTML report in `dvclive/report.html`.
+
+This report will contain all the logged data and will be automatically updated
+during training on each `step` update!
+
+![](/img/dvclive-html.gif)
+
+<admon type="info">
+
+If you don't update the step number, the HTML report won't be generated unless
+you call `Live.make_report()` directly.
+
+</admon>
+
 ## What next?
 
 Learn how to use DVCLive alongside other tools:

--- a/content/docs/sidebar.json
+++ b/content/docs/sidebar.json
@@ -671,6 +671,10 @@
                 "label": "log_plot()"
               },
               {
+                "slug": "make_report",
+                "label": "make_report()"
+              },
+              {
                 "slug": "get_step",
                 "label": "get_step()"
               },

--- a/content/docs/user-guide/experiment-management/checkpoints.md
+++ b/content/docs/user-guide/experiment-management/checkpoints.md
@@ -97,12 +97,10 @@ $ dvc stage add --name train \
                 --params seed,lr,weight_decay \
                 --checkpoints model.pt \
                 --plots-no-cache predictions.json \
-                --live dvclive \
+                --plots-no-cache dvclive/scalars \
+                --metrics-no-cache dvclive.json
                 python train.py
 ```
-
-💡 The `--live dvclive` option enables our special logger
-[DVCLive](/doc/dvclive), which helps you register checkpoints from code.
 
 The checkpoints need to be enabled in DVC at the pipeline level. The
 `-c / --checkpoint` option of the `dvc stage add` command defines the checkpoint
@@ -132,13 +130,14 @@ stages:
     outs:
       - model.pt:
           checkpoint: true
+    metrics:
+      - dvclive.json:
+          cache: false
     plots:
+      - dvclive/scalars:
+          cache: false
       - predictions.json:
           cache: false
-    live:
-      dvclive:
-        summary: true
-        html: true
 ```
 
 ⚠️ Note that enabling checkpoints in a `dvc.yaml` file makes it incompatible

--- a/content/docs/user-guide/project-structure/pipelines-files.md
+++ b/content/docs/user-guide/project-structure/pipelines-files.md
@@ -362,7 +362,6 @@ These are the fields that are accepted in each stage:
 | `always_changed` | Causes this stage to be always considered as [changed] by commands such as `dvc status` and `dvc repro`. `false` by default                                                                                                                                                               |
 | `meta`           | (Optional) arbitrary metadata can be added manually with this field. Any YAML content is supported. `meta` contents are ignored by DVC, but they can be meaningful for user processes that read or write `.dvc` files directly.                                                           |
 | `desc`           | (Optional) user description for this stage. This doesn't affect any DVC operations.                                                                                                                                                                                                       |
-| `live`           | (Optional) [Dvclive](/doc/dvclive/dvclive-with-dvc) configuration field                                                                                                                                                                                                                   |
 
 [changed]: /doc/command-reference/status#local-workspace-status
 


### PR DESCRIPTION
In favor of reusing `metrics` and `plots`.

Closes https://github.com/iterative/dvclive/issues/77
Closes https://github.com/iterative/dvclive/issues/229
Closes https://github.com/iterative/dvclive/issues/230


