### PR TITLE
guide: merge driver can handle non-append conflicts

### DIFF
--- a/content/docs/command-reference/push.md
+++ b/content/docs/command-reference/push.md
@@ -88,7 +88,10 @@ in the cache (compared to the default remote.) It can be used to see what files
 
 - `-r <name>`, `--remote <name>` - name of the
   [remote storage](/doc/command-reference/remote) to push to (see
-  `dvc remote list`).
+  `dvc remote list`). This will override the
+  [default remote](/doc/command-reference/remote/default). For any remote
+  specified in the `dvc.yaml` or `.dvc` files, data will be pushed to the
+  specified remotes.
 
 - `--run-cache` - uploads all available history of
   [stage runs](/doc/user-guide/project-structure/internal-files#run-cache) to

--- a/content/docs/user-guide/how-to/resolve-merge-conflicts.md
+++ b/content/docs/user-guide/how-to/resolve-merge-conflicts.md
@@ -82,6 +82,14 @@ versions, then you can follow this process:
 
 ### Directories
 
+<admon type="warn">
+
+If the same file was added or changed in both branches, the merge driver will
+fail unless the changes are the same. If the same file was deleted in both
+branches, the merge driver will fail.
+
+</admon>
+
 If you have a directory, DVC provides a [Git merge driver] that can
 automatically resolve many merge conflicts for you. To use it, first set it up
 in your Git repo:

--- a/content/docs/user-guide/how-to/resolve-merge-conflicts.md
+++ b/content/docs/user-guide/how-to/resolve-merge-conflicts.md
@@ -82,14 +82,6 @@ versions, then you can follow this process:
 
 ### Directories
 
-<admon type="warn">
-
-If the same file was added or changed in both branches, the merge driver will
-fail unless the changes are the same. If the same file was deleted in both
-branches, the merge driver will fail.
-
-</admon>
-
 If you have a directory, DVC provides a [Git merge driver] that can
 automatically resolve many merge conflicts for you. To use it, first set it up
 in your Git repo:
@@ -108,6 +100,14 @@ And add this line to your `.gitattributes` (in the root of your git repo):
 
 Now, when a merge conflict occurs, DVC will simply combine data from both
 branches.
+
+<admon type="warn">
+
+If the same file was added or changed in both branches, the merge driver will
+fail unless the changes are the same. If the same file was deleted in both
+branches, the merge driver will fail.
+
+</admon>
 
 [git merge driver]:
   https://git-scm.com/docs/git-merge#Documentation/git-merge.txt-mergeltdrivergtname

--- a/content/docs/user-guide/how-to/resolve-merge-conflicts.md
+++ b/content/docs/user-guide/how-to/resolve-merge-conflicts.md
@@ -80,11 +80,11 @@ versions, then you can follow this process:
 3. Merge it by-hand;
 4. Finally, run `dvc add data.xml` to overwrite the conflicted `.dvc` file.
 
-### Append-only directories
+### Directories
 
-If you have an "append-only" dataset (where people only add new
-files/directories) DVC provides a [Git merge driver] that can automatically
-resolve merge conflicts for you. To use it, first set it up in your Git repo:
+If you have a directory, DVC provides a [Git merge driver] that can
+automatically resolve many merge conflicts for you. To use it, first set it up
+in your Git repo:
 
 ```dvc
 $ git config merge.dvc.name 'DVC merge driver'


### PR DESCRIPTION
Core PR: https://github.com/iterative/dvc/pull/8360

The core PR adds merge driver support for changing or deleting files.

In review app: https://dvc-org-merge-driver-k01urtosm.herokuapp.com/doc/user-guide/how-to/resolve-merge-conflicts#directories