### PR TITLE
Added proxy api for Plausible on current express server

### DIFF
--- a/src/components/Page/DefaultSEO/index.tsx
+++ b/src/components/Page/DefaultSEO/index.tsx
@@ -3,6 +3,7 @@ import Helmet from 'react-helmet'
 
 import { MetaProps } from 'gatsby-theme-iterative-docs/src/components/SEO'
 import getSiteMeta from 'gatsby-theme-iterative-docs/src/queries/siteMeta'
+import { PLAUSIBLE } from '../../../consts'
 
 interface IDefaultSEOProps {
   pathname: string
@@ -120,7 +121,7 @@ const DefaultSEO: React.FC<IDefaultSEOProps> = ({ pathname }) => {
       <script
         defer
         data-domain="dvc.org"
-        src="/api/pl/script.outbound-links.js"
+        src={PLAUSIBLE.SCRIPT_SOURCE}
       ></script>
     </Helmet>
   )

--- a/src/components/Page/DefaultSEO/index.tsx
+++ b/src/components/Page/DefaultSEO/index.tsx
@@ -117,7 +117,11 @@ const DefaultSEO: React.FC<IDefaultSEOProps> = ({ pathname }) => {
         }
       ]}
     >
-      <script defer data-domain="dvc.org" src="/api/pl/script.js"></script>
+      <script
+        defer
+        data-domain="dvc.org"
+        src="/api/pl/script.outbound-links.js"
+      ></script>
     </Helmet>
   )
 }

--- a/src/components/Page/DefaultSEO/index.tsx
+++ b/src/components/Page/DefaultSEO/index.tsx
@@ -117,11 +117,7 @@ const DefaultSEO: React.FC<IDefaultSEOProps> = ({ pathname }) => {
         }
       ]}
     >
-      <script
-        defer
-        data-domain="dvc.org"
-        src="https://plausible.io/js/plausible.outbound-links.js"
-      ></script>
+      <script defer data-domain="dvc.org" src="/api/pl/script.js"></script>
     </Helmet>
   )
 }

--- a/src/consts.js
+++ b/src/consts.js
@@ -18,8 +18,15 @@ const BLOG = {
   postsPerRow: 3
 }
 
+const PLAUSIBLE = {
+  SCRIPT_SOURCE: '/api/pl/script.outbound-links.js',
+  SCRIPT_WITHOUT_EXTENSION: '/pl/script',
+  EVENT_ENDPOINT: '/event'
+}
+
 module.exports = {
   FORUM_URL,
   BLOG,
+  PLAUSIBLE,
   PAGE_DOC
 }

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -30,6 +30,7 @@ const serveMiddleware = require('./middleware/serve')
 
 app.use(compression())
 app.use(express.json())
+app.use(express.text())
 app.use(redirectsMiddleware)
 app.use('/api', apiMiddleware)
 app.use(serveMiddleware)

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -29,6 +29,7 @@ const redirectsMiddleware = require('./middleware/redirects')
 const serveMiddleware = require('./middleware/serve')
 
 app.use(compression())
+app.use(express.json())
 app.use(redirectsMiddleware)
 app.use('/api', apiMiddleware)
 app.use(serveMiddleware)

--- a/src/server/middleware/api/index.js
+++ b/src/server/middleware/api/index.js
@@ -3,12 +3,13 @@ const routes = require('express').Router()
 const comments = require('./comments')
 const discourse = require('./discourse')
 const { issues, stars } = require('./github')
-const { handlePlausibleRequest } = require('./plausible')
+const { handlePlausibleRequest, handlePlausibleScript } = require('./plausible')
 
 routes.get('/comments', comments)
 routes.get('/discourse', discourse)
 routes.get('/github/issues', issues)
 routes.get('/github/stars', stars)
-routes.all('/pl/*', handlePlausibleRequest)
+routes.get('/pl/*', handlePlausibleScript)
+routes.post('/event', handlePlausibleRequest)
 
 module.exports = routes

--- a/src/server/middleware/api/index.js
+++ b/src/server/middleware/api/index.js
@@ -3,10 +3,12 @@ const routes = require('express').Router()
 const comments = require('./comments')
 const discourse = require('./discourse')
 const { issues, stars } = require('./github')
