### PR TITLE
Show blog without comments url in blog feed

### DIFF
--- a/src/components/Community/Learn/index.tsx
+++ b/src/components/Community/Learn/index.tsx
@@ -44,13 +44,9 @@ const BlogPost: React.FC<ICommunityBlogPost> = ({
   commentsUrl,
   pictureUrl
 }) => {
-  if (!commentsUrl) {
-    return null
-  }
-
   const logPost = useCallback(() => logBlog(title), [title])
 
-  const { error, ready, result } = useCommentsCount(commentsUrl)
+  const { error, ready, result } = useCommentsCount(commentsUrl || '')
 
   return (
     <div className={cn(sharedStyles.line, sharedStyles.image)} key={url}>
@@ -75,7 +71,7 @@ const BlogPost: React.FC<ICommunityBlogPost> = ({
           {title}
         </Link>
         <div className={sharedStyles.meta}>
-          {ready && !error && (
+          {commentsUrl && ready && !error && (
             <>
               <Link
                 className={sharedStyles.commentsLink}


### PR DESCRIPTION
It's not showing the blog without the comments URL. 


<img width="337" alt="Screenshot 2023-01-23 at 12 41 14" src="https://user-images.githubusercontent.com/20840228/213981631-f44bc74c-2baf-4563-bc21-15c75c51dfe6.png"><img width="342" alt="Screenshot 2023-01-23 at 12 43 47" src="https://user-images.githubusercontent.com/20840228/213982168-57dbaf2d-5af3-4614-b0e4-bf9b4670c873.png">

