### PR TITLE
dvc/guide: share exps without dvc remote

### DIFF
--- a/content/docs/user-guide/experiment-management/sharing-experiments.md
+++ b/content/docs/user-guide/experiment-management/sharing-experiments.md
@@ -2,45 +2,97 @@
 
 In a regular Git workflow, <abbr>DVC repository</abbr> versions are typically
 synchronized among team members. And [DVC Experiments] are internally connected
-to this commit history. But to avoid cluttering everyone's copies of the repo,
-by default experiments will only exist in the local environment where they were
-[created].
+to this commit history, so you can similarly share them.
 
-You must explicitly save or share experiments individually on other locations.
-This is done similarly to [sharing regular project versions], by synchronizing
-with DVC and Git remotes. But DVC takes care of pushing and pulling to/from Git
-remotes in the case of experiments.
+## Basic workflow: store as peristent commits
+
+The most straightforward way to share experiments is to store them as
+[persistent](/doc/user-guide/experiment-management/persisting-experiments.md)
+Git commits and share them like you would [any other commit]. This will share
+all code and metadata associated with the experiment.
+
+```cli
+$ dvc exp branch exp-e6c97 my-branch
+Git branch 'my-branch' has been created from experiment 'exp-e6c97'.
+To switch to the new branch run:
+        git checkout my-branch
+
+$ git checkout my-branch
+Switched to branch 'my-branch'
+
+$ git push origin my-branch
+```
+
+If you only need to share code and metadata like parameters and metrics, then
+pushing to Git is often enough. However, you may also have data, models, etc.
+that are tracked and <abbr>cached</abbr> by DVC. If you need to share these
+files, you can push them to [remote storage](/doc/command-reference/remote)
+(e.g. Amazon S3 or Google Drive).
+
+```
+$ dvc push
+```
 
 ```
   ┌────────────────┐     ┌────────────────┐
-  ├────────────────┤     │                │  Remote locations
-  │   DVC remote   │     │   Git remote   │
-  │    storage     │     ├────────────────┤
+  ├────────────────┤     │   DVC remote   │  Remote locations
+  │   Git remote   │     │    storage     │
+  │                │     ├────────────────┤
+  └────────────────┘     └────────────────┘
+          ▲                       ▲
+          │                       │
+       git push                dvc push
+       git pull                dvc pull
+          │                       │
+          ▼                       ▼
+  ┌─────────────────┐    ┌────────────────┐
+  │   Code and      │    │                │
+  │   metafiles     │    │   Cached data  │  Local project
+  └─────────────────┘    └────────────────┘
+```
+
+## Advanced workflow: `dvc exp push`
+
+Storing experiments as persistent Git commits is not always practical, and it
+can become annoying to do this every time you want to share an experiment. What
+if you aren't ready to make the experiment persistent but still want to share it
+with others? What if you have many experiments to share? For those scenarios,
+you can use `dvc exp push`.
+
+This works similarly to [sharing regular project versions], by synchronizing
+with DVC and [Git remotes]. But DVC takes care of pushing and pulling to/from
+both Git and DVC remotes in the case of experiments.
+
+```
+  ┌────────────────┐     ┌────────────────┐
+  ├────────────────┤     │   DVC remote   │  Remote locations
+  │   Git remote   │     │    storage     │
+  │                │     ├────────────────┤
   └────────────────┘     └────────────────┘
           ▲                       ▲
           │      dvc exp push     │
           │      dvc exp pull     │
           ▼                       ▼
   ┌─────────────────┐    ┌────────────────┐
-  │                 │    │   Code and     │
-  │   Cached data   │    │   metafiles    │  Local project
+  │   Code and      │    │                │
+  │   metafiles     │    │   Cached data  │  Local project
   └─────────────────┘    └────────────────┘
 ```
 
-> Specifically, data, models, etc. are tracked and <abbr>cached</abbr> by DVC
-> and thus will be transferred to/from
-> [remote storage](/doc/command-reference/remote) (e.g. Amazon S3 or Google
-> Drive). Small files like [DVC metafiles](/doc/user-guide/project-structure)
-> and code are tracked by Git, so DVC pushes and pulls them to/from your
-> existing [Git remotes].
-
 [dvc experiments]: /doc/user-guide/experiment-management/experiments-overview
-[created]: /doc/user-guide/experiment-management/running-experiments
-[sharing regular project versions]:
+[any other commit]:
   /doc/start/data-management/data-versioning#storing-and-sharing
 [git remotes]: https://git-scm.com/book/en/v2/Git-Basics-Working-with-Remotes
 
-## Preparation
+### Preparation
+
+<admon type="tip">
+
+If you don't need to share <abbr>cached</abbr> data, you can skip `dvc remote`
+configuration by using the `dvc exp push --no-cache` and
+`dvc exp pull --no-cache`.
+
+</admon>
 
 Make sure that you have the necessary remotes setup. Let's confirm with
 `git remote -v` and `dvc remote list`:
@@ -59,7 +111,7 @@ storage s3://mybucket/my-dvc-store
 [ssh urls]:
   https://git-scm.com/book/en/v2/Git-on-the-Server-The-Protocols#_the_protocols
 
-## Uploading experiments
+### Uploading experiments
 
 You can upload an experiment with all of its files and data using
 `dvc exp push`, which takes a Git remote name and an experiment ID or name as
@@ -76,7 +128,7 @@ Once pushed, you can easily [list remote experiments] (with `dvc exp list`).
 [list remote experiments]:
   /doc/user-guide/experiment-management/comparing-experiments#list-experiments-saved-remotely
 
-## Downloading experiments
+### Downloading experiments
 
 When you clone a DVC repository, it doesn't fetch any experiments by default. In
 order to get them, use `dvc exp pull` (with the Git remote and the experiment
@@ -92,7 +144,7 @@ both of these configured (see this [earlier section](#preparation)).
 If an experiment being pulled already exists in the local project, DVC won't
 overwrite it unless you supply `--force`.
 
-## Sharing many experiments
+### Sharing many experiments
 
 Use the`--rev` option of `dvc exp push` and `dvc exp pull` to share many
 experiments at once. For example, to upload all experiments based on the latest

--- a/content/docs/user-guide/experiment-management/sharing-experiments.md
+++ b/content/docs/user-guide/experiment-management/sharing-experiments.md
@@ -29,7 +29,7 @@ that are tracked and <abbr>cached</abbr> by DVC. If you need to share these
 files, you can push them to [remote storage](/doc/command-reference/remote)
 (e.g. Amazon S3 or Google Drive).
 
-```
+```cli
 $ dvc push
 ```
 


### PR DESCRIPTION
Show some options for how to share experiments without a DVC remote.