+const { handlePlausibleRequest } = require('./plausible')
 
 routes.get('/comments', comments)
 routes.get('/discourse', discourse)
 routes.get('/github/issues', issues)
 routes.get('/github/stars', stars)
+routes.all('/pl/*', handlePlausibleRequest)
 
 module.exports = routes

--- a/src/server/middleware/api/plausible.js
+++ b/src/server/middleware/api/plausible.js
@@ -38,10 +38,15 @@ async function handlePlausibleRequest(req, res) {
           'content-type': 'application/json'
         }
       })
-      res.set({
-        'content-type': response.headers.get('content-type')
-      })
-      return res.status(response.status).send(await response.text())
+      if (response.ok) {
+        res.set({
+          'content-type': response.headers.get('content-type')
+        })
+        return res.status(response.status).send(await response.text())
+      } else {
+        if (!isProduction) console.error(error)
+        return res.status(500).end()
+      }
     }
     res.status(404).end()
   } catch (error) {

--- a/src/server/middleware/api/plausible.js
+++ b/src/server/middleware/api/plausible.js
@@ -41,7 +41,7 @@ async function handlePlausibleRequest(req, res) {
       res.set({
         'content-type': response.headers.get('content-type')
       })
-      return response.body.pipe(res)
+      return res.status(response.status).send(await response.text())
     }
     res.status(404).end()
   } catch (error) {

--- a/src/server/middleware/api/plausible.js
+++ b/src/server/middleware/api/plausible.js
@@ -30,23 +30,22 @@ async function handlePlausibleScript(req, res) {
 async function handlePlausibleRequest(req, res) {
   try {
     const pathname = req.path
+    let { body } = req
+    if (typeof body === 'object') {
+      body = JSON.stringify(body)
+    }
     if (pathname.endsWith(Endpoint)) {
       const response = await fetch('https://plausible.io/api/event', {
         method: req.method,
-        body: JSON.stringify(req.body),
+        body,
         headers: {
           'content-type': 'application/json'
         }
       })
-      if (response.ok) {
-        res.set({
-          'content-type': response.headers.get('content-type')
-        })
-        return res.status(response.status).send(await response.text())
-      } else {
-        if (!isProduction) console.error(error)
-        return res.status(500).end()
-      }
+      res.set({
+        'content-type': response.headers.get('content-type')
+      })
+      return res.status(response.status).send(await response.text())
     }
     res.status(404).end()
   } catch (error) {

--- a/src/server/middleware/api/plausible.js
+++ b/src/server/middleware/api/plausible.js
@@ -2,11 +2,11 @@ const { isProduction } = require('../../utils')
 
 require('isomorphic-fetch')
 const ScriptName = '/pl/script.js'
-const Endpoint = '/pl/event'
+const Endpoint = '/event'
 
 const ScriptWithoutExtension = ScriptName.replace('.js', '')
 
-async function handlePlausibleRequest(req, res) {
+async function handlePlausibleScript(req, res) {
   try {
     const pathname = req.path
     const [baseUri, ...extensions] = pathname.split('.')
@@ -20,7 +20,17 @@ async function handlePlausibleRequest(req, res) {
         'content-type': response.headers.get('content-type')
       })
       return response.body.pipe(res)
-    } else if (pathname.endsWith(Endpoint)) {
+    }
+    res.status(404).end()
+  } catch (error) {
+    if (!isProduction) console.error(error)
+    res.status(500).end()
+  }
+}
+async function handlePlausibleRequest(req, res) {
+  try {
+    const pathname = req.path
+    if (pathname.endsWith(Endpoint)) {
       const response = await fetch('https://plausible.io/api/event', {
         method: req.method,
         body: JSON.stringify(req.body),
@@ -41,5 +51,6 @@ async function handlePlausibleRequest(req, res) {
 }
 
 module.exports = {
+  handlePlausibleScript,
   handlePlausibleRequest
 }

--- a/src/server/middleware/api/plausible.js
+++ b/src/server/middleware/api/plausible.js
@@ -1,7 +1,7 @@
 const { isProduction } = require('../../utils')
 
 require('isomorphic-fetch')
-const ScriptName = '/js/script.js'
+const ScriptName = '/pl/script.js'
 const Endpoint = '/pl/event'
 
 const ScriptWithoutExtension = ScriptName.replace('.js', '')
@@ -13,7 +13,8 @@ async function handlePlausibleRequest(req, res) {
 
     if (baseUri.endsWith(ScriptWithoutExtension)) {
       const response = await fetch(
-        'https://plausible.io/js/plausible.' + extensions.join('.')
+        'https://plausible.io/js/plausible.outbound-links.' +
+          extensions.join('.')
       )
       res.set({
         'content-type': response.headers.get('content-type')

--- a/src/server/middleware/api/plausible.js
+++ b/src/server/middleware/api/plausible.js
@@ -1,10 +1,9 @@
 const { isProduction } = require('../../utils')
+const {
+  PLAUSIBLE: { SCRIPT_WITHOUT_EXTENSION, EVENT_ENDPOINT }
+} = require('../../../consts')
 const NodeCache = require('node-cache')
 require('isomorphic-fetch')
-
-const ScriptName = '/pl/script.js'
-const Endpoint = '/event'
-const ScriptWithoutExtension = ScriptName.replace('.js', '')
 
 const cache = new NodeCache({ stdTTL: 60 })
 
@@ -13,7 +12,7 @@ async function handlePlausibleScript(req, res) {
     const pathname = req.path
     const [baseUri, ...extensions] = pathname.split('.')
 
-    if (baseUri.endsWith(ScriptWithoutExtension)) {
+    if (baseUri.endsWith(SCRIPT_WITHOUT_EXTENSION)) {
       const url = 'https://plausible.io/js/plausible.' + extensions.join('.')
 
       const cachedContent = cache.get(url)
@@ -54,7 +53,7 @@ async function handlePlausibleRequest(req, res) {
     if (typeof body === 'object') {
       body = JSON.stringify(body)
     }
-    if (pathname.endsWith(Endpoint)) {
+    if (pathname.endsWith(EVENT_ENDPOINT)) {
       const response = await fetch('https://plausible.io/api/event', {
         method: req.method,
         body,

--- a/src/server/middleware/api/plausible.js
+++ b/src/server/middleware/api/plausible.js
@@ -1,0 +1,44 @@
+const { isProduction } = require('../../utils')
+
+require('isomorphic-fetch')
+const ScriptName = '/js/script.js'
+const Endpoint = '/pl/event'
+
+const ScriptWithoutExtension = ScriptName.replace('.js', '')
+
+async function handlePlausibleRequest(req, res) {
+  try {
+    const pathname = req.path
+    const [baseUri, ...extensions] = pathname.split('.')
+
+    if (baseUri.endsWith(ScriptWithoutExtension)) {
+      const response = await fetch(
+        'https://plausible.io/js/plausible.' + extensions.join('.')
+      )
+      res.set({
+        'content-type': response.headers.get('content-type')
+      })
+      return response.body.pipe(res)
+    } else if (pathname.endsWith(Endpoint)) {
+      const response = await fetch('https://plausible.io/api/event', {
+        method: req.method,
+        body: JSON.stringify(req.body),
+        headers: {
+          'content-type': 'application/json'
+        }
+      })
+      res.set({
+        'content-type': response.headers.get('content-type')
+      })
+      return response.body.pipe(res)
+    }
+    res.status(404).end()
+  } catch (error) {
+    if (!isProduction) console.error(error)
+    res.status(500).end()
+  }
+}
+
+module.exports = {
+  handlePlausibleRequest
+}


### PR DESCRIPTION
Fixes https://github.com/iterative/iterative.ai/issues/423

Created proxy API for plausible basically to handle these two requests
```
pl/js/script.js -> https://plausible.io/js/script.js
pl/event    -> https://plausible.io/api/event
```

Todo: 
- [x] get this API implementation reviewed and finalize
- [x] replace current plausible API with this proxy API

**Update**: 
Script: https://dvc-org-proxy-plausible-cd4crn.herokuapp.com/api/pl/js/script.js
Event API: https://dvc-org-proxy-plausible-cd4crn.herokuapp.com/api/pl/event