### PR TITLE
Add blog to navbar

### DIFF
--- a/src/@dvcorg/gatsby-theme-iterative/components/HamburgerMenu/index.tsx
+++ b/src/@dvcorg/gatsby-theme-iterative/components/HamburgerMenu/index.tsx
@@ -99,6 +99,15 @@ export const HamburgerMenu: React.FC<
         </li>
         <li className={styles.section}>
           <Link
+            href="https://iterative.ai/blog"
+            className={styles.sectionHeading}
+            onClick={() => handleItemClick('blog')}
+          >
+            Blog
+          </Link>
+        </li>
+        <li className={styles.section}>
+          <Link
             href="https://learn.iterative.ai/"
             className={styles.sectionHeading}
             onClick={() => handleItemClick('course')}

--- a/src/@dvcorg/gatsby-theme-iterative/components/data/menu.ts
+++ b/src/@dvcorg/gatsby-theme-iterative/components/data/menu.ts
@@ -49,6 +49,11 @@ const menuData: IMenuData = {
       text: 'Doc'
     },
     {
+      href: 'https://iterative.ai/blog/',
+      eventType: 'blog',
+      text: 'Blog'
+    },
+    {
       href: 'https://learn.iterative.ai/',
       eventType: 'course',
       text: 'Course'


### PR DESCRIPTION
Once we work on the categorization of blogs, I believe we will have a separate page for the DVC blog and we can link to that.
Related:
- https://github.com/iterative/cml.dev/pull/302
- https://github.com/iterative/mlem.ai/pull/157