### PR TITLE
docs: rename `dvc ls` to `dvc list` to link

### DIFF
--- a/content/docs/api-reference/dvcfilesystem.md
+++ b/content/docs/api-reference/dvcfilesystem.md
@@ -66,7 +66,7 @@ bytes instead of a string.
 ]
 ```
 
-This is similar to `dvc ls --recursive --dvc-only` CLI command. Note that the
+This is similar to `dvc list --recursive --dvc-only` CLI command. Note that the
 `"/"` is considered as the root of the Git repo. You can specify sub-paths to
 only return entries in that directory. Similarly, there is `fs.ls()` that is
 non-recursive.
@@ -96,7 +96,7 @@ non-recursive.
 ]
 ```
 
-This is similar to `dvc ls --recursive` CLI command. It returns all of the files
+This is similar to `dvc list --recursive` CLI command. It returns all of the files
 tracked by DVC and Git and if filesystem is opened locally, it also includes the
 local untracked files.
 

--- a/content/docs/api-reference/dvcfilesystem.md
+++ b/content/docs/api-reference/dvcfilesystem.md
@@ -96,9 +96,9 @@ non-recursive.
 ]
 ```
 
-This is similar to `dvc list --recursive` CLI command. It returns all of the files
-tracked by DVC and Git and if filesystem is opened locally, it also includes the
-local untracked files.
+This is similar to `dvc list --recursive` CLI command. It returns all of the
+files tracked by DVC and Git and if filesystem is opened locally, it also
+includes the local untracked files.
 
 ## Downloading a file or a directory
 


### PR DESCRIPTION
Alias does not seem to get automatically linked if they there are other flags.

> You may disregard these recommendations if you used the **Edit on GitHub** button from dvc.org to improve a doc in place.

❗ Please read the guidelines in the [Contributing to the Documentation](https://dvc.org/doc/user-guide/contributing/docs) list if you make any substantial changes to the documentation or JS engine.

🐛 Please make sure to mention `Fix #issue` (if applicable) in the description of the PR. This causes GitHub to close it automatically when the PR is merged.

Please choose to [allow us](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to edit your branch when creating the PR.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
