### PR TITLE
docs/contributing: Clarify supported Node.js version

### DIFF
--- a/content/docs/contributing/docs.md
+++ b/content/docs/contributing/docs.md
@@ -56,9 +56,8 @@ changes before submitting them, and it's quite necessary when making changes to
 the website engine itself. Source code and content files need to be properly
 formatted and linted as well, which is also ensured by the full setup below.
 
-Make sure you have [Python](https://www.python.org/downloads/) 3.8+, a recent
-LTS version of [Node.js](https://nodejs.org/en/) (`>=18.x`), and install
-[Yarn](https://yarnpkg.com/):
+Make sure you have a recent LTS version of [Node.js](https://nodejs.org/en/)
+(`>=18.0.0`, `<=19.x`), and install [Yarn](https://yarnpkg.com/):
 
 > In Windows, you may need to install [Visual Studio Build Tools], and the
 > [Windows SDK] first.

--- a/content/docs/contributing/docs.md
+++ b/content/docs/contributing/docs.md
@@ -57,8 +57,8 @@ the website engine itself. Source code and content files need to be properly
 formatted and linted as well, which is also ensured by the full setup below.
 
 Make sure you have [Python](https://www.python.org/downloads/) 3.8+, a recent
-LTS version of [Node.js](https://nodejs.org/en/) (`>=14.0.0`, `<=18.x`), and
-install [Yarn](https://yarnpkg.com/):
+LTS version of [Node.js](https://nodejs.org/en/) (`>=18.x`), and install
+[Yarn](https://yarnpkg.com/):
 
 > In Windows, you may need to install [Visual Studio Build Tools], and the
 > [Windows SDK] first.


### PR DESCRIPTION
The current instruction on the supported Node.js versions needs to be more accurate. 

Running `yarn` with Node.js version `16.18.1` raises the following error:
```
$ yarn
yarn install v1.22.19
[1/5] Validating package.json...
[2/5] Resolving packages...
[3/5] Fetching packages...
error @dvcorg/gatsby-theme-iterative@0.3.0: The engine "node" is incompatible with this module. Expected version ">=18.0.0". Got "16.18.1"
error Found incompatible module.
info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.
```

Running the same command with Node.js version `18.x` succeeds.