### PR TITLE
ref: add `read_timeout` and `connect_timeout` config options (`remote add`)

### DIFF
--- a/content/docs/command-reference/remote/modify.md
+++ b/content/docs/command-reference/remote/modify.md
@@ -1151,7 +1151,7 @@ by HDFS. Read more about by expanding the WebHDFS section in
   minutes for example:
 
   ```cli
-  $ dvc remote modify myremote read_timeout 300
+  $ dvc remote add myremote read_timeout 300
   ```
 
 - `connect_timeout` - set the time in seconds till a timeout exception is thrown
@@ -1159,7 +1159,7 @@ by HDFS. Read more about by expanding the WebHDFS section in
   minutes for example:
 
   ```cli
-  $ dvc remote modify myremote connect_timeout 300
+  $ dvc remote add myremote connect_timeout 300
   ```
 
 </details>

--- a/content/docs/command-reference/remote/modify.md
+++ b/content/docs/command-reference/remote/modify.md
@@ -1146,6 +1146,22 @@ by HDFS. Read more about by expanding the WebHDFS section in
   $ dvc remote modify myremote ssl_verify path/to/ca_bundle.pem
   ```
 
+- `read_timeout` - set the time in seconds till a timeout exception is thrown
+  when attempting to read from a connection (60 by default). Let's set it to 5
+  minutes for example:
+
+  ```cli
+  $ dvc remote modify myremote read_timeout 300
+  ```
+
+- `connect_timeout` - set the time in seconds till a timeout exception is thrown
+  when attempting to make a connection (60 by default). Let's set it to 5
+  minutes for example:
+
+  ```cli
+  $ dvc remote modify myremote connect_timeout 300
+  ```
+
 </details>
 
 <details>

--- a/content/docs/command-reference/remote/modify.md
+++ b/content/docs/command-reference/remote/modify.md
@@ -1147,8 +1147,8 @@ by HDFS. Read more about by expanding the WebHDFS section in
   ```
 
 - `read_timeout` - set the time in seconds till a timeout exception is thrown
-  when attempting to read from a connection (60 by default). Let's set it to 5
-  minutes for example:
+  when attempting to read a portion of data from a connection (60 by default).
+  Let's set it to 5 minutes for example:
 
   ```cli
   $ dvc remote add myremote read_timeout 300

--- a/content/docs/command-reference/remote/modify.md
+++ b/content/docs/command-reference/remote/modify.md
@@ -135,22 +135,6 @@ options:
   $ dvc remote modify myremote connect_timeout 300
   ```
 
-- `read_timeout` - set the time in seconds till a timeout exception is thrown
-  when attempting to read from a connection (60 by default). Let's set it to 5
-  minutes for example:
-
-  ```cli
-  $ dvc remote modify myremote read_timeout 300
-  ```
-
-- `connect_timeout` - set the time in seconds till a timeout exception is thrown
-  when attempting to make a connection (60 by default). Let's set it to 5
-  minutes for example:
-
-  ```cli
-  $ dvc remote modify myremote connect_timeout 300
-  ```
-
 By default, DVC authenticates using your AWS CLI
 [configuration](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-configure.html)
 (if set). This uses the default AWS credentials file. Use the following

--- a/content/docs/command-reference/remote/modify.md
+++ b/content/docs/command-reference/remote/modify.md
@@ -1151,7 +1151,7 @@ by HDFS. Read more about by expanding the WebHDFS section in
   Let's set it to 5 minutes for example:
 
   ```cli
-  $ dvc remote add myremote read_timeout 300
+  $ dvc remote modify myremote read_timeout 300
   ```
 
 - `connect_timeout` - set the time in seconds till a timeout exception is thrown
@@ -1159,7 +1159,7 @@ by HDFS. Read more about by expanding the WebHDFS section in
   minutes for example:
 
   ```cli
-  $ dvc remote add myremote connect_timeout 300
+  $ dvc remote modify myremote connect_timeout 300
   ```
 
 </details>


### PR DESCRIPTION
- remote modify: remove duplicated config options for s3
- remote modify: add timeout config options for http remote

Related: 
- iterative/dvc#8722
- iterative/dvc-http#29