### PR TITLE
Fix MLEM and CML highlighting in the blog

### DIFF
--- a/src/components/Blog/Post/Markdown/styles.module.css
+++ b/src/components/Blog/Post/Markdown/styles.module.css
@@ -354,7 +354,9 @@
           color: rgb(204 204 204);
         }
 
-        .token.dvc {
+        .token.dvc,
+        .token.cml,
+        .token.mlem {
           font-weight: bold;
         }
 
@@ -445,7 +447,9 @@
         color: #0086b3;
       }
 
-      .token.dvc {
+      .token.dvc,
+      .token.cml,
+      .token.mlem {
         color: #56b1d0;
       }
 


### PR DESCRIPTION
Fixes an issue where MLEM and CML commands aren't being highlighted in code blocks in the blog. You can see an example of this [on our "Serving Models with MLEM" blog post.](https://dvc.org/blog/serving-models-with-mlem#serve-with-fastapi)

Before:
![image](https://user-images.githubusercontent.com/9111807/180800435-cf897725-69ff-4a10-890f-0a78b63a97c3.png)

After:
![image](https://user-images.githubusercontent.com/9111807/180800550-31dbe4fc-271a-4fe4-9201-17d8756920df.png)

Basically, Prism depends on some special CSS to actually add styles to the tokens it generates. We updated those styles in the docs, but the blog has a completely separate stylesheet which wasn't updated. The relevant parts got `.token.mlem` classes, but that blog stylesheet only targeted `.token.dvc`.
Whether we should have these parallel stylesheets is a good question, but this PR just intends to fix the problem and leave any bigger implementation questions for later.

Some commands still aren't highlighted:
![image](https://user-images.githubusercontent.com/9111807/180801551-8ea5635c-9b81-408a-b54c-c8474ff0a56f.png)

This is because `build` isn't added as a possible command in the theme's [`mlem-commands.js`](https://github.com/iterative/gatsby-theme-iterative/blob/main/packages/gatsby-theme-iterative/config/prismjs/mlem-commands.js)