### PR TITLE
Fix SEO default population

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "node": ">=14.x <=18.x"
   },
   "dependencies": {
-    "@dvcorg/gatsby-theme-iterative": "^0.2.4",
+    "@dvcorg/gatsby-theme-iterative": "^0.2.6",
     "@dvcorg/websites-server": "^0.0.13",
     "@hapi/wreck": "^18.0.0",
     "@octokit/graphql": "^5.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1808,10 +1808,10 @@
     unist-util-remove-position "^4.0.1"
     unist-util-visit "^4.1.0"
 
-"@dvcorg/gatsby-theme-iterative@^0.2.4":
-  version "0.2.4"
-  resolved "https://registry.yarnpkg.com/@dvcorg/gatsby-theme-iterative/-/gatsby-theme-iterative-0.2.4.tgz#2be64f6b3f1f4ceade1103b8b86d2ef7b6e50ced"
-  integrity sha512-dtH9wMZo2WRQGg89yjT+2pX8r9h+6eiKmc4rfSVi9cabddobXCOi2n0sn4UPpbYSDmDHmhSzB/rO+tUqX7aI1w==
+"@dvcorg/gatsby-theme-iterative@^0.2.6":
+  version "0.2.6"
+  resolved "https://registry.yarnpkg.com/@dvcorg/gatsby-theme-iterative/-/gatsby-theme-iterative-0.2.6.tgz#bc54c9332e414812ffc3d8391d85de4742af652a"
+  integrity sha512-dR0AbLqB48rnnlbhrSdg7qPuVMrGEDNz8ReeWa5hfgullpsZQye4PoE0FKsONq8Gf7PnUNljIX1ksy0HmSbwbA==
   dependencies:
     "@reach/portal" "^0.17.0"
     "@reach/router" "^1.3.4"


### PR DESCRIPTION
- update gatsby-theme-iterative to fix SEO default population

Before:
<img width="608" alt="Screenshot 2022-12-01 at 23 08 01" src="https://user-images.githubusercontent.com/20840228/205121158-29a28c5c-a7b8-47e9-a8ad-ee73da1f046b.png">
After:
<img width="579" alt="Screenshot 2022-12-01 at 23 17 26" src="https://user-images.githubusercontent.com/20840228/205121108-72e5390e-0eec-40d7-a506-64d52883aaaf.png">
