### PR TITLE
api docs: use `f` instead of `fd`, and file-like object instead of file descriptor

### DIFF
--- a/content/docs/api-reference/dvcfilesystem.md
+++ b/content/docs/api-reference/dvcfilesystem.md
@@ -34,8 +34,8 @@ or a tag name, a commit hash, or an [experiment name]).
 ## Opening a file
 
 ```py
->>> with fs.open("model.pkl") as fobj:
-        model = pickle.load(fobj)
+>>> with fs.open("model.pkl") as f:
+        model = pickle.load(f)
 ```
 
 This is similar to `dvc.api.open()` which returns a file-like object. Note that,

--- a/content/docs/api-reference/make_checkpoint.md
+++ b/content/docs/api-reference/make_checkpoint.md
@@ -73,15 +73,15 @@ from dvc.api import make_checkpoint
 while True:
     try:
         if os.path.exists("int.txt"):
-            with open("int.txt", "r") as fd:
-                i_ = int(fd.read()) + 1
+            with open("int.txt", "r") as f:
+                i_ = int(f.read()) + 1
         else:
             i_ = 0
 
         # ... do something meaningful
 
-        with open("int.txt", "w") as fd:
-            fd.write(f"{i_}")
+        with open("int.txt", "w") as f:
+            f.write(f"{i_}")
 
         if i_ % 100 == 0:
             make_checkpoint()

--- a/content/docs/api-reference/open.md
+++ b/content/docs/api-reference/open.md
@@ -19,8 +19,8 @@ import dvc.api
 with dvc.api.open(
         'get-started/data.xml',
         repo='https://github.com/iterative/dataset-registry'
-        ) as fd:
-    # ... fd is a file descriptor that can be processed normally.
+        ) as f:
+    # ... f is a file-like object that can be processed normally.
 ```
 
 ## Description
@@ -104,8 +104,8 @@ from mymodule import mySAXHandler
 with dvc.api.open(
         'get-started/data.xml',
         repo='https://github.com/iterative/dataset-registry'
-        ) as fd:
-    parse(fd, mySAXHandler)
+        ) as f:
+    parse(f, mySAXHandler)
 ```
 
 Notice that we use a [SAX](http://www.saxproject.org/) XML parser here because
@@ -139,7 +139,7 @@ import dvc.api
 with dvc.api.open(
         'features.dat',
         repo='git@server.com:path/to/repo.git'
-        ) as fd:
+        ) as f:
     # ... Process 'features'
 ```
 
@@ -157,8 +157,8 @@ import dvc.api
 with dvc.api.open(
         'clean.csv',
         rev='v1.1.0'
-        ) as fd:
-    reader = csv.reader(fd)
+        ) as f:
+    reader = csv.reader(f)
     # ... Process 'clean' data from version 1.1.0
 ```
 
@@ -181,8 +181,8 @@ with dvc.api.open(
         'activity.log',
         repo='location/of/dvc/project',
         remote='my-s3-bucket'
-        ) as fd:
-    for line in fd:
+        ) as f:
+    for line in f:
         match = re.search(r'user=(\w+)', line)
         # ... Process users activity log
 ```
@@ -196,6 +196,6 @@ import dvc.api
 
 with dvc.api.open(
         'data/nlp/words_ru.txt',
-        encoding='koi8_r') as fd:
+        encoding='koi8_r') as f:
     # ... Process Russian words
 ```

--- a/content/docs/start/data-management/data-and-model-access.md
+++ b/content/docs/start/data-management/data-and-model-access.md
@@ -113,6 +113,6 @@ import dvc.api
 with dvc.api.open(
     'get-started/data.xml',
     repo='https://github.com/iterative/dataset-registry'
-) as fd:
-    # fd is a file descriptor which can be processed normally
+) as f:
+    # f is a file-like object which can be processed normally
 ```

--- a/content/docs/use-cases/data-registry/tutorial.md
+++ b/content/docs/use-cases/data-registry/tutorial.md
@@ -122,12 +122,12 @@ import dvc.api.open
 model_path = 'model.pkl'
 repo_url = 'https://github.com/example/registry'
 
-with dvc.api.open(model_path, repo_url) as fd:
-    model = pickle.load(fd)
+with dvc.api.open(model_path, repo_url) as f:
+    model = pickle.load(f)
     # ... Use the model!
 ```
 
-This opens `model.pkl` as a file descriptor. This example illustrates a simple
+This opens `model.pkl` as a file-like object. This example illustrates a simple
 ML model **deployment** method, but it could be extended to more advanced
 scenarios such as a _model zoo_.
 


### PR DESCRIPTION
`fd` means file-descriptor which is not what `open` or `fs.open()` returns. It returns a [file-like object](https://docs.python.org/3/glossary.html#term-file-like-object). 

Both `open()` and `Path.open()` uses `f` in Python's docs. 
1. https://docs.python.org/3/library/functions.html#open
2. https://docs.python.org/3/library/pathlib.html#pathlib.Path.open

`fsspec` does the same: https://filesystem-spec.readthedocs.io/en/latest/api.html#fsspec.open.
