### PR TITLE
Added id as props for unique anchor

### DIFF
--- a/content/docs/command-reference/diff.md
+++ b/content/docs/command-reference/diff.md
@@ -119,7 +119,7 @@ $ dvc diff
 
 ## Example: Comparing workspace with arbitrary commits
 
-<details>
+<details id="example-comparing-workspace-with-arbitrary-commits-expand">
 
 ### Click and expand to set up the example
 
@@ -149,7 +149,7 @@ files summary: 1 added, 0 deleted, 0 modified
 
 ## Example: Comparing tags or branches
 
-<details>
+<details id="example-comparing-tags-or-branches-expand">
 
 ### Click and expand to set up the example
 
@@ -223,7 +223,7 @@ It outputs:
 
 ## Example: Renamed files
 
-<details>
+<details id="example-renamed-files-expand">
 
 ### Click and expand to set up the example
 

--- a/content/docs/command-reference/diff.md
+++ b/content/docs/command-reference/diff.md
@@ -119,7 +119,7 @@ $ dvc diff
 
 ## Example: Comparing workspace with arbitrary commits
 
-<details id="example-comparing-workspace-with-arbitrary-commits-expand">
+<details id="example-arbitrary-commits-set-up">
 
 ### Click and expand to set up the example
 
@@ -149,7 +149,7 @@ files summary: 1 added, 0 deleted, 0 modified
 
 ## Example: Comparing tags or branches
 
-<details id="example-comparing-tags-or-branches-expand">
+<details id="example-tags-branches-set-up">
 
 ### Click and expand to set up the example
 
@@ -223,7 +223,7 @@ It outputs:
 
 ## Example: Renamed files
 
-<details id="example-renamed-files-expand">
+<details id="example-renamed-files-set-up">
 
 ### Click and expand to set up the example
 

--- a/content/docs/install/linux.md
+++ b/content/docs/install/linux.md
@@ -79,7 +79,7 @@ $ snap install --classic dvc
 
 ## Install from repository
 
-<details id="from-repo-on-debian-or-ubuntu">
+<details id="from-repo-on-debian-ubuntu">
 
 ### On Debian/Ubuntu
 
@@ -94,7 +94,7 @@ $ sudo apt install dvc
 
 </details>
 
-<details id="from-repo-on-fedora-or-centos">
+<details id="from-repo-on-fedora-centos">
 
 ### On Fedora/CentOS
 
