### PR TITLE
hotfix: 302 redirect

### DIFF
--- a/redirects-list.json
+++ b/redirects-list.json
@@ -82,7 +82,7 @@
 
   "^/doc/vs-code-extension$                                                               https://marketplace.visualstudio.com/items?itemName=Iterative.dvc 302",
 
-  "^/doc/studio/overview$                                                                 /doc/studio/how-it-works",
+  "^/doc/studio/overview$                                                                 /doc/studio/how-it-works 302",
   "^/doc/studio/view-settings$                                                            /doc/studio/user-guide/views/view-settings",
   "^/doc/studio/user-guide/prepare-repositories$                                          /doc/studio/user-guide/prepare-your-repositories",
   "^/doc/studio/user-guide/explore-experiments$                                           /doc/studio/user-guide/views/explore-experiments",


### PR DESCRIPTION
This one ([just added](https://github.com/iterative/dvc.org/pull/3621/files#diff-a6828b19e9794c1fbb6799ea95263fb7487b676d054932b5f6e3b315eb12a6a2)) should be 302 in prep for possible #3622
