### PR TITLE
Update link-check

### DIFF
--- a/.github/workflows/link-check-deploy.yml
+++ b/.github/workflows/link-check-deploy.yml
@@ -25,7 +25,7 @@ jobs:
         id: check
         uses: iterative/link-check.action@v0.11
         with:
-          diff: true
+          diff: master
           configFile: config/link-check/config.yml
           rootURL: '${{ github.event.deployment.payload.web_url }}'
           output: checksAction

--- a/.github/workflows/link-check-deploy.yml
+++ b/.github/workflows/link-check-deploy.yml
@@ -23,7 +23,7 @@ jobs:
           status: queued
       - name: Run Link Check
         id: check
-        uses: iterative/link-check.action@v0.9
+        uses: iterative/link-check.action@v0.11
         with:
           diff: true
           configFile: config/link-check/config.yml

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "lint-ts": "tsc --noEmit --skipLibCheck && eslint --ext .json,.js,.ts,.tsx .",
     "lint-css": "stylelint \"src/**/*.css\"",
     "link-check": "repo-link-check -c config/link-check/config.yml",
-    "link-check-diff": "repo-link-check -c config/link-check/config.yml -d",
+    "link-check-diff": "repo-link-check -c config/link-check/config.yml -d master",
     "link-check-dev-server": "repo-link-check -c config/link-check/config.yml -r http://localhost:3000",
     "link-check-exclude": "repo-link-check -c config/link-check/config.yml --unused-patterns-only"
   },
@@ -86,7 +86,7 @@
     "react-use": "^17.3.1",
     "rehype-react": "^6.2.1",
     "remark-preset-lint-recommended": "^5.0.0",
-    "repo-link-check": "^0.8.0",
+    "repo-link-check": "^0.11.0",
     "reset-css": "^5.0.1",
     "s3-client": "^4.4.2",
     "scroll": "^3.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -14630,10 +14630,10 @@ repeat-string@^1.0.0, repeat-string@^1.5.4, repeat-string@^1.6.1:
   resolved "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz"
   integrity sha1-jcrkcOHIirwtYA//Sndihtp15jc=
 
-repo-link-check@^0.8.0:
-  version "0.8.0"
-  resolved "https://registry.npmjs.org/repo-link-check/-/repo-link-check-0.8.0.tgz"
-  integrity sha512-v9i/go/athEugxbFocyVIgRZeKodGlTYrw1gywKQBNCSuMcmSBONh2/BCFQAe8DMa68+c2tvKixyw9LOhn7vKQ==
+repo-link-check@^0.11.0:
+  version "0.11.0"
+  resolved "https://registry.yarnpkg.com/repo-link-check/-/repo-link-check-0.11.0.tgz#07c62b99df21f83dc5bacca55dfc5677dc920fe1"
+  integrity sha512-CffKg4SKFd53TuxuOBjavjsCoYlX6/E0TuELKgljhZ+8lZs9Lm7Lnv+f9sxte0RuaEvY1WKjLYy6yLL/2pQV+A==
   dependencies:
     bottleneck "^2.19.5"
     commander "^6.1.0"


### PR DESCRIPTION
This PR upgrades `repo-link-check` to add in main branch rename support as well as a switch of the user agent which helps with medium-based links (like towardsdatascience.com)