### PR TITLE
Remove out-of-date comment on link check deploy workflow

### DIFF
--- a/.github/workflows/link-check-deploy.yml
+++ b/.github/workflows/link-check-deploy.yml
@@ -1,6 +1,4 @@
 name: Check new links against deployment
-# This workflow "triggers" and skips on deployment because GitHub Actions /
-# Checks refuses to show the check on deployment_status
 on:
   - deployment_status
 jobs:


### PR DESCRIPTION
I missed this in #3700 and only caught it when starting to add it to our other websites