### PR TITLE
install: add note regarding arm macos support

### DIFF
--- a/content/docs/install/macos.md
+++ b/content/docs/install/macos.md
@@ -2,8 +2,8 @@
 
 <admon type="tip">
 
-To use DVC [as a Python library](/doc/api-reference), please
-install [with `pip`](#install-with-pip) or [with `conda`](#install-with-conda).
+To use DVC [as a Python library](/doc/api-reference), please install
+[with `pip`](#install-with-pip) or [with `conda`](#install-with-conda).
 
 </admon>
 


### PR DESCRIPTION
Document that pip (and homebrew which uses pip) is the only supported installation method for ARM macs. Currently the conda packages and PKG binary installer are only built for x86.