### PR TITLE
Move Script tag outside of helmet

### DIFF
--- a/src/components/Blog/Layout/index.tsx
+++ b/src/components/Blog/Layout/index.tsx
@@ -15,15 +15,14 @@ const description =
 
 const Layout: LayoutComponent = ({ children, ...restProps }) => (
   <MainLayout {...restProps} className={styles.layoutBlog}>
+    <Script src="//embed.redditmedia.com/widgets/platform.js" />
     <SEO
       title="Blog"
       defaultMetaTitle
       description={description}
       keywords={keywords}
       pageInfo={restProps.pageContext.pageInfo}
-    >
-      <Script async src="//embed.redditmedia.com/widgets/platform.js" />
-    </SEO>
+    />
     {children}
   </MainLayout>
 )


### PR DESCRIPTION
After finding something that implements the reddit embed API, I realized #3677 actually broke it. Seems like the `Script` tag is incompatible with `Helmet`, but that's not an issue since the `Script` tag already moves its scripts to the bottom of the page regardless of where they are.

See demo of broken reddit embed [on this page](http://dvc.org/blog/july-19-dvc-heartbeat#how-do-you-manage-your-machine-learning-experiments-discussion-on-reddit-is-full-of-insights).

broken:
![image](https://user-images.githubusercontent.com/9111807/174890519-c115dffe-3af4-422c-b25f-fb66c362440f.png)

fixed:
![image](https://user-images.githubusercontent.com/9111807/174890575-6e45abb3-e7b9-467a-89e4-1c929bad0763.png)
