### PR TITLE
Stop build failing when a blog post has no header image

### DIFF
--- a/src/gatsby/models/blog/onCreateMarkdownContentNode.js
+++ b/src/gatsby/models/blog/onCreateMarkdownContentNode.js
@@ -72,7 +72,7 @@ async function createMarkdownBlogNode(api, { parentNode, createChildNode }) {
     }
   }
 
-  if (isProduction) {
+  if (isProduction && picture) {
     await mkdirp(path.join(__basedir, 'public', 'blog', 'images'), {
       recursive: true
     })


### PR DESCRIPTION
* Currently a build will fail if blog post has no image (See #3583)
* Not sure if the bug has always been there or started due to a recent change