### PR TITLE
guide: remove term "pipelines files" (stick to "dvc.yaml" files)

### DIFF
--- a/content/docs/command-reference/config.md
+++ b/content/docs/command-reference/config.md
@@ -251,7 +251,7 @@ experiments or projects use a similar structure.
 
 - `parsing.bool` - Controls the templating syntax for boolean values when used
   in
-  [dict unpacking](/doc/user-guide/project-structure/pipelines-files#dict-unpacking).
+  [dict unpacking](/doc/user-guide/project-structure/dvcyaml-files#dict-unpacking).
 
   Valid values are `"store_true"` (default) and `"boolean_optional"`, named
   after
@@ -286,7 +286,7 @@ experiments or projects use a similar structure.
   ```
 
 - `parsing.list` - Controls the templating syntax for list values when used in
-  [dict unpacking](/doc/user-guide/project-structure/pipelines-files#dict-unpacking).
+  [dict unpacking](/doc/user-guide/project-structure/dvcyaml-files#dict-unpacking).
 
   Valid values are `"nargs"` (default) and `"append"`, named after
   [Python argparse actions](https://docs.python.org/3/library/argparse.html#action).

--- a/content/docs/command-reference/exp/init.md
+++ b/content/docs/command-reference/exp/init.md
@@ -60,7 +60,7 @@ See the `dvc.yaml` specification for more complex data pipelines.
 </admon>
 
 [stage definition]:
-  /doc/user-guide/project-structure/pipelines-files#stage-entries
+  /doc/user-guide/project-structure/dvcyaml-files#stage-entries
 [checkpoints]: /doc/user-guide/experiment-management/checkpoints
 [dvc experiments]: /doc/user-guide/experiment-management/experiments-overview
 

--- a/content/docs/command-reference/params/index.md
+++ b/content/docs/command-reference/params/index.md
@@ -70,7 +70,7 @@ The `dvc params diff` command is available to show parameter changes, displaying
 their current and previous values.
 
 💡 Parameters can also be used for
-[templating](/doc/user-guide/project-structure/pipelines-files#templating)
+[templating](/doc/user-guide/project-structure/dvcyaml-files#templating)
 `dvc.yaml` itself.
 
 ## Options

--- a/content/docs/sidebar.json
+++ b/content/docs/sidebar.json
@@ -112,8 +112,8 @@
         "source": "project-structure/index.md",
         "children": [
           {
-            "label": "Pipelines Files (dvc.yaml)",
-            "slug": "pipelines-files"
+            "label": "dvc.yaml Files",
+            "slug": "dvcyaml-files"
           },
           {
             "label": ".dvc Files",

--- a/content/docs/start/experiments/visualization.md
+++ b/content/docs/start/experiments/visualization.md
@@ -105,5 +105,5 @@ workflow:
 - [DVCLive] integrations can produce plots automatically during training.
 
 [plot outputs]:
-  /doc/user-guide/project-structure/pipelines-files#metrics-and-plots-outputs
+  /doc/user-guide/project-structure/dvcyaml-files#metrics-and-plots-outputs
 [dvclive]: /doc/dvclive/dvclive-with-dvc

--- a/content/docs/use-cases/experiment-tracking.md
+++ b/content/docs/use-cases/experiment-tracking.md
@@ -22,7 +22,7 @@ revisions. DVC's approach guarantees reproducibility by working on top of Git
 instead, and not as a separate system.
 
 [experiment management]: /doc/user-guide/experiment-management
-[codified with dvc]: /doc/user-guide/project-structure/pipelines-files
+[codified with dvc]: /doc/user-guide/project-structure/dvcyaml-files
 [versioning everything]: /doc/use-cases/versioning-data-and-model-files
 
 ```dvctable

--- a/content/docs/user-guide/experiment-management/index.md
+++ b/content/docs/user-guide/experiment-management/index.md
@@ -83,7 +83,7 @@ DVC takes care of arranging `dvc exp` experiments and the data
 until your experiments are made [persistent].
 
 [`foreach` stages]:
-  /doc/user-guide/project-structure/pipelines-files#foreach-stages
+  /doc/user-guide/project-structure/dvcyaml-files#foreach-stages
 [persistent]: /doc/user-guide/experiment-management/persisting-experiments
 
 ## Run Cache: Automatic Log of Stage Runs

--- a/content/docs/user-guide/experiment-management/running-experiments.md
+++ b/content/docs/user-guide/experiment-management/running-experiments.md
@@ -8,7 +8,7 @@ details.
 > experimentation, you may want to check the basics in
 > [Get Started: Experiments](/doc/start/experiments/) first.
 
-## Pipelines files
+## `dvc.yaml` files
 
 DVC relies on `dvc.yaml` files that contain the commands to run the
 experiment(s). These files codify _pipelines_ that specify one or more

--- a/content/docs/user-guide/project-structure/dvcyaml-files.md
+++ b/content/docs/user-guide/project-structure/dvcyaml-files.md
@@ -1,9 +1,9 @@
-# Pipelines Files (`dvc.yaml`)
+# `dvc.yaml`
 
 You can construct data science or machine learning pipelines by defining
-individual [stages](/doc/command-reference/run) in one or more `dvc.yaml` files
-(or _pipelines files_). Stages form a pipeline when they connect with each other
-(forming a _dependency graph_, see `dvc dag`). Refer to
+individual [stages](/doc/command-reference/run) in one or more `dvc.yaml` files.
+Stages form a pipeline when they connect with each other (forming a _dependency
+graph_, see `dvc dag`). Refer to
 [Get Started: Data Pipelines](/doc/start/data-pipelines).
 
 <admon type="tip">

--- a/content/docs/user-guide/project-structure/index.md
+++ b/content/docs/user-guide/project-structure/index.md
@@ -5,9 +5,9 @@ project</abbr>, including the internal `.dvc/` directory. From there on, you
 will create and manage different DVC files and populate the <abbr>cache</abbr>
 as you use DVC and work on your data science experiments.
 
-- `dvc.yaml` _pipelines files_ define stages that form the pipeline(s) of a
-  project. All stage-based features such as `dvc params`, `dvc metrics`, and
-  `dvc plots` are specified here.
+- `dvc.yaml` files define stages that form the pipeline(s) of a project. All
+  stage-based features such as `dvc params`, `dvc metrics`, and `dvc plots` are
+  specified here.
 
 - `.dvc` files ("dot DVC files") are placeholders to track data files and
   directories.

--- a/content/linked-terms.js
+++ b/content/linked-terms.js
@@ -1,11 +1,11 @@
 module.exports = [
   {
     matches: 'dvc.yaml',
-    url: '/doc/user-guide/project-structure/pipelines-files'
+    url: '/doc/user-guide/project-structure/dvcyaml-files'
   },
   {
     matches: 'dvc.lock',
-    url: '/doc/user-guide/project-structure/pipelines-files#dvclock-file'
+    url: '/doc/user-guide/project-structure/dvcyaml-files#dvclock-file'
   },
   {
     matches: '.dvc',

--- a/redirects-list.json
+++ b/redirects-list.json
@@ -19,7 +19,7 @@
 
   "^https://s\\.dvc\\.org/g/exp/run(.*)?$                                                https://dvc.org/doc/user-guide/experiment-management/running-experiments$1 302",
   "^https://s\\.dvc\\.org/g/exp/(.*)?$                                                   https://dvc.org/doc/user-guide/experiment-management/$1 302",
-  "^https://s\\.dvc\\.org/g/pipeline-files$                                              https://dvc.org/doc/user-guide/project-structure/pipelines-files 302",
+  "^https://s\\.dvc\\.org/g/pipeline-files$                                              https://dvc.org/doc/user-guide/project-structure/dvcyaml-files 302",
   "^https://s\\.dvc\\.org/g/(.*)?$                                                       https://dvc.org/doc/user-guide/$1 302",
   "^https://s\\.dvc\\.org/s/(.*)?$                                                       https://dvc.org/doc/start/$1 302",
   "^https://s\\.dvc\\.org/c/(.*)?$                                                       https://dvc.org/doc/use-cases/$1 302",
@@ -60,6 +60,7 @@
   "^/doc/user-guide/dvc-files$                                                            /doc/user-guide/project-structure",
   "^/doc/user-guide/dvc-files/dvc-yaml$                                                   /doc/user-guide/project-structure",
   "^/doc/user-guide/dvc-files/advanced-dvc-yaml$                                          /doc/user-guide/project-structure/pipelines-files",
+  "^/doc/user-guide/project-structure/pipelines-files$                                    /doc/user-guide/project-structure/dvcyaml-files",
   "^/doc/user-guide/dvc-files/.dvc$                                                       /doc/user-guide/project-structure/dvc-files",
   "^/doc/user-guide/dvc-internals(/.*)?$                                                  /doc/user-guide/project-structure/internal-files$1",
   "^/doc/user-guide/dvcignore$                                                            /doc/user-guide/project-structure/dvcignore-files",


### PR DESCRIPTION
Closes #3734

Main changes in
- content/docs/sidebar.json
- content/docs/user-guide/project-structure/index.md &
- content/docs/user-guide/project-structure/dvcyaml-files.md
- content/docs/user-guide/experiment-management/running-experiments.md
- redirects-list.json

The rest are link updates.