### PR TITLE
Replace protected tweet embed with a static representation

### DIFF
--- a/config/link-check/excluded-links.yml
+++ b/config/link-check/excluded-links.yml
@@ -18,3 +18,4 @@
 - 'https://timheuer.com/blog/skipping-ci-github-actions-workflows/'
 - 'https://www.zazzle.com/t_shirt-235920696568133954'
 - 'https://medium.com**'
+- 'https://twitter.com/flavioclesio/status/*'

--- a/content/blog/2021-03-15-March-21-dvc-heartbeat.md
+++ b/content/blog/2021-03-15-March-21-dvc-heartbeat.md
@@ -177,13 +177,19 @@ image="/uploads/images/2021-03-15/arxiv.png"/>
 
 ## Tweet Love ❤️
 
-From a Porutguese speaking community member in Finland...
+From a Portuguese speaking community member in Finland...
 
 > "The @DVCorg surely it is among the best tools of the ecosystem of the last 3
 > years. It won't be long before DVC is as common as Scikit-Learn in ML / DS
 > projects with high maturity. 👏🏼👏🏼👏🏼"
 
-https://twitter.com/flavioclesio/status/1367187054749224961
+O [@DVCorg](https://twitter.com/DVCorg) seguramente está entre as melhores
+ferramentas do ecossistema dos últimos 3 anos. Não vai demorar para o DVC ser
+tão comum quanto o Scikit-Learn em projetos de ML/DS com alta maturidade. 👏👏👏
+https://t.co/nnfecYoTQv
+
+— Flávio Clésio (@flavioclesio)
+[March 3, 2021](https://twitter.com/flavioclesio/status/1367187054749224961)
 
 We think so too! 🙌🏼 You're all caught up! See you at the next Community Gems 💎!
 


### PR DESCRIPTION
The tweet that this PR changes recently became protected, likely due to the author marking their account protected for other reasons. This is a problem for us because `gatsby-remark-embedder` throws an error if it runs into a protected tweet, and even if we disabled that and went full client-side we still wouldn't be able to embed it.

This PR puts out the fire by changing the tweet in question into a static representation with a link to the original. The style is modeled after the original, and the change is nearly imperceptible.

https://user-images.githubusercontent.com/9111807/182909746-4f7555b5-613c-4d95-aea3-8aff160fe2e7.mp4
