### PR TITLE
Remove mention of deprecated apt-key

### DIFF
--- a/content/docs/install/linux.md
+++ b/content/docs/install/linux.md
@@ -87,7 +87,9 @@ $ snap install --classic dvc
 $ sudo wget \
        https://dvc.org/deb/dvc.list \
        -O /etc/apt/sources.list.d/dvc.list
-$ wget -qO - https://dvc.org/deb/iterative.asc | sudo apt-key add -
+$ wget -qO - https://dvc.org/deb/iterative.asc | gpg --dearmor > packages.iterative.gpg
+$ sudo install -o root -g root -m 644 packages.iterative.gpg /etc/apt/trusted.gpg.d/
+$ rm -f packages.iterative.gpg
 $ sudo apt update
 $ sudo apt install dvc
 ```


### PR DESCRIPTION
`apt-key` is deprecated. New install steps inspired by: https://code.visualstudio.com/docs/setup/linux#_debian-and-ubuntu-based-distributions