### PR TITLE
Resize images for blogpost previews to preserve aspect ratio

### DIFF
--- a/src/@dvcorg/gatsby-theme-iterative/components/data/styles.module.css
+++ b/src/@dvcorg/gatsby-theme-iterative/components/data/styles.module.css
@@ -1,17 +1,17 @@
 .cmlIcon {
-  background-image: url('../../../../../static/img/cml_icon-color--square_vector.svg');
+  background-image: url("../../../../../static/img/cml_icon-color--square_vector.svg");
 }
 
 .dvcIcon {
-  background-image: url('../../../../../static/img/dvc_icon-color--square_vector.svg');
+  background-image: url("../../../../../static/img/dvc_icon-color--square_vector.svg");
 }
 
 .studioIcon {
-  background-image: url('../../../../../static/img/studio_icon-color--square_vector.svg');
+  background-image: url("../../../../../static/img/studio_icon-color--square_vector.svg");
 }
 
 .mlemIcon {
-  background-image: url('../../../../../static/img/mlem-icon.svg');
+  background-image: url("../../../../../static/img/mlem-icon.svg");
 }
 
 .other {

--- a/src/components/Blog/Feed/Item/styles.module.css
+++ b/src/components/Blog/Feed/Item/styles.module.css
@@ -47,8 +47,8 @@
 
 .picture {
   display: block;
-  width: 300px;
-  height: 250px;
+  width: calc(650px / 13 * 6);
+  height: calc(450px / 13 * 6);
   background-color: #dee8ed;
 
   @media (--md-scr) {


### PR DESCRIPTION
Thumbnails for blogpost header images are resized to a different aspect ratio. This results in some content being lost on the left and right sides, which can be problematic if there are logos or text in that area.

This change to the CSS resizes the images in a way that preserves the aspect ratio.

**Before:**

![Screenshot 2022-06-13 at 10 26 00](https://user-images.githubusercontent.com/7165065/173311709-63d908ef-4663-43c2-8e12-971cebc07fb9.png)

**After:**

![Screenshot 2022-06-13 at 10 26 18](https://user-images.githubusercontent.com/7165065/173311774-57cc3d5e-fba9-40de-8052-d36eafb8f8a4.png)

