### PR TITLE
gdrive remote service accounts can use env var

### DIFF
--- a/content/docs/user-guide/setup-google-drive-remote.md
+++ b/content/docs/user-guide/setup-google-drive-remote.md
@@ -199,7 +199,7 @@ authentication is needed.
    key in CI/CD systems, production setup, read-only file systems, etc. The
    content of this variable should be a string with JSON that has the same
    format as in the keys file described above. If both this variable and
-   `gdrive_service_account_json_file_path` are provide,
+   `gdrive_service_account_json_file_path` are provided,
    `GDRIVE_CREDENTIALS_DATA` takes priority and
    `gdrive_service_account_json_file_path` is ignored.
 

--- a/content/docs/user-guide/setup-google-drive-remote.md
+++ b/content/docs/user-guide/setup-google-drive-remote.md
@@ -199,8 +199,8 @@ authentication is needed.
    key in CI/CD systems, production setup, read-only file systems, etc. The
    content of this variable should be a string with JSON that has the same
    format as in the keys file described above. If both this variable and
-   `gdrive_service_account_json_file_path` are provide, DVC reads the
-   environment variable first.
+   `gdrive_service_account_json_file_path` are provide, `GDRIVE_CREDENTIALS_DATA`
+   takes priority and `gdrive_service_account_json_file_path` is ignored.
 
 3. Share the Google Drive folders that you want to use with the service account.
    Navigate to your Google Drive folder's sharing options and add the service
@@ -247,7 +247,7 @@ Alternatively, a `GDRIVE_CREDENTIALS_DATA` can be set to pass user credentials
 in CI/CD systems, production setup, read-only file systems, etc. The content of
 this variable should be a string with JSON that has the same format as in the
 credentials files described above, and usually you get it going through the same
-authentication process. DVC reads this variable first, before the credentials
-file.
+authentication process. If `GDRIVE_CREDENTIALS_DATA` is set, the
+`gdrive_user_credentials_file` value (if provided) is ignored.
 
 > Please note our [Privacy Policy (Google APIs)](/doc/user-guide/privacy).

--- a/content/docs/user-guide/setup-google-drive-remote.md
+++ b/content/docs/user-guide/setup-google-drive-remote.md
@@ -194,6 +194,12 @@ authentication is needed.
    $ dvc remote modify myremote --local \
                  gdrive_service_account_json_file_path path/to/file.json
    ```
+   
+   Alternatively, a `GDRIVE_CREDENTIALS_DATA` can be set to pass service account
+   key in CI/CD systems, production setup, read-only file systems, etc. The content of
+   this variable should be a string with JSON that has the same format as in the
+   keys file described above. If both this variable and `gdrive_service_account_json_file_path`
+   are provide, DVC reads the environment variable first.
 
 3. Share the Google Drive folders that you want to use with the service account.
    Navigate to your Google Drive folder's sharing options and add the service

--- a/content/docs/user-guide/setup-google-drive-remote.md
+++ b/content/docs/user-guide/setup-google-drive-remote.md
@@ -194,12 +194,13 @@ authentication is needed.
    $ dvc remote modify myremote --local \
                  gdrive_service_account_json_file_path path/to/file.json
    ```
-   
+
    Alternatively, a `GDRIVE_CREDENTIALS_DATA` can be set to pass service account
-   key in CI/CD systems, production setup, read-only file systems, etc. The content of
-   this variable should be a string with JSON that has the same format as in the
-   keys file described above. If both this variable and `gdrive_service_account_json_file_path`
-   are provide, DVC reads the environment variable first.
+   key in CI/CD systems, production setup, read-only file systems, etc. The
+   content of this variable should be a string with JSON that has the same
+   format as in the keys file described above. If both this variable and
+   `gdrive_service_account_json_file_path` are provide, DVC reads the
+   environment variable first.
 
 3. Share the Google Drive folders that you want to use with the service account.
    Navigate to your Google Drive folder's sharing options and add the service

--- a/content/docs/user-guide/setup-google-drive-remote.md
+++ b/content/docs/user-guide/setup-google-drive-remote.md
@@ -199,8 +199,9 @@ authentication is needed.
    key in CI/CD systems, production setup, read-only file systems, etc. The
    content of this variable should be a string with JSON that has the same
    format as in the keys file described above. If both this variable and
-   `gdrive_service_account_json_file_path` are provide, `GDRIVE_CREDENTIALS_DATA`
-   takes priority and `gdrive_service_account_json_file_path` is ignored.
+   `gdrive_service_account_json_file_path` are provide,
+   `GDRIVE_CREDENTIALS_DATA` takes priority and
+   `gdrive_service_account_json_file_path` is ignored.
 
 3. Share the Google Drive folders that you want to use with the service account.
    Navigate to your Google Drive folder's sharing options and add the service


### PR DESCRIPTION
For service accounts it is also an option to pass keys via an env variable.

> You may disregard these recommendations if you used the **Edit on GitHub** button from dvc.org to improve a doc in place.

❗ Please read the guidelines in the [Contributing to the Documentation](https://dvc.org/doc/user-guide/contributing/docs) list if you make any substantial changes to the documentation or JS engine.

🐛 Please make sure to mention `Fix #issue` (if applicable) in the description of the PR. This causes GitHub to close it automatically when the PR is merged.

Please choose to [allow us](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to edit your branch when creating the PR.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
