### PR TITLE
ref: reorg and wrap `import` usage block

### DIFF
--- a/content/docs/command-reference/import.md
+++ b/content/docs/command-reference/import.md
@@ -8,9 +8,10 @@ Download a file or directory tracked by another DVC or Git repository into the
 ## Synopsis
 
 ```usage
-usage: dvc import [-h] [-q | -v] [-j <number>]
-                  [-o <path>] [--file <filename>]
-                  [--rev <commit>] [--no-exec | --no-download] [--desc <text>]
+usage: dvc import [-h] [-q | -v] [--file <filename>]
+                  [-o <path>] [--rev <commit>]
+                  [--no-exec | --no-download]
+                  [-j <number>] [--desc <text>]
                   url path
 
 positional arguments:


### PR DESCRIPTION
Prevents horizontal scrolling in https://dvc.org/doc/command-reference/import#synopsis.

> Edited from GH so couldn't combine with https://github.com/iterative/dvc.org/pull/3934, sorry.