### PR TITLE
doc: add doc about foreach target

### DIFF
--- a/content/docs/command-reference/checkout.md
+++ b/content/docs/command-reference/checkout.md
@@ -12,7 +12,7 @@ usage: dvc checkout [-h] [-q | -v] [--summary] [-d] [-R] [-f]
 
 positional arguments:
   targets       Limit command scope to these tracked files/directories,
-                .dvc files, or stage names.
+                .dvc files and stage or foreach-group names.
 ```
 
 ## Description

--- a/content/docs/command-reference/commit.md
+++ b/content/docs/command-reference/commit.md
@@ -9,7 +9,8 @@ usage: dvc commit [-h] [-q | -v] [-f] [-d] [-R]
                   [targets [targets ...]]
 
 positional arguments:
-  targets        Limit command scope to these stages or .dvc files.
+  targets        Limit command scope to these tracked files/directories,
+                 .dvc files and stage or foreach-group names.
                  Using -R, directories to search for stages or .dvc
                  files can also be given.
 ```

--- a/content/docs/command-reference/dag.md
+++ b/content/docs/command-reference/dag.md
@@ -11,7 +11,7 @@ usage: dvc dag [-h] [-q | -v] [-o] [--full]
                [target]
 
 positional arguments:
-  target          Stage or output to show pipeline for (optional)
+  target          Stage name, foreach-group name output to show pipeline for.
                   Uses all stages in the workspace by default.
 ```
 

--- a/content/docs/command-reference/fetch.md
+++ b/content/docs/command-reference/fetch.md
@@ -12,7 +12,7 @@ usage: dvc fetch [-h] [-q | -v] [-j <number>] [-r <name>] [-a] [-T]
 
 positional arguments:
   targets       Limit command scope to these tracked files/directories,
-                .dvc files, or stage names.
+                .dvc files and stage or foreach-group names.
 ```
 
 ## Description

--- a/content/docs/command-reference/pull.md
+++ b/content/docs/command-reference/pull.md
@@ -13,7 +13,7 @@ usage: dvc pull [-h] [-q | -v] [-j <number>] [-r <name>] [-a] [-T]
 
 positional arguments:
   targets       Limit command scope to these tracked files/directories,
-                .dvc files, or stage names.
+                .dvc files and stage or foreach-group names.
 ```
 
 ## Description

--- a/content/docs/command-reference/push.md
+++ b/content/docs/command-reference/push.md
@@ -13,7 +13,7 @@ usage: dvc push [-h] [-q | -v] [-j <number>] [-r <name>] [-a] [-T]
 
 positional arguments:
   targets       Limit command scope to these tracked files/directories,
-                .dvc files, or stage names.
+                .dvc files and stage or foreach-group names.
 ```
 
 ## Description

--- a/content/docs/command-reference/status.md
+++ b/content/docs/command-reference/status.md
@@ -14,7 +14,7 @@ usage: dvc status [-h] [-v] [-j <number>] [-q] [-c] [-r <name>] [-a] [-T]
 
 positional arguments:
   targets       Limit command scope to these tracked files/directories,
-                .dvc files, or stage names.
+                .dvc files and stage or foreach-group names.
 ```
 
 ## Description


### PR DESCRIPTION
Syncing with https://github.com/iterative/dvc/pull/8352. I am skipping `repro` and `exp run` because they are well discussed in `Options` sections, and we wanted to avoid describing too much and took the example-based approach in the docs.

See https://github.com/iterative/dvc.org/pull/1983. The support for foreach group name in the target was extended in https://github.com/iterative/dvc/pull/8210.