### PR TITLE
Studio: Document live metrics for local experiments

### DIFF
--- a/content/docs/studio/get-started.md
+++ b/content/docs/studio/get-started.md
@@ -107,8 +107,8 @@ You should now see that a project has been added in your dashboard.
 
 1. You can use your project to [submit new experiments] from Iterative Studio.
 
-2. For the experiments that you submit from Iterative Studio, you can [track
-   live metrics and plots][live-metrics-and-plots] by using [DVCLive].
+2. You can [track live metrics and plots][live-metrics-and-plots] by using
+   [DVCLive].
 
 ## Use model registry
 

--- a/content/docs/studio/how-it-works.md
+++ b/content/docs/studio/how-it-works.md
@@ -24,9 +24,7 @@ https://www.youtube.com/watch?v=5xM5az78Lrg
 - Using Iterative Studio, or using [GTO] and possibly [MLEM], you will push
   information about your ML models as Git commits and tags.
 - Using [DVCLive], you will push live metrics and plots from your experiments to
-  Iterative Studio. Note that at the moment, live metrics are supported only for
-  experiments that you [submit from the Iterative Studio
-  UI][run new experiments].
+  Iterative Studio.
 
 ## How Iterative Studio extracts your project data
 

--- a/content/docs/studio/user-guide/projects-and-experiments/live-metrics-and-plots.md
+++ b/content/docs/studio/user-guide/projects-and-experiments/live-metrics-and-plots.md
@@ -1,21 +1,14 @@
 # Generate live (real-time) metrics and plots for remote experiments
 
-When you
-[submit a new experiment](/doc/studio/user-guide/projects-and-experiments/run-experiments)
-from Iterative Studio, the
-[CI/CD setup](/doc/use-cases/ci-cd-for-machine-learning) in your Git repository
-gets invoked. If this setup includes a model training process, it will be
-triggered.
-
-In this model training CI action, you can use [DVCLive] to send live updates to
-metrics and plots back to Iterative Studio, without writing them to your Git
-repository. This will enable you to view all intermediate results in Studio
-while your experiment is still running.
+In your model training script, you can use [DVCLive] to send live updates to
+metrics and plots to Iterative Studio, without writing them to your Git
+repository. This will enable you to view all intermediate results in Iterative
+Studio while your experiment is still running.
 
 This requires a 3-step process:
 
 1. [Set up an access token](#set-up-an-access-token)
-2. [Configure your model training CI job](#configure-your-model-training-ci-job)
+2. [Configure your model training job](#configure-your-model-training-job)
 3. [Send and view the updates](#send-and-view-live-metrics-and-plots)
 
 ## Set up an access token
@@ -30,16 +23,25 @@ your password. That is, you can reset all your access credentials (your password
 and the access token) at once. This is handy if you suspect that your account
 security may have been compromised.
 
-## Configure your model training CI job
+## Configure your model training job
 
-You should define the following environment variables in your CI job:
+You should provide the following environment variables to your model training
+job:
 
 1.  `STUDIO_TOKEN`: The access token must be present in any request that sends
     data to the Iterative Studio ingestion endpoint. Requests with missing or
     incorrect access tokens are rejected with an appropriate HTTP error code and
     error message.
 
-    A secure way to provide the access token is to create a
+    If you are running the experiment locally, you can set this environment
+    variable when submitting the training job.
+
+    ```
+    $ STUDIO_TOKEN=**** dvc exp run
+    ```
+
+    If you are running the experiment as part of a CI job, a secure way to
+    provide the access token is to create a
     [GitHub secret](https://docs.github.com/en/actions/security-guides/encrypted-secrets)
     containing the value of the token, and use the secret in your CI job (see
     example below).
@@ -53,10 +55,11 @@ You should define the following environment variables in your CI job:
     ...
     ```
 
-2.  `STUDIO_REPO_URL`: If your repository is on github.com, gitlab.com or
-    bitbucket.org, you do not need to set this environment variable. But if you
-    are using some other Git provider, then you should set the repository url in
-    this format: `{remote-type}:{namespace}/{repo-name}`. For example, for the
+2.  `STUDIO_REPO_URL`: If you are running the experiment locally, or your
+    repository is on github.com, gitlab.com or bitbucket.org, you do not need to
+    set this environment variable. But if you are using some other Git provider,
+    then you should set the repository url in this format:
+    `{remote-type}:{namespace}/{repo-name}`. For example, for the
     `example-get-started` repository in the `iterative` namespace,
     `STUDIO_REPO_URL` should be set to the following value:
 
@@ -67,9 +70,9 @@ You should define the following environment variables in your CI job:
 
 ## Send and view live metrics and plots
 
-In the training CI job (which has been configured as detailed above), whenever
-you log your metrics or plots using [DVCLive], they will be automatically sent
-to Iterative Studio. Here is an example of how you can use [DVCLive] in your
+In the training job (which has been configured as detailed above), whenever you
+log your metrics or plots using [DVCLive], they will be automatically sent to
+Iterative Studio. Here is an example of how you can use [DVCLive] in your
 training code:
 
 ```
@@ -124,8 +127,9 @@ An experiment can have one of the following statuses:
 - **Completed** - Iterative Studio does not expect to receive any more updates
   for these experiments. Once the experiment concludes, you can delete the live
   metrics row from the project table. Iterative Studio does not automatically
-  commit and push the final results of your experiment to Git. Your CI action
-  should persist the final results in Git.
+  commit and push the final results of your experiment to Git. If you want to
+  save the experiment result, you should persist it using appropriate Git
+  commands.
 
 <admon>
 

--- a/content/docs/studio/user-guide/projects-and-experiments/live-metrics-and-plots.md
+++ b/content/docs/studio/user-guide/projects-and-experiments/live-metrics-and-plots.md
@@ -97,9 +97,8 @@ DVCLive signals the end of the experiment using `live.end()`. Using
 
 Iterative Studio stores the live metrics and plots data in its database.
 
-In the project table, the live metrics are displayed next to the Git commit
-corresponding to the experiment. Updates to the live metrics are highlighted in
-orange.
+In the project table, the live metrics are displayed nested under the parent Git
+commit. Updates to the live metrics are highlighted in orange.
 
 ![](https://static.iterative.ai/img/studio/live_metrics.gif)
 

--- a/content/docs/studio/user-guide/projects-and-experiments/visualize-and-compare.md
+++ b/content/docs/studio/user-guide/projects-and-experiments/visualize-and-compare.md
@@ -74,9 +74,9 @@ experiment, you can use the plots to compare them.
 
 ### Live plots
 
-For the experiments that you submit from Iterative Studio, you can [send live
-updates to your plots][live-metrics-and-plots] by using [DVCLive]. The number of
-recent updates to the live metrics are displayed in the `Live` icon as shown
+You can [send live updates to your plots][live-metrics-and-plots] by using
+[DVCLive]. The number of recent updates to the live metrics are displayed in the
+`Live` icon as shown
 [here](/doc/studio/user-guide/projects-and-experiments/explore-ml-experiments#git-history-and-live-metrics).
 
 Live plots are also shown in the plots pane, just like all other plots.


### PR DESCRIPTION
Closes https://github.com/iterative/studio/issues/4941

Update Studio docs to include live metrics for local experiments. Most of the changes are in this file: `content/docs/studio/user-guide/projects-and-experiments/live-metrics-and-plots.md`