### PR TITLE
Try heroku deploy action

### DIFF
--- a/.github/workflows/heroku-deploy.yml
+++ b/.github/workflows/heroku-deploy.yml
@@ -14,3 +14,5 @@ jobs:
         uses: mheap/github-action-pr-heroku-review-app@master
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HEROKU_API_TOKEN: ${{ secrets.HEROKU_API_TOKEN }}
+          HEROKU_PIPELINE_ID: ${{ secrets.HEROKU_PIPELINE_ID }}

--- a/.github/workflows/heroku-deploy.yml
+++ b/.github/workflows/heroku-deploy.yml
@@ -1,0 +1,16 @@
+name: Heroku Review Application
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, labeled, closed]
+  pull_request_target:
+    types: [opened, reopened, synchronize, labeled, closed]
+
+jobs:
+  heroku-review-application:
+    name: Heroku Review Application
+    runs-on: ubuntu-latest
+    steps:
+      - name: Heroku Review Application
+        uses: mheap/github-action-pr-heroku-review-app@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/heroku-deploy.yml
+++ b/.github/workflows/heroku-deploy.yml
@@ -16,3 +16,13 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           HEROKU_API_TOKEN: ${{ secrets.HEROKU_API_TOKEN }}
           HEROKU_PIPELINE_ID: ${{ secrets.HEROKU_PIPELINE_ID }}
+      - name: Run review-app test
+        id: review_app_test  # `id` value is used to refer the outputs from the corresponding action 
+        uses: teamniteo/reviewapps-deploy-status@v1.4.0
+        env:
+            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Check review_app_url
+        run: |
+          echo "Outputs :"
+          echo "- App name: ${{ steps.review_app_test.outputs.review_app_name }}"
+          echo "- App url: ${{ steps.review_app_test.outputs.review_app_url }}"


### PR DESCRIPTION
I imagine this won't work since I don't think we have Heroku API keys in our repo's secrets, but let's see what happens.

[Here's the docs for the environment variables we need](https://github.com/mheap/github-action-pr-heroku-review-app#available-configuration)
- `HEROKU_API_TOKEN` comes from someone's account,  which it seems like I can do
- `HEROKU_PIPELINE_ID` seems to be what's displayed in the URL when looking at the review apps index, i.e. `https://dashboard.heroku.com/pipelines/${ID}`
