### PR TITLE
Use reusable link check workflows

### DIFF
--- a/.github/workflows/link-check-all.yml
+++ b/.github/workflows/link-check-all.yml
@@ -5,12 +5,4 @@ on:
     - cron: '0 0 * * *'
 jobs:
   run:
-    name: Link Check All
-    runs-on: ubuntu-latest
-    env:
-      NODE_OPTIONS: '--max-http-header-size=65536'
-    steps:
-      - uses: actions/checkout@v3
-      - name: Run Link Check
-        id: check
-        run: npx repo-link-check -d -c config/link-check/config.yml
+    uses: iterative/link-check/.github/workflows/link-check-all.yml@v0.13.0

--- a/.github/workflows/link-check-deploy.yml
+++ b/.github/workflows/link-check-deploy.yml
@@ -1,52 +1,6 @@
 name: Check new links against deployment
 on:
-  - deployment_status
+  deployment_status:
 jobs:
   run:
-    name: Run
-    runs-on: ubuntu-latest
-    if:
-      github.event.deployment.ref != 'main' &&
-      github.event.deployment_status.state == 'success'
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-      - name: Run Link Check
-        id: check
-        run: |
-          set +e
-          body="$(
-            npx repo-link-check \
-            -d -c config/link-check/config.yml \
-            -r ${{ github.event.deployment.payload.web_url }}
-          )"
-          body="${body//'%'/'%25'}"
-          body="${body//$'\n'/'%0A'}"
-          body="${body//$'\r'/'%0D'}"
-          echo "::set-output name=report::$body"
-          exit 0
-
-      - name: Find Current Pull Request
-        id: findPr
-        uses: jwalton/gh-find-current-pr@v1.3.0
-
-      - name: Find Existing Link Check Report Comment
-        uses: peter-evans/find-comment@v2
-        id: findComment
-        continue-on-error: true
-        with:
-          issue-number: ${{ steps.findPr.outputs.pr }}
-          comment-author: 'github-actions[bot]'
-          body-includes: <h1 id="link-check">Link Check Report</h1>
-
-      - name: Create or update comment
-        uses: peter-evans/create-or-update-comment@v2
-        with:
-          issue-number: ${{ steps.findPr.outputs.pr }}
-          comment-id: ${{ steps.findComment.outputs.comment-id }}
-          body: |
-            <h1 id="link-check">Link Check Report</h1>
-
-            ${{ steps.check.outputs.report }}
-          edit-mode: replace
+    uses: iterative/link-check/.github/workflows/link-check-deployment-status.yml@v0.13.0


### PR DESCRIPTION
https://github.com/iterative/mlem.ai/pull/146 = https://github.com/iterative/dvc.org/pull/3814 = https://github.com/iterative/cml.dev/pull/283

This PR extracts the link check workflows into [reusable workflows](https://docs.github.com/en/actions/using-workflows/reusing-workflows) located in [the link-check repo](https://github.com/iterative/link-check/tree/master/.github/workflows). Hopefully this will minimize the amount of copy-paste PRs on workflow updates, though depending on how we version it'll still require version bump PRs.