### PR TITLE
Revert and remove static tweet

### DIFF
--- a/config/link-check/excluded-links.yml
+++ b/config/link-check/excluded-links.yml
@@ -18,4 +18,3 @@
 - 'https://timheuer.com/blog/skipping-ci-github-actions-workflows/'
 - 'https://www.zazzle.com/t_shirt-235920696568133954'
 - 'https://medium.com**'
-- 'https://twitter.com/flavioclesio/status/*'

--- a/content/blog/2021-03-15-March-21-dvc-heartbeat.md
+++ b/content/blog/2021-03-15-March-21-dvc-heartbeat.md
@@ -177,19 +177,13 @@ image="/uploads/images/2021-03-15/arxiv.png"/>
 
 ## Tweet Love ❤️
 
-From a Portuguese speaking community member in Finland...
+From a Porutguese speaking community member in Finland...
 
 > "The @DVCorg surely it is among the best tools of the ecosystem of the last 3
 > years. It won't be long before DVC is as common as Scikit-Learn in ML / DS
 > projects with high maturity. 👏🏼👏🏼👏🏼"
 
-O [@DVCorg](https://twitter.com/DVCorg) seguramente está entre as melhores
-ferramentas do ecossistema dos últimos 3 anos. Não vai demorar para o DVC ser
-tão comum quanto o Scikit-Learn em projetos de ML/DS com alta maturidade. 👏👏👏
-https://t.co/nnfecYoTQv
-
-— Flávio Clésio (@flavioclesio)
-[March 3, 2021](https://twitter.com/flavioclesio/status/1367187054749224961)
+https://twitter.com/flavioclesio/status/1367187054749224961
 
 We think so too! 🙌🏼 You're all caught up! See you at the next Community Gems 💎!
 

--- a/content/blog/2021-03-15-March-21-dvc-heartbeat.md
+++ b/content/blog/2021-03-15-March-21-dvc-heartbeat.md
@@ -175,17 +175,7 @@ image="/uploads/images/2021-03-15/arxiv.png"/>
 
 ![ScienceMindBlown](https://media.giphy.com/media/xT0xeJpnrWC4XWblEk/giphy.gif)
 
-## Tweet Love ❤️
-
-From a Porutguese speaking community member in Finland...
-
-> "The @DVCorg surely it is among the best tools of the ecosystem of the last 3
-> years. It won't be long before DVC is as common as Scikit-Learn in ML / DS
-> projects with high maturity. 👏🏼👏🏼👏🏼"
-
-https://twitter.com/flavioclesio/status/1367187054749224961
-
-We think so too! 🙌🏼 You're all caught up! See you at the next Community Gems 💎!
+You're all caught up! See you at the next Community Gems 💎!
 
 ---
 

--- a/content/blog/2021-03-15-March-21-dvc-heartbeat.md
+++ b/content/blog/2021-03-15-March-21-dvc-heartbeat.md
@@ -183,6 +183,13 @@ From a Portuguese speaking community member in Finland...
 > years. It won't be long before DVC is as common as Scikit-Learn in ML / DS
 > projects with high maturity. 👏🏼👏🏼👏🏼"
 
+O [@DVCorg](https://twitter.com/DVCorg) seguramente está entre as melhores
+ferramentas do ecossistema dos últimos 3 anos. Não vai demorar para o DVC ser
+tão comum quanto o Scikit-Learn em projetos de ML/DS com alta maturidade. 👏👏👏
+https://t.co/nnfecYoTQv
+
+— Flávio Clésio March 3, 2021
+
 We think so too! 🙌🏼 You're all caught up! See you at the next Community Gems 💎!
 
 ---

--- a/content/blog/2021-03-15-March-21-dvc-heartbeat.md
+++ b/content/blog/2021-03-15-March-21-dvc-heartbeat.md
@@ -175,7 +175,15 @@ image="/uploads/images/2021-03-15/arxiv.png"/>
 
 ![ScienceMindBlown](https://media.giphy.com/media/xT0xeJpnrWC4XWblEk/giphy.gif)
 
-You're all caught up! See you at the next Community Gems 💎!
+## Tweet Love ❤️
+
+From a Portuguese speaking community member in Finland...
+
+> "The @DVCorg surely it is among the best tools of the ecosystem of the last 3
+> years. It won't be long before DVC is as common as Scikit-Learn in ML / DS
+> projects with high maturity. 👏🏼👏🏼👏🏼"
+
+We think so too! 🙌🏼 You're all caught up! See you at the next Community Gems 💎!
 
 ---
 


### PR DESCRIPTION
Reverts iterative/dvc.org#3864

from https://github.com/iterative/dvc.org/issues/3865#issuecomment-1205653477

> > Just paste the tweet in as a blockquote
> 
> we can't do this, Twitter has certain rules about embedding their tweets (put a logo, etc).

> In this case I would just keep a quote and link to person's name.

I merged #3864 before I read this, so this PR changes to a static quote with a name and no tweet link.