### PR TITLE
doc eng fix: hide anchor icons by default in lists

### DIFF
--- a/plugins/gatsby-theme-iterative-docs/src/components/Documentation/Markdown/Main/styles.module.css
+++ b/plugins/gatsby-theme-iterative-docs/src/components/Documentation/Markdown/Main/styles.module.css
@@ -109,6 +109,7 @@
 
     li .anchor {
       line-height: unset;
+      margin-left: -17px;
     }
 
     .anchor {

--- a/plugins/gatsby-theme-iterative-docs/src/components/Documentation/Markdown/Main/styles.module.css
+++ b/plugins/gatsby-theme-iterative-docs/src/components/Documentation/Markdown/Main/styles.module.css
@@ -79,27 +79,36 @@
       content: unset;
     }
 
-    li,
     .collapsableDiv .anchor svg {
       visibility: hidden;
     }
 
-    li,
+    .collapsableDiv .anchor:focus svg {
+      visibility: visible;
+    }
+
     .collapsableDiv:hover .anchor svg {
       visibility: visible;
     }
 
-    li,
-    .collapsableDiv .anchor:focus svg {
+    .collapsableDiv .anchor {
+      line-height: 2.5;
+    }
+
+    li .anchor svg {
+      visibility: hidden;
+    }
+
+    li .anchor:focus svg {
+      visibility: visible;
+    }
+
+    li:hover .anchor svg {
       visibility: visible;
     }
 
     li .anchor {
       line-height: unset;
-    }
-
-    .collapsableDiv .anchor {
-      line-height: 2.5;
     }
 
     .anchor {


### PR DESCRIPTION
Fixes permanently visible icons in the lists:

<img width="674" alt="Screen Shot 2022-04-27 at 10 54 26 PM" src="https://user-images.githubusercontent.com/3659196/165686175-acce6b8b-585d-439b-97b0-ca2ae7b9b2c8.png">

There is one more bug I haven't had time to fix - there is some space in between this link icon and the bullet point when hover is not active.

> You may disregard these recommendations if you used the **Edit on GitHub** button from dvc.org to improve a doc in place.

❗ Please read the guidelines in the [Contributing to the Documentation](https://dvc.org/doc/user-guide/contributing/docs) list if you make any substantial changes to the documentation or JS engine.

🐛 Please make sure to mention `Fix #issue` (if applicable) in the description of the PR. This causes GitHub to close it automatically when the PR is merged.

Please choose to [allow us](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to edit your branch when creating the PR.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
