### PR TITLE
guide: add run cache page to pipelines

### DIFF
--- a/content/docs/sidebar.json
+++ b/content/docs/sidebar.json
@@ -133,7 +133,7 @@
       {
         "slug": "pipelines",
         "source": "pipelines/index.md",
-        "children": ["defining-pipelines"]
+        "children": ["defining-pipelines", "run-cache"]
       },
       {
         "label": "Experiment Management",

--- a/content/docs/user-guide/pipelines/run-cache.md
+++ b/content/docs/user-guide/pipelines/run-cache.md
@@ -1,0 +1,13 @@
+# Run Cache: Automatic Log of Stage Runs
+
+Every time you [reproduce](/doc/command-reference/repro) a pipeline with DVC, it
+logs the unique signature of each stage run (in `.dvc/cache/runs` by default).
+If it never happened before, its command(s) are executed normally. Every
+subsequent time a [stage](/doc/command-reference/run) runs under the same
+conditions, the previous results can be restored instantly, without wasting time
+or computing resources.
+
+✅ This built-in feature is called <abbr>run-cache</abbr> and it can
+dramatically improve performance. It's enabled out-of-the-box (can be disabled),
+which means DVC is already saving all of your tests and experiments behind the
+scene.


### PR DESCRIPTION
Follow up to discussion in https://github.com/iterative/dvc.org/pull/4220#discussion_r1080636192. I dropped the run cache description in the experiments guide, but here I'm adding it back as a separate page in the pipelines guide. It's short, but I'm not sure that's a bad thing. It's probably the most important feature of pipelines, so it seems reasonable to have its own page.