### PR TITLE
Fix wording of copy-on-write notes for git-annex

### DIFF
--- a/content/docs/user-guide/overview.md
+++ b/content/docs/user-guide/overview.md
@@ -108,8 +108,8 @@ bringing best practices from software engineering into the data science field.
 \* **copy-on-write links or "reflinks"** are a relatively new way to link files
 in UNIX-style file systems. Unlike hardlinks or symlinks, they support
 transparent [copy on write](https://en.wikipedia.org/wiki/Copy-on-write). This
-means that editing a reflinked file is always safe as all the other links to the
-file will reflect the changes.
+means that editing a reflinked file is always safe as all the other linked copies
+of the file will remain unchanged.
 
 </admon>
 

--- a/content/docs/user-guide/overview.md
+++ b/content/docs/user-guide/overview.md
@@ -105,11 +105,11 @@ bringing best practices from software engineering into the data science field.
 
 <admon type="info">
 
-\* **copy-on-write links or "reflinks"** are a relatively new way to link files
-in UNIX-style file systems. Unlike hardlinks or symlinks, they support
-transparent [copy on write](https://en.wikipedia.org/wiki/Copy-on-write). This
-means that editing a reflinked file is always safe as all the other linked copies
-of the file will remain unchanged.
+\* ([copy-on-write](https://en.wikipedia.org/wiki/Copy-on-write)) links or
+**reflinks** are a type of file linking available in UNIX-style file systems.
+Unlike hardlinks or symlinks, these file entries turn into a plain copy when
+modified. This means that editing reflinks is always safe, as the original
+<abbr>cached</abbr> data will remain unchanged.
 
 </admon>
 


### PR DESCRIPTION
The existing wording suggested that copy-on-write is safe because other copies get updated on write.

In fact it's the opposite: unlike symlinks, where an edit would also change the original, copy-on-write is a safe means of deduplicating content because you can write to the copy without changing the original.

The new wording clarifies this.