### PR TITLE
hotfix: dvc.yaml spec format

### DIFF
--- a/content/docs/user-guide/project-structure/dvcyaml-files.md
+++ b/content/docs/user-guide/project-structure/dvcyaml-files.md
@@ -201,7 +201,7 @@ stages:
 `cache: false` is typical here, since they're small enough for Git to store
 directly.
 
-<admon>
+</admon>
 
 The commands in `dvc metrics` and `dvc plots` help you display and compare
 metrics and plots.


### PR DESCRIPTION
The format under https://dvc.org/doc/user-guide/project-structure/dvcyaml-files#metrics-and-plots-outputs is currently all broken due to an open `<admon>` tag:

<img width="1256" alt="image" src="https://user-images.githubusercontent.com/1477535/195461941-19b02384-8e40-4d17-9007-80a59880c0de.png">
