### PR TITLE
Fix typo

### DIFF
--- a/content/docs/use-cases/versioning-data-and-model-files/tutorial.md
+++ b/content/docs/use-cases/versioning-data-and-model-files/tutorial.md
@@ -315,7 +315,7 @@ command (`python train.py`) that was run to produce the result.
 > stage and its outputs to the repository.
 
 `dvc repro` will run the `train` stage if any of its dependencies (`-d`)
-changed. For example, when we added new images to built the second version of
+changed. For example, when we added new images to build the second version of
 our model, that was a dependency change. It also updates outputs and puts them
 into the <abbr>cache</abbr>.
 


### PR DESCRIPTION
I've fixed a minor typo in the "versioning data and model files" tutorial.
