### PR TITLE
ref: include import-url scenario in dvc update

### DIFF
--- a/content/docs/command-reference/update.md
+++ b/content/docs/command-reference/update.md
@@ -1,8 +1,8 @@
 # update
 
 Update files or directories imported from external <abbr>DVC repositories</abbr>
-or [URLs](/doc/command-reference/import-url#description),
-and the corresponding import `.dvc` files.
+or [URLs](/doc/command-reference/import-url#description), and the corresponding
+import `.dvc` files.
 
 ## Synopsis
 

--- a/content/docs/command-reference/update.md
+++ b/content/docs/command-reference/update.md
@@ -1,7 +1,7 @@
 # update
 
-Update files or directories imported from external <abbr>DVC
-repositories</abbr> or URLs, and the corresponding import `.dvc` files.
+Update files or directories imported from external <abbr>DVC repositories</abbr>
+or URLs, and the corresponding import `.dvc` files.
 
 ## Synopsis
 

--- a/content/docs/command-reference/update.md
+++ b/content/docs/command-reference/update.md
@@ -1,7 +1,8 @@
 # update
 
 Update files or directories imported from external <abbr>DVC repositories</abbr>
-or URLs, and the corresponding import `.dvc` files.
+or [URLs](/doc/command-reference/import-url#description),
+and the corresponding import `.dvc` files.
 
 ## Synopsis
 

--- a/content/docs/command-reference/update.md
+++ b/content/docs/command-reference/update.md
@@ -1,7 +1,7 @@
 # update
 
 Update files or directories imported from external <abbr>DVC
-repositories</abbr>, and the corresponding import `.dvc` files.
+repositories</abbr> or URLs, and the corresponding import `.dvc` files.
 
 ## Synopsis
 
@@ -18,7 +18,7 @@ positional arguments:
 
 After creating import stages (`.dvc` files) with `dvc import` or
 `dvc import-url`, the data source can change. Use `dvc update` to bring these
-imported file or directory up to date.
+imported files or directories up to date.
 
 To indicate which import stages to update, we can specify the corresponding
 `.dvc` file `targets` as command arguments.


### PR DESCRIPTION
Parts of the doc look like they predate `import-url`, so I added some text to clarify that it also updates external URLs from `import-url`.