### PR TITLE
docs: dvcfs: use read_bytes/read_text instead of cat_file

### DIFF
--- a/content/docs/api-reference/dvcfilesystem.md
+++ b/content/docs/api-reference/dvcfilesystem.md
@@ -45,11 +45,17 @@ can also specify `encoding` argument in case of text mode (`"r"`).
 ## Reading a file
 
 ```py
->>> contents = fs.cat_file("get-started/data.xml")
+>>> text = fs.read_text("get-started/data.xml", encoding="utf-8")
 ```
 
-This is similar to `dvc.api.read()`, but it returns the contents of the file as
-bytes instead of a string.
+This is similar to `dvc.api.read()`, which returns the contents of the file as a
+string.
+
+To get the binary contents of the file, you can use `read_bytes()`.
+
+```py
+>>> contents = fs.read_bytes("get-started/data.xml")
+```
 
 ## Listing all DVC-tracked files recursively
 

--- a/content/docs/api-reference/dvcfilesystem.md
+++ b/content/docs/api-reference/dvcfilesystem.md
@@ -51,7 +51,8 @@ can also specify `encoding` argument in case of text mode (`"r"`).
 This is similar to `dvc.api.read()`, which returns the contents of the file as a
 string.
 
-To get the binary contents of the file, you can use `read_bytes()` or `cat_file()`.
+To get the binary contents of the file, you can use `read_bytes()` or
+`cat_file()`.
 
 ```py
 >>> contents = fs.read_bytes("get-started/data.xml")

--- a/content/docs/api-reference/dvcfilesystem.md
+++ b/content/docs/api-reference/dvcfilesystem.md
@@ -51,7 +51,7 @@ can also specify `encoding` argument in case of text mode (`"r"`).
 This is similar to `dvc.api.read()`, which returns the contents of the file as a
 string.
 
-To get the binary contents of the file, you can use `read_bytes()`.
+To get the binary contents of the file, you can use `read_bytes()` or `cat_file()`.
 
 ```py
 >>> contents = fs.read_bytes("get-started/data.xml")


### PR DESCRIPTION
I have proposed the `read_text`/`read_bytes` and their write counterparts' API in [fsspec][1]. If/when that gets merged, and we update DVC, we can start suggesting this API for reading text/binary contents from the file.

Till then, this should not be merged.

[1]: https://github.com/fsspec/filesystem_spec/pull/1047