### PR TITLE
gc: Add `--time` flag to dvc gc and dvc exp gc

### DIFF
--- a/content/docs/command-reference/exp/gc.md
+++ b/content/docs/command-reference/exp/gc.md
@@ -46,8 +46,8 @@ separately to delete it.
 
 - `--date <commit_date>` - Keep experiments from any commits on of after a
   certain date. Argument `<commit_date>` expects a date in the
-  [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html)
-  format (YYYY-MM-DD).
+  [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format
+  (YYYY-MM-DD).
 
 - `--queued` - keep also experiments that haven't been run yet (defined via
   `dvc exp run --queue`). Another scope option (`-w`, `-a`, etc.) is required

--- a/content/docs/command-reference/exp/gc.md
+++ b/content/docs/command-reference/exp/gc.md
@@ -44,8 +44,10 @@ separately to delete it.
   as from the last commit (implies `-w`). This is mainly needed when clearing
   `--queued` experiments (below).
 
-- `--date` - Keep experiments from the commits after (inclusive) a certain date.
-  Date must match the extended ISO 8601 format (YYYY-MM-DD).
+- `--date <commit_date>` - Keep experiments from any commits on of after a
+  certain date. Argument `<commit_date>` expects a date in the
+  [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html)
+  format (YYYY-MM-DD).
 
 - `--queued` - keep also experiments that haven't been run yet (defined via
   `dvc exp run --queue`). Another scope option (`-w`, `-a`, etc.) is required

--- a/content/docs/command-reference/exp/gc.md
+++ b/content/docs/command-reference/exp/gc.md
@@ -45,8 +45,8 @@ separately to delete it.
   as from the last commit (implies `-w`). This is mainly needed when clearing
   `--queued` experiments (below).
 
