### PR TITLE
Remove GTO docs from sidebar & update existing links (mainly Studio)

### DIFF
--- a/content/docs/sidebar.json
+++ b/content/docs/sidebar.json
@@ -723,10 +723,5 @@
         ]
       }
     ]
-  },
-  {
-    "label": "GTO",
-    "url": "https://mlem.ai/doc/gto",
-    "type": "external"
   }
 ]

--- a/content/docs/studio/how-it-works.md
+++ b/content/docs/studio/how-it-works.md
@@ -65,5 +65,5 @@ https://www.youtube.com/watch?v=5xM5az78Lrg
 [dvc]: https://dvc.org/
 [cml]: https://cml.dev
 [mlem]: https://mlem.ai/
-[gto]: https://github.com/iterative/gto
+[gto]: https://mlem.ai/doc/gto
 [git]: https://git-scm.com/

--- a/content/docs/studio/index.md
+++ b/content/docs/studio/index.md
@@ -3,8 +3,8 @@
 [Iterative Studio](https://studio.iterative.ai/) is a web application that you
 can access online or even host on-prem. Using the power of leading open-source
 tools [DVC](https://dvc.org/), [CML](https://cml.dev), [MLEM](https://mlem.ai/),
-[GTO](https://github.com/iterative/gto) and [Git](https://git-scm.com/), it
-enables you to seamlessly manage data and machine learning models, run and track
+[GTO](https://mlem.ai/doc/gto), and [Git](https://git-scm.com/), it enables you
+to seamlessly manage data and machine learning models, run and track
 experiments, and visualize and share results.
 
 <admon>

--- a/content/docs/studio/troubleshooting.md
+++ b/content/docs/studio/troubleshooting.md
@@ -243,7 +243,8 @@ Then you can come back to the model registry and add the model.
 ## Model registry does not display the models in my Git repositories
 
 For a model to be displayed in the model registry, it has to be registered using
-[GTO]. You can [register the model] from Iterative Studio or with GTO's CLI.
+[GTO]. You can [register the model] from Iterative Studio or with the [`gto`
+CLI].
 
 ## How can I remove models from my model registry
 
@@ -269,5 +270,6 @@ Check out the [Frequently Asked Questions](https://studio.iterative.ai/faq) to
 see if your questions have already been answered. If you still have problems,
 please [contact us](#support).
 
-[gto]: https://github.com/iterative/gto
+[gto]: https://mlem.ai/doc/gto
 [register the model]: /doc/studio/user-guide/model-registry/add-a-model
+[`gto` cli]: https://mlem.ai/doc/gto/command-reference

--- a/content/docs/studio/user-guide/model-registry/add-a-model.md
+++ b/content/docs/studio/user-guide/model-registry/add-a-model.md
@@ -3,8 +3,8 @@
 You can add models from any ML project to the model registry. To add a model to
 your model registry, Iterative Studio creates an annotation for it in an
 `artifacts.yaml` file in your Git repository. If you are using the [GTO] command
-line tool, you can also add models [from the CLI]. To add models using Iterative
-Studio, watch this tutorial video or read on below:
+line tool, you can also add models [from the CLI][gto annotate]. To add models
+using Iterative Studio, watch this tutorial video or read on below:
 
 https://www.youtube.com/watch?v=szzv4ZXmYAs
 
@@ -69,10 +69,10 @@ https://www.youtube.com/watch?v=szzv4ZXmYAs
   `dvc import-url <remote_path> <directory_path>/<filename from remote_path> --no-exec`.
 - Iterative Studio annotate the model by executing
   `gto annotate <model_name> --path <directory_path>/<filename from remote_path> --type model`.
-  [Learn more](https://github.com/iterative/gto#annotating).
+  [Learn more][gto annotate].
 
 [connected repository]:
   /doc/studio/user-guide/projects-and-experiments/create-a-project
-[gto]: https://github.com/iterative/gto
-[from the cli]: https://github.com/iterative/gto#annotating
+[gto]: https://mlem.ai/doc/gto
+[gto annotate]: https://mlem.ai/doc/gto/command-reference/annotate
 [mlem]: https://mlem.ai/

--- a/content/docs/studio/user-guide/model-registry/assign-stage.md
+++ b/content/docs/studio/user-guide/model-registry/assign-stage.md
@@ -4,14 +4,14 @@ To manage model lifecycle, you can assign stages (such as `development`,
 `staging`, `production`, etc.) to specific model versions.
 
 To assign a stage to a model version, Iterative Studio uses [GTO] to create an
-[annotated Git tag][git tag] with the specified stage and version number. Refer
-the [GTO docs][gto] to see the exact format of the Git tag.
+annotated [Git tag][git tag] with the specified stage and version number. Refer
+to the [GTO docs][gto-format] to see the exact format of the Git tag.
 
 You can write CI/CD actions that can actually deploy the models to the different
 deployment environments upon the creation of a new Git tag for stage assignment.
 For that, you can leverage any ML model deployment tool, such as MLEM.
 
-You can assign stages using the [GTO] CLI. To assign stages using Iterative
+You can assign stages using the [`gto` CLI]. To assign stages using Iterative
 Studio, watch this tutorial video or read on below:
 
 https://www.youtube.com/watch?v=Vrp1O5lkWBo
@@ -51,5 +51,7 @@ https://www.youtube.com/watch?v=Vrp1O5lkWBo
    the selected version and stage has been created, indicating the stage
    assignment.
 
-[gto]: https://github.com/iterative/gto
+[gto]: https://mlem.ai/doc/gto
 [git tag]: https://git-scm.com/docs/git-tag
+[gto-format]: https://mlem.ai/doc/gto/user-guide#git-tag-message-format
+[`gto` cli]: https://mlem.ai/doc/gto/command-reference

--- a/content/docs/studio/user-guide/model-registry/register-version.md
+++ b/content/docs/studio/user-guide/model-registry/register-version.md
@@ -4,12 +4,11 @@ You can register new versions of registered models by specifying the Git commit
 which corresponds to the new version.
 
 To register a new version of a model, Iterative Studio uses [GTO] to create an
-[annotated Git tag][git tag] with the specified version number. Refer the [GTO
-docs][gto] to see the exact format of the Git tag.
+annotated [Git tag][git tag] with the specified version number. Refer to the
+[GTO docs][gto-format] to see the exact format of the Git tag.
 
-You can register versions using the [GTO] command line interface (CLI). To
-register versions using Iterative Studio, watch this tutorial video or read on
-below:
+You can register versions using the [`gto` CLI]. To register versions using
+Iterative Studio, watch this tutorial video or read on below:
 
 https://www.youtube.com/watch?v=eA70puzOp1o
 
@@ -44,6 +43,8 @@ https://www.youtube.com/watch?v=eA70puzOp1o
 8. If you go to your Git repository, you will see that a new Git tag referencing
    the selected commit has been created, representing the new version.
 
-[gto]: https://github.com/iterative/gto
-[semver]: https://semver.org/
+[gto]: https://mlem.ai/doc/gto
 [git tag]: https://git-scm.com/docs/git-tag
+[gto-format]: https://mlem.ai/doc/gto/user-guide#git-tag-message-format
+[`gto` cli]: https://mlem.ai/doc/gto/command-reference
+[semver]: https://semver.org/

--- a/content/docs/studio/user-guide/model-registry/view-models.md
+++ b/content/docs/studio/user-guide/model-registry/view-models.md
@@ -20,7 +20,7 @@ Iterative Studio consolidates the stages of all the models in the registry, and
 provides a way to filter models by stages.
 
 Iterative Studio also consolidates the frameworks of all the models in the
-registry, and provides a way to filter models by framework. Note that the
+registry and provides a way to filter models by framework. Note that the
 framework of a model is identified by Iterative’s model deployment tool [MLEM].
 If you have not used MLEM, then Iterative Studio will use a generic framework
 label (`G`) to indicate that the model framework was not identified, and that
@@ -70,4 +70,4 @@ belongs.
 ![](https://static.iterative.ai/img/studio/model-columns-in-experiment-table.png)
 
 [mlem]: https://mlem.ai/
-[gto]: https://github.com/iterative/gto
+[gto]: https://mlem.ai/doc/gto

--- a/content/docs/studio/user-guide/model-registry/what-is-a-model-registry.md
+++ b/content/docs/studio/user-guide/model-registry/what-is-a-model-registry.md
@@ -20,9 +20,9 @@ open-source Git-based tools [GTO] and [MLEM].
   be in S3, GCP, or any other of your remote, or local, storages.
 
 The model registry provides an interactive web interface to the metadata files
-and Git tags. You can also use the model registry through the [GTO CLI and
-Python API][gto]. Any updates that you make from the CLI or API are also
-reflected in the model registry in Iterative Studio.
+and Git tags. You can also use the model registry through the [`gto` CLI]. Any
+updates that you make from the CLI or API are also reflected in the model
+registry in Iterative Studio.
 
 In the model registry, you can find information about your models in the
 following interfaces:
@@ -50,5 +50,6 @@ incorporate these tasks also. Similarly, you can use GTO in your CI/CD actions
 to interpret Git tags for deploying the models to the desired environment.
 
 [semantic versioning]: https://semver.org/
-[gto]: https://github.com/iterative/gto
+[gto]: https://mlem.ai/doc/gto
 [mlem]: https://mlem.ai/
+[`gto` cli]: https://mlem.ai/doc/gto/command-reference

--- a/content/docs/studio/user-guide/prepare-your-repositories.md
+++ b/content/docs/studio/user-guide/prepare-your-repositories.md
@@ -12,12 +12,12 @@ values are found in JSON or YAML files in the repository. Additionally, model
 information may be available as Git tags.
 
 New ML model metadata can be added directly from the **Models** tab after
-[creating a project]. You can also use [GTO] or [MLEM].
+[creating a project]. You can also use the underlying [GTO] or [MLEM] directly.
 
 [projects]: /doc/studio/user-guide/projects-and-experiments/what-is-a-project
 [creating a project]:
   /doc/studio/user-guide/projects-and-experiments/create-a-project
-[gto]: https://github.com/iterative/gto
+[gto]: https://mlem.ai/doc/gto
 [mlem]: https://mlem.ai/
 
 ## Set up datasets, metrics, and hyperparameters

--- a/content/docs/use-cases/model-registry.md
+++ b/content/docs/use-cases/model-registry.md
@@ -4,11 +4,11 @@ A **model registry** is a tool to catalog ML models and their versions. Models
 from your data science projects can be discovered, tested, shared, deployed, and
 audited from there. [DVC](/doc), [GTO], and [MLEM] enable these capabilities on
 top of Git, so you can stick to an existing software engineering stack. No more
-divide between ML engineering and operations!
+division between ML engineering and operations!
 
 ![](/img/ml_model_registry.jpg) _MLOps from modeling to production_
 
-[gto]: https://github.com/iterative/gto
+[gto]: https://mlem.ai/doc/gto
 [mlem]: https://mlem.ai/
 
 ML model registries give your team key capabilities:


### PR DESCRIPTION
Reverts iterative/dvc.org#4131

per https://github.com/iterative/dvc.org/pull/4131#issuecomment-1331650296

- [x] We do mention GTO in some DVC docs, let's just link to https://mlem.ai/doc/gto instead of https://github.com/iterative/gto in those places?