### PR TITLE
Use Gatsby Script tag to add Reddit script

### DIFF
--- a/src/components/Blog/Layout/index.tsx
+++ b/src/components/Blog/Layout/index.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import { Script } from 'gatsby'
 import SEO from '@dvcorg/gatsby-theme-iterative/src/components/SEO'
 import { LayoutComponent } from '@dvcorg/gatsby-theme-iterative/src/components/MainLayout'
 import MainLayout from '../../../@dvcorg/gatsby-theme-iterative/components/MainLayout'
@@ -21,7 +22,7 @@ const Layout: LayoutComponent = ({ children, ...restProps }) => (
       keywords={keywords}
       pageInfo={restProps.pageContext.pageInfo}
     >
-      <script async src="//embed.redditmedia.com/widgets/platform.js" />
+      <Script async src="//embed.redditmedia.com/widgets/platform.js" />
     </SEO>
     {children}
   </MainLayout>


### PR DESCRIPTION
Gatsby 4.15 introduced a built-in `Script` component, which acts much like the HTML `script` element but does optimizations such as making scripts loaded with the Gatsby component load after Hydration, improving initial page load time.

It turns out this is the only `script` tag in the repo which isn't in the theme. There's another in `gatsby-ssr` but that one is meant to not be deferred. Probably won't gain us a ton of points, but figured I may as well push it.