### PR TITLE
Fix webpack config

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -17,3 +17,34 @@ exports.onPostBuild = api => callOnModels(models, 'onPostBuild', api)
 exports.onCreatePage = ({ page, actions }) => {
   setPageContext(page, actions)
 }
+
+// Ignore warnings about CSS inclusion order, because we use CSS modules.
+// https://spectrum.chat/gatsby-js/general/having-issue-related-to-chunk-commons-mini-css-extract-plugin~0ee9c456-a37e-472a-a1a0-cc36f8ae6033?m=MTU3MjYyNDQ5OTAyNQ==
+exports.onCreateWebpackConfig = ({ stage, actions, getConfig }) => {
+  if (stage === 'build-javascript') {
+    const config = getConfig()
+
+    // Add polyfills
+    config.entry.app = Array.isArray(config.entry.app)
+      ? [
+          'promise-polyfill/src/polyfill',
+          'isomorphic-fetch',
+          'raf-polyfill',
+          ...config.entry.app
+        ]
+      : [
+          'promise-polyfill/src/polyfill',
+          'isomorphic-fetch',
+          'raf-polyfill',
+          config.entry.app
+        ]
+
+    const miniCssExtractPlugin = config.plugins.find(
+      plugin => plugin.constructor.name === 'MiniCssExtractPlugin'
+    )
+    if (miniCssExtractPlugin) {
+      miniCssExtractPlugin.options.ignoreOrder = true
+    }
+    actions.replaceWebpackConfig(config)
+  }
+}


### PR DESCRIPTION
I wanted to update the theme to the latest version in order to fix tooltip issue (https://github.com/iterative/gatsby-theme-iterative/pull/155). 
It will be covered on https://github.com/iterative/dvc.org/pull/4191 so I went ahead to fix the webpack config issue there.

I believe we want to keep the webpack config that prevents the warnings on the build as it will be hard to debug otherwise if anything happens. I remember I had applied a patch for a single use case https://github.com/iterative/dvc.org/pull/3988. 

I think this will be a better patch.