### PR TITLE
replace exp list --all with --all-commits

### DIFF
--- a/content/docs/command-reference/exp/list.md
+++ b/content/docs/command-reference/exp/list.md
@@ -64,7 +64,7 @@ Let's say we have run 3 experiments in our project. You can quickly list the
 available experiments with this command:
 
 ```dvc
-$ dvc exp list --all
+$ dvc exp list --all-commits
 10-bigrams-experiment:
         exp-e6c97
         exp-1dad0
@@ -77,7 +77,7 @@ $ dvc exp list --all
 You can also list experiments in any DVC repo with `dvc exp list`:
 
 ```dvc
-$ dvc exp list --all git@github.com:iterative/example-get-started.git
+$ dvc exp list --all-commits git@github.com:iterative/example-get-started.git
 10-bigrams-experiment:
         exp-e6c97
         exp-86dd6
@@ -93,7 +93,7 @@ name instead:
 ```dvc
 $ git remote -v
 origin  git@github.com:iterative/example-get-started.git
-$ dvc exp list --all origin
+$ dvc exp list --all-commits origin
 10-bigrams-experiment:
         exp-e6c97
         exp-86dd6

--- a/content/docs/command-reference/exp/pull.md
+++ b/content/docs/command-reference/exp/pull.md
@@ -89,7 +89,7 @@ Let's say we have cloned a DVC repository, and would like to fetch an experiment
 that someone else shared (see also `dvc exp list`).
 
 ```dvc
-$ dvc exp list --all origin
+$ dvc exp list --all-commits origin
 master:
         exp-e6c97
 $ dvc exp pull origin exp-e6c97
@@ -99,7 +99,7 @@ Pulled experiment 'exp-e6c97' from Git remote 'origin'.
 We can now see that the experiment exists in the local repo:
 
 ```dvc
-$ dvc exp list --all
+$ dvc exp list --all-commits
 master:
         exp-e6c97
 ```

--- a/content/docs/command-reference/exp/push.md
+++ b/content/docs/command-reference/exp/push.md
@@ -84,7 +84,7 @@ This command will also try to [push](/doc/command-reference/push) all
 Let's say we have run 3 experiments in our project:
 
 ```dvc
-$ dvc exp list --all
+$ dvc exp list --all-commits
 11-bigrams-experiment:
         exp-e6c97
         exp-1dad0

--- a/content/docs/user-guide/experiment-management/cleaning-experiments.md
+++ b/content/docs/user-guide/experiment-management/cleaning-experiments.md
@@ -59,7 +59,7 @@ Supplying `--workspace` flag to `dvc exp gc` causes all experiments to be
 removed **except** those in the current workspace.
 
 ```dvc
-$ dvc exp list --all
+$ dvc exp list --all-commits
 main:
    exp-aaa000
    exp-aaa111
@@ -78,7 +78,7 @@ branches in this example.
 
 ```dvc
 $ dvc exp gc --workspace
-$ dvc exp list --all
+$ dvc exp list --all-commits
 main:
    exp-abc000
    exp-abc111


### PR DESCRIPTION
`dvc exp list --all` has been replaced by `dvc exp list --all-commits` (the former still works but is an undocumented alias).