@@ -115,7 +115,7 @@ Get the binary package from the big "Download" button on the [home page](/), or
 from the [release page](https://github.com/iterative/dvc/releases/) on GitHub.
 Then install it with the following command.
 
-<details id="from-pkg-on-debian-or-ubuntu">
+<details id="from-pkg-on-debian-ubuntu">
 
 ### On Debian/Ubuntu
 
@@ -125,7 +125,7 @@ $ sudo apt install ./dvc_0.62.1_amd64.deb
 
 </details>
 
-<details id="from-pkg-on-fedora-or-centos">
+<details id="from-pkg-on-fedora-centos">
 
 ### On Fedora/CentOS
 

--- a/content/docs/install/linux.md
+++ b/content/docs/install/linux.md
@@ -22,7 +22,7 @@ plan to use, you might need to install optional dependencies: `[s3]`,
 `[gdrive]`, `[gs]`, `[azure]`, `[ssh]`, `[hdfs]`, `[webdav]`, `[oss]`. Use
 `[all]` to include them all.
 
-<details>
+<details id="example-pip-with-support-for-amazon-s3-storage">
 
 ### Example: with support for Amazon S3 storage
 
@@ -53,7 +53,7 @@ Depending on the type of the [remote storage](/doc/command-reference/remote) you
 plan to use, you might need to install optional dependencies: `dvc-s3`,
 `dvc-azure`, `dvc-gdrive`, `dvc-gs`, `dvc-oss`, `dvc-ssh`.
 
-<details>
+<details id="example-conda-with-support-for-amazon-s3-storage">
 
 ### Example: with support for Amazon S3 storage
 
@@ -79,7 +79,7 @@ $ snap install --classic dvc
 
 ## Install from repository
 
-<details>
+<details id="from-repo-on-debian-or-ubuntu">
 
 ### On Debian/Ubuntu
 
@@ -94,7 +94,7 @@ $ sudo apt install dvc
 
 </details>
 
-<details>
+<details id="from-repo-on-fedora-or-centos">
 
 ### On Fedora/CentOS
 
@@ -115,7 +115,7 @@ Get the binary package from the big "Download" button on the [home page](/), or
 from the [release page](https://github.com/iterative/dvc/releases/) on GitHub.
 Then install it with the following command.
 
-<details>
+<details id="from-pkg-on-debian-or-ubuntu">
 
 ### On Debian/Ubuntu
 
@@ -125,7 +125,7 @@ $ sudo apt install ./dvc_0.62.1_amd64.deb
 
 </details>
 
-<details>
+<details id="from-pkg-on-fedora-or-centos">
 
 ### On Fedora/CentOS
 

--- a/content/docs/install/macos.md
+++ b/content/docs/install/macos.md
@@ -43,7 +43,7 @@ plan to use, you might need to install optional dependencies: `[s3]`,
 `[gdrive]`, `[gs]`, `[azure]`, `[ssh]`, `[hdfs]`, `[webdav]`, `[oss]`. Use
 `[all]` to include them all.
 
-<details>
+<details id="example-pip-with-support-for-amazon-s3-storage">
 
 ### Example: with support for Amazon S3 storage
 
@@ -69,7 +69,7 @@ Depending on the type of the [remote storage](/doc/command-reference/remote) you
 plan to use, you might need to install optional dependencies: `dvc-s3`,
 `dvc-azure`, `dvc-gdrive`, `dvc-gs`, `dvc-oss`, `dvc-ssh`.
 
-<details>
+<details id="example-conda-with-support-for-amazon-s3-storage">
 
 ### Example: with support for Amazon S3 storage
 

--- a/content/docs/install/windows.md
+++ b/content/docs/install/windows.md
@@ -35,7 +35,7 @@ Depending on the type of the [remote storage](/doc/command-reference/remote) you
 plan to use, you might need to install optional dependencies: `dvc-s3`,
 `dvc-azure`, `dvc-gdrive`, `dvc-gs`, `dvc-oss`, `dvc-ssh`.
 
-<details>
+<details id="example-conda-with-support-for-amazon-s3-storage">
 
 ### Example: with support for Amazon S3 storage
 
@@ -61,7 +61,7 @@ Depending on the type of the [remote storage](/doc/command-reference/remote) you
 plan to use, you might need to install optional dependencies: `[s3]`, `[azure]`,
 `[gdrive]`, `[gs]`, `[oss]`, `[ssh]`. Use `[all]` to include them all.
 
-<details>
+<details id="example-pip-with-support-for-amazon-s3-storage">
 
 ### Example: with support for Amazon S3 storage
 

--- a/content/docs/start/data-and-model-versioning.md
+++ b/content/docs/start/data-and-model-versioning.md
@@ -59,7 +59,7 @@ $ git commit -m "Add raw data"
 
 The data, meanwhile, is listed in `.gitignore`.
 
-<details id="expand-dvc-add">
+<details id="add-expand-to-see-what-happens-under-the-hood">
 
 ### 💡 Expand to see what happens under the hood.
 
@@ -145,7 +145,7 @@ $ dvc push
 Usually, we also want to `git commit` and `git push` the corresponding `.dvc`
 files.
 
-<details id="expand-dvc-push">
+<details id="push-expand-to-see-what-happens-under-the-hood">
 
 ### 💡 Expand to see what happens under the hood.
 

--- a/content/docs/start/data-and-model-versioning.md
+++ b/content/docs/start/data-and-model-versioning.md
@@ -59,7 +59,7 @@ $ git commit -m "Add raw data"
 
 The data, meanwhile, is listed in `.gitignore`.
 
-<details>
+<details id="expand-dvc-add">
 
 ### 💡 Expand to see what happens under the hood.
 
@@ -145,7 +145,7 @@ $ dvc push
 Usually, we also want to `git commit` and `git push` the corresponding `.dvc`
 files.
 
-<details>
+<details id="expand-dvc-push">
 
 ### 💡 Expand to see what happens under the hood.
 

--- a/content/docs/start/data-pipelines.md
+++ b/content/docs/start/data-pipelines.md
@@ -79,7 +79,7 @@ DVC uses these metafiles to track the data used and produced by the stage, so
 there's no need to use `dvc add` on `data/prepared`
 [manually](/doc/start/data-and-model-versioning).
 
-<details id="pipeline-stages-expand">
+<details id="stage-expand-to-see-what-happens-under-the-hood">
 
 ### 💡 Expand to see what happens under the hood.
 
@@ -172,7 +172,7 @@ $ dvc stage add -n featurize \
 
 The `dvc.yaml` file is updated automatically and should include two stages now.
 
-<details id="dependency-graphs-expand">
+<details id="pipeline-expand-to-see-what-happens-under-the-hood">
 
 ### 💡 Expand to see what happens under the hood.
 
@@ -271,7 +271,7 @@ it also doesn't rerun `train`! The previous run with the same set of inputs
 
 </details>
 
-<details id="reproduce-expand">
+<details id="repro-expand-to-see-what-happens-under-the-hood">
 
 ### 💡 Expand to see what happens under the hood.
 

--- a/content/docs/start/data-pipelines.md
+++ b/content/docs/start/data-pipelines.md
@@ -79,7 +79,7 @@ DVC uses these metafiles to track the data used and produced by the stage, so
 there's no need to use `dvc add` on `data/prepared`
 [manually](/doc/start/data-and-model-versioning).
 
-<details>
+<details id="pipeline-stages-expand">
 
 ### 💡 Expand to see what happens under the hood.
 
@@ -172,7 +172,7 @@ $ dvc stage add -n featurize \
 
 The `dvc.yaml` file is updated automatically and should include two stages now.
 
-<details>
+<details id="dependency-graphs-expand">
 
 ### 💡 Expand to see what happens under the hood.
 
@@ -271,7 +271,7 @@ it also doesn't rerun `train`! The previous run with the same set of inputs
 
 </details>
 
-<details>
+<details id="reproduce-expand">
 
 ### 💡 Expand to see what happens under the hood.
 

--- a/content/docs/user-guide/external-dependencies.md
+++ b/content/docs/user-guide/external-dependencies.md
@@ -189,7 +189,7 @@ Importing 'https://data.dvc.org/get-started/data.xml' -> 'data.xml'
 The command above creates the import `.dvc` file `data.xml.dvc`, that contains
 an external dependency (in this case an HTTPs URL).
 
-<details id="dvc-import-url-resulting-dot-dvc-file">
+<details id="import-url-expand-to-see-resulting-dvc-file">
 
 ### Expand to see resulting `.dvc` file
 
@@ -227,7 +227,7 @@ Importing 'model.pkl (git@github.com:iterative/example-get-started)'
 The command above creates `model.pkl.dvc`, where the external dependency is
 specified (with the `repo` field).
 
-<details id="dvc-import-resulting-dot-dvc-file">
+<details id="import-expand-to-see-resulting-dvc-file">
 
 ### Expand to see resulting `.dvc` file
 

--- a/content/docs/user-guide/external-dependencies.md
+++ b/content/docs/user-guide/external-dependencies.md
@@ -189,7 +189,7 @@ Importing 'https://data.dvc.org/get-started/data.xml' -> 'data.xml'
 The command above creates the import `.dvc` file `data.xml.dvc`, that contains
 an external dependency (in this case an HTTPs URL).
 
-<details>
+<details id="dvc-import-url-resulting-dot-dvc-file">
 
 ### Expand to see resulting `.dvc` file
 
@@ -227,7 +227,7 @@ Importing 'model.pkl (git@github.com:iterative/example-get-started)'
 The command above creates `model.pkl.dvc`, where the external dependency is
 specified (with the `repo` field).
 
-<details>
+<details id="dvc-import-resulting-dot-dvc-file">
 
 ### Expand to see resulting `.dvc` file
 

--- a/plugins/gatsby-theme-iterative-docs/src/components/Documentation/Markdown/index.tsx
+++ b/plugins/gatsby-theme-iterative-docs/src/components/Documentation/Markdown/index.tsx
@@ -60,17 +60,10 @@ const Details: React.FC<{ slugger: Slugger; id: string }> = ({
         ? cur?.props?.children?.toString()
         : '')
   }, '')
-  try {
-    id = id
-      ? useMemo(() => slugger.slug(id), [id])
-      : useMemo(() => slugger.slug(title), [title])
-  } catch (error) {
-    throw new Error(
-      `Duplicate ${id ? `id: "${id}"` : `title: "${title}"`} \n in page: ${
-        location.pathname
-      }`
-    )
-  }
+  id = useMemo(() => {
+    return id ? slugger.slug(id) : slugger.slug(title)
+  }, [id, title])
+
   useEffect(() => {
     if (location.hash === `#${id}`) {
       setIsOpen(true)

--- a/plugins/gatsby-theme-iterative-docs/src/utils/front/Slugger.ts
+++ b/plugins/gatsby-theme-iterative-docs/src/utils/front/Slugger.ts
@@ -22,19 +22,13 @@ class Slugger {
     this.slugs.push(slug)
     return slug
   }
-  slugify = (str: string) => {
+  slugify(str: string) {
     return str
       .replace(/[^\w\s-]/g, '')
       .trim()
       .replace(/[-\s]+/g, this.separator)
       .replace(this.separator + this.separator, this.separator)
       .replace(/(^\-+|\-+$)/g, '')
-  }
-  add(slug: string) {
-    if (this.slugs.includes(slug)) {
-      throw new Error(`Duplicate slug: ${slug} for title:${slug}`)
-    }
-    this.slugs.push(slug)
   }
   reset() {
     this.slugs = []

--- a/plugins/gatsby-theme-iterative-docs/src/utils/front/Slugger.ts
+++ b/plugins/gatsby-theme-iterative-docs/src/utils/front/Slugger.ts
@@ -1,0 +1,43 @@
+class Slugger {
+  separator: string
+  lowercase: boolean
+  slugs: Array<string>
+
+  constructor(options?: { separator?: string; lowercase?: boolean }) {
+    this.separator = options?.separator || '-'
+    this.lowercase = options?.lowercase === false ? false : true
+    this.slugs = []
+  }
+
+  slug(str: string) {
+    str = typeof str === 'string' ? str : ''
+    let slug = this.slugify(str)
+
+    if (this.lowercase) {
+      slug = slug.toLowerCase()
+    }
+    if (this.slugs.includes(slug)) {
+      throw new Error(`Duplicate slug: ${slug}`)
+    }
+    this.slugs.push(slug)
+    return slug
+  }
+  slugify = (str: string) => {
+    return str
+      .replace(/[^\w\s-]/g, '')
+      .trim()
+      .replace(/[-\s]+/g, this.separator)
+      .replace(this.separator + this.separator, this.separator)
+      .replace(/(^\-+|\-+$)/g, '')
+  }
+  add(slug: string) {
+    if (this.slugs.includes(slug)) {
+      throw new Error(`Duplicate slug: ${slug} for title:${slug}`)
+    }
+    this.slugs.push(slug)
+  }
+  reset() {
+    this.slugs = []
+  }
+}
+export default Slugger


### PR DESCRIPTION
Fixes #3383 
The comments from previous pr https://github.com/iterative/dvc.org/pull/3352#issuecomment-1068236555 and issue https://github.com/iterative/dvc.org/issues/3383#issuecomment-1085153649 are taken into consideration.

So by default, the anchor id will be generated based on the title. And, if there are duplicate titles inside the same page(path) then a run time error popup will appear on the page.
We can set the unique id using the `id` as props on the `<details>` tag, this will clear the above error if the id is unique.

Currently, if the `<details>` block misses the header element as first-child an error popup is thrown. It will be similar to that.
We need to display the error popup in order to make sure the id either passed as props or generated from the title is unique.

PS: Again, I expect the preview deployment to fail because I have only added a unique id for the duplicate titles on `start/data-and-model-versioning`. I will be collaborating with @iterative/docs once the implementation is finalized. 
