### PR TITLE
user-guide: add troubleshooting entry for dvc-exp in shallow clones

### DIFF
--- a/content/docs/user-guide/troubleshooting.md
+++ b/content/docs/user-guide/troubleshooting.md
@@ -157,8 +157,11 @@ Set `fetch-depth` to `0` in the `actions/checkout` action:
     fetch-depth: 0
 ```
 
-> More info.
-> [here](https://github.com/actions/checkout#fetch-all-history-for-all-tags-and-branches).
+<admon type="info">
+
+See the [GitHub Actions docs](https://github.com/actions/checkout#fetch-all-history-for-all-tags-and-branches) for more information.
+
+</admon>
 
 </tab>
 <tab title="GitLab CI/CD">
@@ -170,8 +173,11 @@ variables:
   GIT_DEPTH: '0'
 ```
 
-> More info.
-> [here](https://docs.gitlab.com/ee/ci/large_repositories/#shallow-cloning).
+<admon type="info">
+
+See the [GitLab CI/CD docs](https://docs.gitlab.com/ee/ci/large_repositories/#shallow-cloning) for more information.
+
+</admon>
 
 </tab>
 </toggle>

--- a/content/docs/user-guide/troubleshooting.md
+++ b/content/docs/user-guide/troubleshooting.md
@@ -132,9 +132,9 @@ and retry the DVC command. Specifically, one of:
 [shallow clones](https://git-scm.com/docs/git-clone#Documentation/git-clone.txt---depthltdepthgt).
 Local Git repositories can be unshallowed with `git fetch --unshallow`.
 
-This often occurs in transient remote environments such as
-Continuous Integration (CI) jobs, which use shallow clones by default. In those
-cases, change their configuration to avoid shallow cloning. Common examples:
+This often occurs in transient remote environments such as Continuous
+Integration (CI) jobs, which use shallow clones by default. In those cases,
+change their configuration to avoid shallow cloning. Common examples:
 
 <toggle>
 <tab title="CML">

--- a/content/docs/user-guide/troubleshooting.md
+++ b/content/docs/user-guide/troubleshooting.md
@@ -125,3 +125,39 @@ and retry the DVC command. Specifically, one of:
 
 [internal directories]:
   https://dvc.org/doc/user-guide/project-structure/internal-files
+
+## DVC experiments may fail in shallow Git repositories {#git-shallow}
+
+DVC experiments rely on Git features which may not work properly in shallow Git
+repositories. This error commonly occurs in certain CI environments which use
+shallow git clones by default. When this error is encountered, try unshallowing
+the Git repository and then retry the DVC command.
+
+Local Git repositories can be unshallowed by using:
+
+```
+$ git fetch --unshallow
+```
+
+When using [CML](https://cml.dev/doc), repositories can be unshallowed by using:
+
+```
+$ cml ci --unshallow
+```
+
+In GitHub Actions, repositories can be unshallowed by setting `fetch-depth` in
+the `actions/checkout` action.
+
+```
+- uses: actions/checkout@v3
+  with:
+    fetch-depth: 0
+```
+
+In GitLab CI/CD, repositories can be unshallowed by setting the `GIT_DEPTH`
+environment variable:
+
+```
+variables:
+  GIT_DEPTH: "0"
+```

--- a/content/docs/user-guide/troubleshooting.md
+++ b/content/docs/user-guide/troubleshooting.md
@@ -139,7 +139,8 @@ cases, change their configuration to avoid shallow cloning. Common examples:
 <toggle>
 <tab title="CML">
 
-When using [CML](https://cml.dev/doc), repositories can be unshallowed by using:
+[CML](https://cml.dev/doc) has a convenient `--unshallow` option for it's
+[`ci`](https://cml.dev/doc/ref/ci) command:
 
 ```cli
 $ cml ci --unshallow

--- a/content/docs/user-guide/troubleshooting.md
+++ b/content/docs/user-guide/troubleshooting.md
@@ -126,38 +126,51 @@ and retry the DVC command. Specifically, one of:
 [internal directories]:
   https://dvc.org/doc/user-guide/project-structure/internal-files
 
-## DVC experiments may fail in shallow Git repositories {#git-shallow}
+## DVC Experiments may fail in Git shallow clones {#git-shallow}
 
-DVC experiments rely on Git features which may not work properly in shallow Git
-repositories. This error commonly occurs in certain CI environments which use
-shallow git clones by default. When this error is encountered, try unshallowing
-the Git repository and then retry the DVC command.
+`dvc exp` commands use internal Git operations which may not work properly in
+[shallow clones](https://git-scm.com/docs/git-clone#Documentation/git-clone.txt---depthltdepthgt).
+Local Git repositories can be unshallowed with `git fetch --unshallow`.
 
-Local Git repositories can be unshallowed by using:
+Typically, however, this occurs in transient remote environments such as
+Continuous Integration jobs, which use shallow clones by default. In those cases,
+change their configuration to avoid shallow cloning. Common examples:
 
-```
-$ git fetch --unshallow
-```
+<toggle>
+<tab title="CML">
 
 When using [CML](https://cml.dev/doc), repositories can be unshallowed by using:
 
-```
+```cli
 $ cml ci --unshallow
 ```
 
-In GitHub Actions, repositories can be unshallowed by setting `fetch-depth` in
-the `actions/checkout` action.
+</tab>
+<tab title="GitHub Actions">
 
-```
+Set `fetch-depth` to `0` in the `actions/checkout` action:
+
+```yaml
 - uses: actions/checkout@v3
   with:
     fetch-depth: 0
 ```
 
-In GitLab CI/CD, repositories can be unshallowed by setting the `GIT_DEPTH`
-environment variable:
+> More info.
+> [here](https://github.com/actions/checkout#fetch-all-history-for-all-tags-and-branches).
 
-```
+</tab>
+<tab title="GitLab CI/CD">
+
+Set the `GIT_DEPTH` env var to `0`:
+
+```yaml
 variables:
   GIT_DEPTH: "0"
 ```
+
+> More info.
+> [here](https://docs.gitlab.com/ee/ci/large_repositories/#shallow-cloning).
+
+</tab>
+</toggle>

--- a/content/docs/user-guide/troubleshooting.md
+++ b/content/docs/user-guide/troubleshooting.md
@@ -132,14 +132,14 @@ and retry the DVC command. Specifically, one of:
 [shallow clones](https://git-scm.com/docs/git-clone#Documentation/git-clone.txt---depthltdepthgt).
 Local Git repositories can be unshallowed with `git fetch --unshallow`.
 
-Typically, however, this occurs in transient remote environments such as
-Continuous Integration jobs, which use shallow clones by default. In those
+This often occurs in transient remote environments such as
+Continuous Integration (CI) jobs, which use shallow clones by default. In those
 cases, change their configuration to avoid shallow cloning. Common examples:
 
 <toggle>
 <tab title="CML">
 
-[CML](https://cml.dev/doc) has a convenient `--unshallow` option for it's
+[CML](https://cml.dev) has a convenient `--unshallow` option for its
 [`ci`](https://cml.dev/doc/ref/ci) command:
 
 ```cli

--- a/content/docs/user-guide/troubleshooting.md
+++ b/content/docs/user-guide/troubleshooting.md
@@ -159,7 +159,9 @@ Set `fetch-depth` to `0` in the `actions/checkout` action:
 
 <admon type="info">
 
-See the [GitHub Actions docs](https://github.com/actions/checkout#fetch-all-history-for-all-tags-and-branches) for more information.
+See the
+[GitHub Actions docs](https://github.com/actions/checkout#fetch-all-history-for-all-tags-and-branches)
+for more information.
 
 </admon>
 
@@ -175,7 +177,9 @@ variables:
 
 <admon type="info">
 
-See the [GitLab CI/CD docs](https://docs.gitlab.com/ee/ci/large_repositories/#shallow-cloning) for more information.
+See the
+[GitLab CI/CD docs](https://docs.gitlab.com/ee/ci/large_repositories/#shallow-cloning)
+for more information.
 
 </admon>
 

--- a/content/docs/user-guide/troubleshooting.md
+++ b/content/docs/user-guide/troubleshooting.md
@@ -133,8 +133,8 @@ and retry the DVC command. Specifically, one of:
 Local Git repositories can be unshallowed with `git fetch --unshallow`.
 
 Typically, however, this occurs in transient remote environments such as
-Continuous Integration jobs, which use shallow clones by default. In those cases,
-change their configuration to avoid shallow cloning. Common examples:
+Continuous Integration jobs, which use shallow clones by default. In those
+cases, change their configuration to avoid shallow cloning. Common examples:
 
 <toggle>
 <tab title="CML">
@@ -166,7 +166,7 @@ Set the `GIT_DEPTH` env var to `0`:
 
 ```yaml
 variables:
-  GIT_DEPTH: "0"
+  GIT_DEPTH: '0'
 ```
 
 > More info.


### PR DESCRIPTION
Closes https://github.com/iterative/dvc.org/issues/3416 (via this https://github.com/iterative/dvc.org/issues/3416#issuecomment-1089866190).

In review app: https://dvcorg-troubleshootingshallow.gtsb.io/doc/user-guide/troubleshooting#git-shallow