### PR TITLE
Studio: [skip studio] functionality

### DIFF
--- a/content/docs/studio/troubleshooting.md
+++ b/content/docs/studio/troubleshooting.md
@@ -198,10 +198,11 @@ show/hide columns, remember to save the changes.
 ## Project does not contain some of my commits or branches
 
 This is likely not an error. Iterative Studio identifies commits that do not
-change metrics, files or hyperparameters and will auto-hide such commits. You
-can also manually hide commits and branches. So, it is possible that the commits
-or branches you do not see in your project were manually hidden by you or
-someone else in your team.
+change metrics, files or hyperparameters and will auto-hide such commits. It
+also auto-hides commits that contain the string `[skip studio]` in the commit
+message. You can also manually hide commits and branches. So, it is possible
+that the commits or branches you do not see in your project were manually hidden
+by you or someone else in your team.
 
 You can unhide commits and branches to display them. For details, refer to
 [Display preferences -> Hide commits]. However, if the missing commit/branch is

--- a/content/docs/studio/user-guide/projects-and-experiments/explore-ml-experiments.md
+++ b/content/docs/studio/user-guide/projects-and-experiments/explore-ml-experiments.md
@@ -86,6 +86,24 @@ from the table.
 - **Iterative Studio auto-hides irrelevant commits:** Iterative Studio
   identifies commits where metrics, files and hyperparameters did not change and
   hides them automatically.
+- **Iterative Studio auto-hides commits that contain `[skip studio]` in the
+  commit message:** This is particularly useful if your workflow creates
+  multiple commits per experiment and you would like to hide all those commits
+  except the final one. Below is an example:
+
+  > Suppose you submit hyper-parameter changes by creating a Git commit. Your CI
+  > job gets invoked when the commit is created, starting the model training
+  > process. Suppose your CI job creates a new Git commit with the experiment
+  > results at the end of model training. This new Git commit, therefore,
+  > contains the new values of the hyper-parameters as well as experiment
+  > results (metrics).
+  >
+  > In Iterative Studio, you may want to display only this final commit and
+  > auto-hide the original commit which contains the the new values of the
+  > hyper-parameters but not the experiment results (metrics). In this case,
+  > what you should do is add the string `[skip studio]` to the commit message
+  > when you create the original commit.
+
 - **Hide commits and branches manually:** You can selectively hide commits and
   branches. This can be useful if there are commits that do not add much value
   in your project. To hide a commit or branch, click on the 3-dot menu next to

--- a/content/docs/studio/user-guide/projects-and-experiments/run-experiments.md
+++ b/content/docs/studio/user-guide/projects-and-experiments/run-experiments.md
@@ -125,10 +125,22 @@ extracted from your selected commit.
 ![](https://static.iterative.ai/img/studio/cml_changes.png)
 
 Once you have made all the required changes, enter your Git commit message and
-description. Then, select the branch to commit to. You can commit to either the
-base branch or a new branch. If you commit to a new branch, a Git pull request
-will automatically be created from the new branch to the base branch. Now, click
-on `Commit changes`.
+description.
+
+<admon>
+
+If your CI job creates a new Git commit to write the experiment results to your
+Git repository, you may want to hide the Git commit that you created when
+submitting the experiment from your project table. In this case, add
+`[skip studio]` in the commit message. For details, refer to [Display
+preferences -> Hide commits].
+
+</admon>
+
+Then, select the branch to commit to. You can commit to either the base branch
+or a new branch. If you commit to a new branch, a Git pull request will
+automatically be created from the new branch to the base branch. Now, click on
+`Commit changes`.
 
 ![](https://static.iterative.ai/img/studio/cml_commit.png)
 
@@ -153,3 +165,6 @@ the Git commit message in the table. The `CML Report` tooltip appears over the
 CML report icon on mouse hover.
 
 ![](https://static.iterative.ai/img/studio/cml_report_icon.png)
+
+[display preferences -> hide commits]:
+  /doc/studio/user-guide/projects-and-experiments/explore-ml-experiments#hide-commits


### PR DESCRIPTION
Closes https://github.com/iterative/studio/issues/4362

This Studio feature is already deployed in prod. So this PR can be merged as soon as it is approved.