### PR TITLE
Use internal-use tag in link-check

### DIFF
--- a/.github/workflows/link-check-all.yml
+++ b/.github/workflows/link-check-all.yml
@@ -5,4 +5,4 @@ on:
     - cron: '0 0 * * *'
 jobs:
   run:
-    uses: iterative/link-check/.github/workflows/link-check-all.yml@v0.13.0
+    uses: iterative/link-check/.github/workflows/link-check-all.yml@internal-use

--- a/.github/workflows/link-check-deploy.yml
+++ b/.github/workflows/link-check-deploy.yml
@@ -3,4 +3,4 @@ on:
   deployment_status:
 jobs:
   run:
-    uses: iterative/link-check/.github/workflows/link-check-deployment-status.yml@v0.13.0
+    uses: iterative/link-check/.github/workflows/link-check-deployment-status.yml@internal-use


### PR DESCRIPTION
# https://github.com/iterative/dvc.org/pull/3878 = https://github.com/iterative/mlem.ai/pull/155 = https://github.com/iterative/cml.dev/pull/300 = https://github.com/iterative/iterative.ai/pull/542

These PRs change the version of link check to be pinned to a git tag on the link check repo called `internal-use`, which currently points to https://github.com/iterative/link-check/pull/22, making the default check only show failing links instead of showing all links including passing ones.

This `internal-use` git tag can be moved to different versions and updated independently of the default branch, which could be useful for temporarily testing features on our sites with the link checker.