-- `--date <commit_date>` - Keep experiments from any commits on of after a
-  certain date. Argument `<commit_date>` expects a date in the
+- `--date <YYYY-MM-DD>` - Keep experiments from any commits on of after a
+  certain date. Argument `<YYYY-MM-DD>` expects a date in the
   [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format
   (YYYY-MM-DD).
 

--- a/content/docs/command-reference/exp/gc.md
+++ b/content/docs/command-reference/exp/gc.md
@@ -5,8 +5,9 @@ Remove unnecessary experiments from the <abbr>project</abbr>.
 ## Synopsis
 
 ```usage
-usage: dvc exp gc [-h] [-q | -v] [-w] [-a] [-T] [-A]
-                  [--date <commit_date>] [--queued] [-f]
+usage: dvc exp gc [-h] [-q | -v] [-w]
+                  [-a] [-T] [-A] [--date <commit_date>]
+                  [--queued] [-f]
 ```
 
 ## Description

--- a/content/docs/command-reference/exp/gc.md
+++ b/content/docs/command-reference/exp/gc.md
@@ -47,8 +47,7 @@ separately to delete it.
 
 - `--date <YYYY-MM-DD>` - Keep cached data referenced in the commits on of after
   a certain date. Argument `<YYYY-MM-DD>` expects a date in the
-  [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format
-  (YYYY-MM-DD).
+  [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format.
 
 - `--queued` - keep also experiments that haven't been run yet (defined via
   `dvc exp run --queue`). Another scope option (`-w`, `-a`, etc.) is required

--- a/content/docs/command-reference/exp/gc.md
+++ b/content/docs/command-reference/exp/gc.md
@@ -5,8 +5,8 @@ Remove unnecessary experiments from the <abbr>project</abbr>.
 ## Synopsis
 
 ```usage
-usage: dvc exp gc [-h] [-q | -v] [-w]
-                  [-a] [-T] [-A] [--queued] [-f]
+usage: dvc exp gc [-h] [-q | -v] [-w] [-a] [-T] [-A]
+                  [--date <commit_date>] [--queued] [-f]
 ```
 
 ## Description
@@ -43,6 +43,9 @@ separately to delete it.
 - `-A`, `--all-commits` - keep experiments derived from all Git commits, as well
   as from the last commit (implies `-w`). This is mainly needed when clearing
   `--queued` experiments (below).
+
+- `--date` - Keep experiments from the commits after (inclusive) a certain date.
+  Date must match the extended ISO 8601 format (YYYY-MM-DD).
 
 - `--queued` - keep also experiments that haven't been run yet (defined via
   `dvc exp run --queue`). Another scope option (`-w`, `-a`, etc.) is required

--- a/content/docs/command-reference/exp/gc.md
+++ b/content/docs/command-reference/exp/gc.md
@@ -6,7 +6,7 @@ Remove unnecessary experiments from the <abbr>project</abbr>.
 
 ```usage
 usage: dvc exp gc [-h] [-q | -v] [-w]
-                  [-a] [-T] [-A] [--date <commit_date>]
+                  [-a] [-T] [-A] [--date <YYYY-MM-DD>]
                   [--queued] [-f]
 ```
 
@@ -45,8 +45,8 @@ separately to delete it.
   as from the last commit (implies `-w`). This is mainly needed when clearing
   `--queued` experiments (below).
 
-- `--date <YYYY-MM-DD>` - Keep experiments from any commits on of after a
-  certain date. Argument `<YYYY-MM-DD>` expects a date in the
+- `--date <YYYY-MM-DD>` - Keep cached data referenced in the commits on of after
+  a certain date. Argument `<YYYY-MM-DD>` expects a date in the
   [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format
   (YYYY-MM-DD).
 

--- a/content/docs/command-reference/gc.md
+++ b/content/docs/command-reference/gc.md
@@ -99,8 +99,8 @@ project we want to clear.
 
 - `--date <commit_date>` - Keep experiments from any commits on of after a
   certain date. Argument `<commit_date>` expects a date in the
-  [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html)
-  format (YYYY-MM-DD).
+  [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format
+  (YYYY-MM-DD).
 
 - `--all-experiments` keep cached objects referenced in all [DVC experiments],
   as well as in the workspace (implying `-w`). This preserves the project's

--- a/content/docs/command-reference/gc.md
+++ b/content/docs/command-reference/gc.md
@@ -99,8 +99,7 @@ project we want to clear.
 
 - `--date <YYYY-MM-DD>` - Keep experiments from any commits on of after a
   certain date. Argument `<YYYY-MM-DD>` expects a date in the
-  [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format
-  (YYYY-MM-DD).
+  [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format.
 
 - `--all-experiments` keep cached objects referenced in all [DVC experiments],
   as well as in the workspace (implying `-w`). This preserves the project's

--- a/content/docs/command-reference/gc.md
+++ b/content/docs/command-reference/gc.md
@@ -96,8 +96,10 @@ project we want to clear.
 
   > \* Not including [DVC experiments]
 
-- `--date` - Keep cacheed data referenced in all commits after ( inclusive ) a
-  certain time. Date must match the extended ISO 8601 format (YYYY-MM-DD).
+- `--date <commit_date>` - Keep experiments from any commits on of after a
+  certain date. Argument `<commit_date>` expects a date in the
+  [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html)
+  format (YYYY-MM-DD).
 
 - `--all-experiments` keep cached objects referenced in all [DVC experiments],
   as well as in the workspace (implying `-w`). This preserves the project's

--- a/content/docs/command-reference/gc.md
+++ b/content/docs/command-reference/gc.md
@@ -6,7 +6,7 @@ Remove unused files and directories from <abbr>cache</abbr> or [remote storage].
 
 ```usage
 usage: dvc gc [-h] [-q | -v] [-w] [-a] [-T] [--all-commits]
-              [--date <commit_date>] [--all-experiments]
+              [--date <YYYY-MM-DD>] [--all-experiments]
               [-c] [-r <name>] [-f] [-j <number>]
               [-p [<path> [<path> ...]]]
 ```

--- a/content/docs/command-reference/gc.md
+++ b/content/docs/command-reference/gc.md
@@ -97,8 +97,8 @@ project we want to clear.
 
   > \* Not including [DVC experiments]
 
-- `--date <commit_date>` - Keep experiments from any commits on of after a
-  certain date. Argument `<commit_date>` expects a date in the
+- `--date <YYYY-MM-DD>` - Keep experiments from any commits on of after a
+  certain date. Argument `<YYYY-MM-DD>` expects a date in the
   [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format
   (YYYY-MM-DD).
 

--- a/content/docs/command-reference/gc.md
+++ b/content/docs/command-reference/gc.md
@@ -5,8 +5,9 @@ Remove unused files and directories from <abbr>cache</abbr> or [remote storage].
 ## Synopsis
 
 ```usage
-usage: dvc gc [-h] [-q | -v] [-w] [-a] [-T] [--all-commits] [--date <commit_date>]
-              [--all-experiments] [-c] [-r <name>] [-f] [-j <number>]
+usage: dvc gc [-h] [-q | -v] [-w] [-a] [-T] [--all-commits]
+              [--date <commit_date>] [--all-experiments]
+              [-c] [-r <name>] [-f] [-j <number>]
               [-p [<path> [<path> ...]]]
 ```
 

--- a/content/docs/command-reference/gc.md
+++ b/content/docs/command-reference/gc.md
@@ -5,7 +5,7 @@ Remove unused files and directories from <abbr>cache</abbr> or [remote storage].
 ## Synopsis
 
 ```usage
-usage: dvc gc [-h] [-q | -v] [-w] [-a] [-T] [--all-commits]
+usage: dvc gc [-h] [-q | -v] [-w] [-a] [-T] [--all-commits] [--date <commit_date>]
               [--all-experiments] [-c] [-r <name>] [-f] [-j <number>]
               [-p [<path> [<path> ...]]]
 ```
@@ -95,6 +95,9 @@ project we want to clear.
   be stored in the project's cache).
 
   > \* Not including [DVC experiments]
+
+- `--date` - Keep cacheed data referenced in all commits after ( inclusive ) a
+  certain time. Date must match the extended ISO 8601 format (YYYY-MM-DD).
 
 - `--all-experiments` keep cached objects referenced in all [DVC experiments],
   as well as in the workspace (implying `-w`). This preserves the project's


### PR DESCRIPTION
related to PR: https://github.com/iterative/dvc/pull/7970

> You may disregard these recommendations if you used the **Edit on GitHub** button from dvc.org to improve a doc in place.

❗ Please read the guidelines in the [Contributing to the Documentation](https://dvc.org/doc/user-guide/contributing/docs) list if you make any substantial changes to the documentation or JS engine.

🐛 Please make sure to mention `Fix #issue` (if applicable) in the description of the PR. This causes GitHub to close it automatically when the PR is merged.

Please choose to [allow us](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to edit your branch when creating the PR.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
