### PR TITLE
Remove static directory after heroku build

### DIFF
--- a/scripts/heroku-deploy.sh
+++ b/scripts/heroku-deploy.sh
@@ -4,3 +4,4 @@ mv $OLDPWD $NEWPWD
 ln -s $NEWPWD $OLDPWD
 cd $NEWPWD
 ./scripts/deploy-with-s3.js
+rm -rf static


### PR DESCRIPTION
I don't think we use this directory in production as all contents are copied to `public`. This will help us with our slug size issue on our websites, particularly with blogs.

The resulting slug is much smaller, and will probably scale just fine since it doesn't include infinitely scaling images.
```
-----> Compressing...

       Done: 192.1M
```