### PR TITLE
Studio: Change "Run" button to "Experiment" button as per change in S…

### DIFF
--- a/content/docs/studio/user-guide/projects-and-experiments/explore-ml-experiments.md
+++ b/content/docs/studio/user-guide/projects-and-experiments/explore-ml-experiments.md
@@ -137,7 +137,7 @@ The table also contains buttons to visualize, compare and run experiments.
 - **Show plots:** Show plots for the selected commits. When you click on this
   button, plots for the selected commits are displayed in a `Plots ` pane.
 - **Compare:** Compare different experiments side by side.
-- **Run:** Run experiments by selecting any one commit. Refer
+- **Experiment:** Run experiments by selecting any one commit. Refer
   [here][run-experiments] for details on how to run experiments and track
   metrics in real time.
 - **Trends:** Generate trend charts to show metric evolution over time.

--- a/content/docs/studio/user-guide/projects-and-experiments/run-experiments.md
+++ b/content/docs/studio/user-guide/projects-and-experiments/run-experiments.md
@@ -41,8 +41,8 @@ you should do the following:
 
 ## Use the Iterative Studio wizard to set up your CI action
 
-Select a commit and click **Run**. You will see a message that invites you to
-set up your CI.
+Select a commit and click **Experiment**. You will see a message that invites
+you to set up your CI.
 
 ![](https://static.iterative.ai/img/studio/set_up_cml_message.png)
 
@@ -101,8 +101,8 @@ https://www.youtube.com/watch?v=nXJXR-zBvHQ
 
 To run experiments from Iterative Studio, first you need to determine the Git
 commit (experiment) on which you want to iterate. Select the commit that you
-want to use and click the `Run` button. A form will let you specify all the
-changes that you want to make to your experiment. On this form, there are 2
+want to use and click the `Experiment` button. A form will let you specify all
+the changes that you want to make to your experiment. On this form, there are 2
 types of inputs that you can change:
 
 1. **Input data files**: You can change datasets that are used for model


### PR DESCRIPTION
Minor change to rename `Run` button to `Experiment`. The button was renamed in Studio a while back, and we missed updating the docs. Thanks @jendefig for reporting this.