### PR TITLE
plots: mention dir support and update templates

### DIFF
--- a/content/docs/command-reference/plots/index.md
+++ b/content/docs/command-reference/plots/index.md
@@ -19,8 +19,9 @@ positional arguments:
                 in a single image.
     modify      Modify display properties of data-series plots
                 defined in stages (has no effect on image plots).
-    templates   Write built-in plots templates to a directory
-                (.dvc/plots by default).
+
+    templates   List built-in plots templates or show JSON
+                specification for one.
 ```
 
 ## Description

--- a/content/docs/command-reference/plots/index.md
+++ b/content/docs/command-reference/plots/index.md
@@ -19,7 +19,6 @@ positional arguments:
                 in a single image.
     modify      Modify display properties of data-series plots
                 defined in stages (has no effect on image plots).
-
     templates   List built-in plots templates or show JSON
                 specification for one.
 ```

--- a/content/docs/user-guide/project-structure/dvcyaml-files.md
+++ b/content/docs/user-guide/project-structure/dvcyaml-files.md
@@ -537,9 +537,9 @@ libraries in the environment.
 ## Top-level plot definitions
 
 The `plots` dictionary contains one or more user-defined `dvc plots`
-configurations. Every plot needs a unique ID, which may be either a file path
-(relative to the location of `dvc.yaml`) or an arbitrary string. Optional
-configuration fields can be provided as well.
+configurations. Every plot needs a unique ID, which may be either a file or
+directory path (relative to the location of `dvc.yaml`) or an arbitrary string.
+Optional configuration fields can be provided as well.
 
 📖 Refer to [Visualizing Plots] and `dvc plots show` for examples.
 


### PR DESCRIPTION
Minor updates to address https://github.com/iterative/dvcyaml-schema/pull/16#discussion_r968801509 (and an unrelated change for `dvc plots templates`).

I don't see a good place to mention support for `plots outputs` dir support specifically. Since it's a subset of both `top-level plots` and `outputs`, both of which support dirs, I don't know if an explicit mention is needed, but open to suggestions.