### PR TITLE
Add missing Security Headers

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   },
   "dependencies": {
     "@dvcorg/gatsby-theme-iterative": "^0.1.23",
-    "@dvcorg/websites-server": "^0.0.11",
+    "@dvcorg/websites-server": "^0.0.13",
     "@hapi/wreck": "^18.0.0",
     "@octokit/graphql": "^5.0.0",
     "@reach/portal": "^0.17.0",

--- a/src/server.js
+++ b/src/server.js
@@ -3,10 +3,20 @@ const server = require('@dvcorg/websites-server')
 
 const app = server.app
 
+const helmetOptions = {
+  contentSecurityPolicy: {
+    directives: {
+      frameSrc: ['https://embed.testimonial.to']
+    }
+  }
+}
+
 // we can also extend to add further custom routes
 app.get('/api/status', (req, res) => {
   res.send('ok')
 })
 
 // run the server
-server.run()
+server.run({
+  helmetOptions
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -2112,10 +2112,10 @@
     unist-util-remove-position "^4.0.1"
     unist-util-visit "^4.1.0"
 
-"@dvcorg/websites-server@^0.0.11":
-  version "0.0.11"
-  resolved "https://registry.yarnpkg.com/@dvcorg/websites-server/-/websites-server-0.0.11.tgz#3db2a8dc93b6bf015512985ba33f5b5ba1b6d888"
-  integrity sha512-ssfz2u1qe7qQgwYP6v8TBWTN1cumvP1DyLGze7xaMWiZNrnckG+6kd+2TRXnzcMwxo83nJ8D7flnGweW+1e8yQ==
+"@dvcorg/websites-server@^0.0.13":
+  version "0.0.13"
+  resolved "https://registry.yarnpkg.com/@dvcorg/websites-server/-/websites-server-0.0.13.tgz#824fb2407a10c4e66c62c3758db29a3118845eac"
+  integrity sha512-p6mlj54afEjJC/b+PPh3w+msmoUthbZZtQ513UHKfXzuyhH4V/HFpYYUygaEhWQU9vdoI1B5jVJn3uh1DYsAhA==
   dependencies:
     "@dvcorg/gatsby-theme-iterative" "^0.1.17"
     "@hapi/wreck" "^18.0.0"
@@ -2125,12 +2125,15 @@
     dotenv "^16.0.1"
     express "^4.18.1"
     fs-extra "^10.1.0"
+    helmet "^6.0.0"
     http-proxy-middleware "^2.0.6"
     isomorphic-fetch "^3.0.0"
+    lodash "^4.17.21"
     node-cache "^5.1.2"
+    permissions-policy "^0.6.0"
     react "^18.2.0"
     s3-client "^4.4.2"
-    serve-handler "^6.1.3"
+    serve-handler "^6.1.5"
 
 "@endemolshinegroup/cosmiconfig-typescript-loader@3.0.2":
   version "3.0.2"
@@ -10325,6 +10328,11 @@ header-case@^2.0.4:
     capital-case "^1.0.4"
     tslib "^2.0.3"
 
+helmet@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/helmet/-/helmet-6.0.0.tgz#8e183820ddccd7729a206ad73c577b264f495595"
+  integrity sha512-FO9RpR1wNJepH/GbLPQVtkE2eESglXL641p7SdyoT4LngHFJcZheHMoyUcjCZF4qpuMMO1u5q6RK0l9Ux8JBcg==
+
 hogan.js@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/hogan.js/-/hogan.js-3.0.2.tgz#4cd9e1abd4294146e7679e41d7898732b02c7bfd"
@@ -12982,7 +12990,7 @@ minimatch@3.0.4:
   dependencies:
     brace-expansion "^1.1.7"
 
-minimatch@^3.0.4, minimatch@^3.1.1, minimatch@^3.1.2:
+minimatch@3.1.2, minimatch@^3.0.4, minimatch@^3.1.1, minimatch@^3.1.2:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.1.2.tgz#19cd194bfd3e428f049a70817c038d89ab4be35b"
   integrity sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==
@@ -13927,6 +13935,11 @@ performance-now@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"
   integrity sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==
+
+permissions-policy@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/permissions-policy/-/permissions-policy-0.6.0.tgz#9c01b1a8e360ab4955e20a7946abcb0fd34d276d"
+  integrity sha512-VfN72swhRiuvfejFP/N5hOVCyriBgzy1KiLE8mjN2KkCJCOtFv2N221SVUHYl0OPXIOoqu7tkc7efreiN7encA==
 
 physical-cpu-count@^2.0.0:
   version "2.0.0"
@@ -15944,7 +15957,7 @@ serialize-javascript@^6.0.0:
   dependencies:
     randombytes "^2.1.0"
 
-serve-handler@^6.1.2, serve-handler@^6.1.3:
+serve-handler@^6.1.2:
   version "6.1.3"
   resolved "https://registry.yarnpkg.com/serve-handler/-/serve-handler-6.1.3.tgz#1bf8c5ae138712af55c758477533b9117f6435e8"
   integrity sha512-FosMqFBNrLyeiIDvP1zgO6YoTzFYHxLDEIavhlmQ+knB2Z7l1t+kGLHkZIDN7UVWqQAmKI3D20A6F6jo3nDd4w==
@@ -15954,6 +15967,20 @@ serve-handler@^6.1.2, serve-handler@^6.1.3:
     fast-url-parser "1.1.3"
     mime-types "2.1.18"
     minimatch "3.0.4"
+    path-is-inside "1.0.2"
+    path-to-regexp "2.2.1"
+    range-parser "1.2.0"
+
+serve-handler@^6.1.5:
+  version "6.1.5"
+  resolved "https://registry.yarnpkg.com/serve-handler/-/serve-handler-6.1.5.tgz#a4a0964f5c55c7e37a02a633232b6f0d6f068375"
+  integrity sha512-ijPFle6Hwe8zfmBxJdE+5fta53fdIY0lHISJvuikXB3VYFafRjMRpOffSPvCYsbKyBA7pvy9oYr/BT1O3EArlg==
+  dependencies:
+    bytes "3.0.0"
+    content-disposition "0.5.2"
+    fast-url-parser "1.1.3"
+    mime-types "2.1.18"
+    minimatch "3.1.2"
     path-is-inside "1.0.2"
     path-to-regexp "2.2.1"
     range-parser "1.2.0"


### PR DESCRIPTION
Similar to https://github.com/iterative/iterative.ai/pull/704 for `dvc.org`.

https://securityheaders.com/?q=https%3A%2F%2Fdvc-org-security-header-jrpdcu.herokuapp.com%2F&followRedirects=on
<img width="1235" alt="Screenshot 2022-11-29 at 17 20 54" src="https://user-images.githubusercontent.com/20840228/204518938-913b25f2-6c89-4a5a-b186-b881b5298ebf.png">
