### PR TITLE
doc: use `--name-only` alias instead in exp/stage list

### DIFF
--- a/content/docs/command-reference/exp/list.md
+++ b/content/docs/command-reference/exp/list.md
@@ -6,7 +6,7 @@ List experiments in a <abbr>DVC repository</abbr> (remote or local).
 
 ```usage
 usage: dvc exp list [-h] [-q | -v] [-A] [--rev <commit>]
-                    [-n <num>] [--names-only]
+                    [-n <num>] [--name-only]
                     [git_remote]
 
 positional arguments:
@@ -44,7 +44,7 @@ options below).
 - `-A, --all-commits` - list all experiments in the repository (overrides
   `--rev` and `--num`).
 
-- `--names-only` - print only the names of the experiments without their parent
+- `--name-only` - print only the names of the experiments without their parent
   Git commit.
 
 - `-h`, `--help` - shows the help message and exit.

--- a/content/docs/command-reference/stage/list.md
+++ b/content/docs/command-reference/stage/list.md
@@ -6,7 +6,7 @@ List <abbr>stages</abbr> in the project.
 
 ```usage
 usage: dvc stage list [-h] [-q | -v]
-                      [-R] [--all] [--fail] [--names-only]
+                      [-R] [--all] [--fail] [--name-only]
                       [targets ...]
 
 positional arguments:
@@ -20,7 +20,7 @@ positional arguments:
 ## Description
 
 Prints a list of stages including their names and a one-line description (which
-can be omitted using `--names-only`). This command is useful for discovering or
+can be omitted using `--name-only`). This command is useful for discovering or
 reviewing what stages are present in the project without having to examine
 `dvc.yaml` files manually.
 
@@ -42,7 +42,7 @@ important characteristics (dependencies, outputs, or metrics).
   - `dvc stage list modeling/dvc.yaml:prepare`: Stage(s) from a specific
     `dvc.yaml` file
 
-- `--names-only` - only lists stage names. Useful for scripting purposes (DVC
+- `--name-only` - only lists stage names. Useful for scripting purposes (DVC
   uses it for shell tab completion).
 
 - `-R`, `--recursive` - determines the files to list by searching each target

--- a/content/docs/user-guide/experiment-management/comparing-experiments.md
+++ b/content/docs/user-guide/experiment-management/comparing-experiments.md
@@ -51,11 +51,11 @@ This command lists remote experiments based on that repo's `HEAD`. You can use
 
 `dvc exp list` may be printing too much information when it comes to feed its
 output to other commands. You can get only the names of the experiments via the
-`--names-only` flag. For example, to get all the experiment names from a remote
+`--name-only` flag. For example, to get all the experiment names from a remote
 (`origin`):
 
 ```dvc
-$ for experiment in $(dvc exp list origin --names-only --all) ; do
+$ for experiment in $(dvc exp list origin --name-only --all) ; do
   dvc exp pull "${experiment}"
 done
 ```

--- a/content/docs/user-guide/how-to/share-many-experiments.md
+++ b/content/docs/user-guide/how-to/share-many-experiments.md
@@ -7,7 +7,7 @@ experiments.
 Here's a simple shell loop to push or pull all experiments (Linux):
 
 ```dvc
-$ dvc exp list --all --names-only | while read -r expname ; do \
+$ dvc exp list --all --name-only | while read -r expname ; do \
     dvc exp pull origin ${expname} \
 done
 ```


### PR DESCRIPTION
See https://github.com/iterative/dvc/pull/7598.

I'll suggest not merging this PR for a few months :). Until we are confident that a lot of users have that alias support, otherwise may result in a confusion.