### PR TITLE
docs: mention that dvc requires Python 3.8 now

### DIFF
--- a/content/docs/contributing/core.md
+++ b/content/docs/contributing/core.md
@@ -42,7 +42,7 @@ Get the latest development version. Fork and clone the repo:
 $ git clone git@github.com:<your-username>/dvc.git
 ```
 
-Make sure that you have Python 3.7 or higher installed. On macOS, we recommend
+Make sure that you have Python 3.8 or higher installed. On macOS, we recommend
 using `brew` to install Python. For Windows, we recommend an official
 [python.org release](https://www.python.org/downloads/windows/).
 

--- a/content/docs/contributing/docs.md
+++ b/content/docs/contributing/docs.md
@@ -56,7 +56,7 @@ changes before submitting them, and it's quite necessary when making changes to
 the website engine itself. Source code and content files need to be properly
 formatted and linted as well, which is also ensured by the full setup below.
 
-Make sure you have [Python](https://www.python.org/downloads/) 3.7+, a recent
+Make sure you have [Python](https://www.python.org/downloads/) 3.8+, a recent
 LTS version of [Node.js](https://nodejs.org/en/) (`>=14.0.0`, `<=18.x`), and
 install [Yarn](https://yarnpkg.com/):
 

--- a/content/docs/install/linux.md
+++ b/content/docs/install/linux.md
@@ -11,7 +11,7 @@
 > [pipx](https://packaging.python.org/guides/installing-stand-alone-command-line-tools/)
 > to encapsulate your local environment.
 
-> ⚠️ Note that Python 3.7+ is needed to get the latest version of DVC.
+> ⚠️ Note that Python 3.8+ is needed to get the latest version of DVC.
 
 ```dvc
 $ pip install dvc

--- a/content/docs/install/macos.md
+++ b/content/docs/install/macos.md
@@ -45,7 +45,7 @@ from the [release page](https://github.com/iterative/dvc/releases/) on GitHub.
 > [pipx](https://packaging.python.org/guides/installing-stand-alone-command-line-tools/)
 > to encapsulate your local environment.
 
-> ⚠️ Note that Python 3.7+ is needed to get the latest version of DVC.
+> ⚠️ Note that Python 3.8+ is needed to get the latest version of DVC.
 
 ```dvc
 $ pip install dvc

--- a/content/docs/install/pre-release.md
+++ b/content/docs/install/pre-release.md
@@ -7,7 +7,7 @@ releases, you can install it from our code repository GitHub.
 > [virtual environment](https://python.readthedocs.io/en/stable/library/venv.html)
 > or using
 > [pipx](https://packaging.python.org/guides/installing-stand-alone-command-line-tools/)
-> (on Python 3.7+) to encapsulate your local environment.
+> (on Python 3.8+) to encapsulate your local environment.
 
 ```dvc
 # Plain DVC


### PR DESCRIPTION
DVC requires Python 3.8 at a minimum since [2.11.0](https://github.com/iterative/dvc/releases/tag/2.11.0) (https://github.com/iterative/dvc/pull/7826). Updating the docs to reflect that. 