### PR TITLE
Quick fix for heroku crash

### DIFF
--- a/src/server/middleware/api/comments.js
+++ b/src/server/middleware/api/comments.js
@@ -20,7 +20,7 @@ const getCommentCount = async (req, res) => {
     query: { url }
   } = req
 
-  if (!url.startsWith(FORUM_URL)) {
+  if (!url || !url.startsWith(FORUM_URL)) {
     res.status(400)
 
     return

--- a/src/server/middleware/api/comments.js
+++ b/src/server/middleware/api/comments.js
@@ -20,7 +20,7 @@ const getCommentCount = async (req, res) => {
     query: { url }
   } = req
 
-  if (!url || !url.startsWith(FORUM_URL)) {
+  if (!(url && url.startsWith(FORUM_URL))) {
     res.status(400)
 
     return


### PR DESCRIPTION
check `url` exists before checking `url.startsWith`.

```
 Aug 19 22:46:53 dvc-org app/web.1 ^
 Aug 19 22:46:53 dvc-org app/web.1 TypeError: Cannot read properties of undefined (reading 'startsWith')
 Aug 19 22:46:53 dvc-org app/web.1 at getCommentCount (/app/src/server/middleware/api/comments.js:23:12)
 Aug 19 22:46:53 dvc-org app/web.1 at Layer.handle [as handle_request] (/app/node_modules/express/lib/router/layer.js:95:5)
 Aug 19 22:46:53 dvc-org app/web.1 at next (/app/node_modules/express/lib/router/route.js:144:13)
 Aug 19 22:46:53 dvc-org app/web.1 at Route.dispatch (/app/node_modules/express/lib/router/route.js:114:3)
 Aug 19 22:46:53 dvc-org app/web.1 at Layer.handle [as handle_request] (/app/node_modules/express/lib/router/layer.js:95:5)
 Aug 19 22:46:53 dvc-org app/web.1 at /app/node_modules/express/lib/router/index.js:284:15
 Aug 19 22:46:53 dvc-org app/web.1 at Function.process_params (/app/node_modules/express/lib/router/index.js:346:12)
 Aug 19 22:46:53 dvc-org app/web.1 at next (/app/node_modules/express/lib/router/index.js:280:10)
 Aug 19 22:46:53 dvc-org app/web.1 at Function.handle (/app/node_modules/express/lib/router/index.js:175:3)
 Aug 19 22:46:53 dvc-org app/web.1     at router (/app/node_modules/express/lib/router/index.js:47:12)
 Aug 19 22:46:53 dvc-org app/web.1 Node.js v18.7.0
```