### PR TITLE
Manually add renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:base", "group:allNonMajor"]
+}


### PR DESCRIPTION
This PR manually adds renovate config since the onboarding PR is taking its time. Also adds `group:allNonMajor`.