### PR TITLE
Add a missing preposition "to"

### DIFF
--- a/content/docs/use-cases/fast-data-caching-hub.md
+++ b/content/docs/use-cases/fast-data-caching-hub.md
@@ -1,9 +1,9 @@
 # Fast and Secure Data Caching Hub
 
 Datasets used in data science tend to exceed typical storage and networking
-capacities. Storage needs expand rapidly as more people acquire the same data,
-creating duplication (increasing cost). Valuable time is wasted waiting for
-downloads in each environment.
+capacities. Storage needs to expand rapidly as more people acquire the same
+data, creating duplication (increasing cost). Valuable time is wasted waiting
+for downloads in each environment.
 
 ![](/img/dataset-copies.png) _Users wait for repeated transfers and produce
 multiple data copies locally._


### PR DESCRIPTION
I've added a missing preposition "to" in the "Fast and Secure Data Caching Hub" tutorial.

The change affects a few lines because of the required line wrap.