### PR TITLE
Fix typo

### DIFF
--- a/content/docs/use-cases/model-registry.md
+++ b/content/docs/use-cases/model-registry.md
@@ -3,7 +3,7 @@
 A **model registry** is a tool to catalog ML models and their versions. Models
 from your data science projects can be discovered, tested, shared, deployed, and
 audited from there. [DVC](/doc), [GTO], and [MLEM] enable these capabilities on
-top of Git, so you can stick to en existing software engineering stack. No more
+top of Git, so you can stick to an existing software engineering stack. No more
 divide between ML engineering and operations!
 
 ![](/img/ml_model_registry.jpg) _MLOps from modeling to production_


### PR DESCRIPTION
I've fixed a typo in the "Machine Learning Model Registry" tutorial.