### PR TITLE
nav: remove CML link

### DIFF
--- a/content/docs/sidebar.json
+++ b/content/docs/sidebar.json
@@ -523,35 +523,6 @@
     "type": "external"
   },
   {
-    "label": "CML",
-    "slug": "cml",
-    "source": "cml/index.md",
-    "icon": "cml",
-    "children": [
-      {
-        "label": "Get Started (GitHub)",
-        "slug": "start-github"
-      },
-      {
-        "label": "Get Started (GitLab)",
-        "slug": "start-gitlab"
-      },
-      "usage",
-      {
-        "label": "CML with DVC",
-        "slug": "cml-with-dvc"
-      },
-      {
-        "label": "Self-hosted Runners",
-        "slug": "self-hosted-runners"
-      },
-      {
-        "label": "Install as a Package",
-        "slug": "cml-with-npm"
-      }
-    ]
-  },
-  {
     "label": "Studio",
     "slug": "studio",
     "source": "studio/index.md",

--- a/content/docs/studio/index.md
+++ b/content/docs/studio/index.md
@@ -3,9 +3,9 @@
 [`Iterative Studio`](https://studio.iterative.ai/) is a web application that you
 can [access online](https://studio.iterative.ai/) or even host on-prem. It works
 with the data, metrics and hyperparameters that you add to your ML project
-repositories. Using the power of leading open-source tools DVC, CML and Git, it
-enables you to seamlessly manage data and models, run and track experiments, and
-visualize and share results.
+repositories. Using the power of leading open-source tools DVC,
+[CML](https://cml.dev) and Git, it enables you to seamlessly manage data and
+models, run and track experiments, and visualize and share results.
 
 <cards>
 

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -82,10 +82,7 @@ const plugins = [
   },
   'community-page',
   {
-    resolve: 'gatsby-plugin-catch-links',
-    options: {
-      excludePattern: /\/doc/
-    }
+    resolve: 'gatsby-plugin-catch-links'
   },
   {
     resolve: `gatsby-plugin-algolia`,

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -84,7 +84,7 @@ const plugins = [
   {
     resolve: 'gatsby-plugin-catch-links',
     options: {
-      excludePattern: /\/doc\/cml/
+      excludePattern: /\/doc/
     }
   },
   {


### PR DESCRIPTION
Leave redirect for now.

Why? The nav is growing a lot (VS Code section coming soon) and CML is already linked in several places as well as in the "Other tools" widgets.