### PR TITLE
docs: fix code formatting/indentations

### DIFF
--- a/content/docs/api-reference/get_url.md
+++ b/content/docs/api-reference/get_url.md
@@ -17,8 +17,8 @@ import dvc.api
 
 resource_url = dvc.api.get_url(
     'get-started/data.xml',
-    repo='https://github.com/iterative/dataset-registry')
-
+    repo='https://github.com/iterative/dataset-registry'
+)
 # resource_url is now "https://remote.dvc.org/dataset-registry/a3/04afb96060aad90176268345e10355"
 ```
 
@@ -84,9 +84,8 @@ import dvc.api
 
 resource_url = dvc.api.get_url(
     'get-started/data.xml',
-    repo='https://github.com/iterative/dataset-registry'
-    )
-
+    repo='https://github.com/iterative/dataset-registry',
+)
 print(resource_url)
 ```
 

--- a/content/docs/api-reference/open.md
+++ b/content/docs/api-reference/open.md
@@ -17,9 +17,9 @@ def open(path: str,
 import dvc.api
 
 with dvc.api.open(
-        'get-started/data.xml',
-        repo='https://github.com/iterative/dataset-registry'
-        ) as f:
+    'get-started/data.xml',
+    repo='https://github.com/iterative/dataset-registry'
+) as f:
     # ... f is a file-like object that can be processed normally.
 ```
 
@@ -102,9 +102,9 @@ import dvc.api
 from mymodule import mySAXHandler
 
 with dvc.api.open(
-        'get-started/data.xml',
-        repo='https://github.com/iterative/dataset-registry'
-        ) as f:
+    'get-started/data.xml',
+    repo='https://github.com/iterative/dataset-registry'
+) as f:
     parse(f, mySAXHandler)
 ```
 
@@ -121,8 +121,8 @@ usage), and is typically faster than loading the whole data into memory.
 > from xml.dom.minidom import parse
 > import dvc.api
 >
-> xmldata = dvc.api.read('get-started/data.xml',
->     repo='https://github.com/iterative/dataset-registry')
+> url = 'https://github.com/iterative/dataset-registry'
+> xmldata = dvc.api.read('get-started/data.xml', repo=url)
 > xmldom = parse(xmldata)
 > ```
 
@@ -137,9 +137,9 @@ locally):
 import dvc.api
 
 with dvc.api.open(
-        'features.dat',
-        repo='git@server.com:path/to/repo.git'
-        ) as f:
+    'features.dat',
+    repo='git@server.com:path/to/repo.git'
+) as f:
     # ... Process 'features'
 ```
 
@@ -154,10 +154,7 @@ CSV dataset:
 import csv
 import dvc.api
 
-with dvc.api.open(
-        'clean.csv',
-        rev='v1.1.0'
-        ) as f:
+with dvc.api.open('clean.csv', rev='v1.1.0') as f:
     reader = csv.reader(f)
     # ... Process 'clean' data from version 1.1.0
 ```
@@ -177,11 +174,7 @@ providing a `remote` argument:
 ```py
 import dvc.api
 
-with dvc.api.open(
-        'activity.log',
-        repo='location/of/dvc/project',
-        remote='my-s3-bucket'
-        ) as f:
+with dvc.api.open('activity.log', remote='my-s3-bucket') as f:
     for line in f:
         match = re.search(r'user=(\w+)', line)
         # ... Process users activity log
@@ -194,8 +187,6 @@ To chose which codec to open a text file with, send an `encoding` argument:
 ```py
 import dvc.api
 
-with dvc.api.open(
-        'data/nlp/words_ru.txt',
-        encoding='koi8_r') as f:
+with dvc.api.open('data/nlp/words_ru.txt', encoding='koi8_r') as f:
     # ... Process Russian words
 ```

--- a/content/docs/api-reference/read.md
+++ b/content/docs/api-reference/read.md
@@ -19,7 +19,8 @@ import dvc.api
 modelpkl = dvc.api.read(
     'model.pkl',
     repo='https://github.com/iterative/example-get-started',
-    mode='rb')
+    mode='rb'
+)
 ```
 
 ## Description
@@ -91,13 +92,12 @@ unserialize a binary model from a repo on GitHub:
 import pickle
 import dvc.api
 
-model = pickle.loads(
-    dvc.api.read(
-        'model.pkl',
-        repo='https://github.com/iterative/example-get-started'
-        mode='rb'
-        )
-    )
+data = dvc.api.read(
+    'model.pkl',
+    repo='https://github.com/iterative/example-get-started'
+    mode='rb'
+)
+model = pickle.loads(data)
 ```
 
 > We're using `'rb'` mode here for compatibility with `pickle.loads()`.


### PR DESCRIPTION
- Adding hanging indent where matters
- moving end-bracket to a newline (without indent) like how `black` does
- reducing indentations from 8 to 4
- trying to fit some code into a single line (I did not see any reason to hang some of them).