### PR TITLE
Update troubleshooting.md

### DIFF
--- a/content/docs/user-guide/troubleshooting.md
+++ b/content/docs/user-guide/troubleshooting.md
@@ -130,11 +130,11 @@ change their configuration to avoid shallow cloning. Common examples:
 <toggle>
 <tab title="CML">
 
-[CML](https://cml.dev) has a convenient `--unshallow` option for its
+[CML](https://cml.dev) has a convenient `fetch-depth` option for its
 [`ci`](https://cml.dev/doc/ref/ci) command:
 
 ```cli
-$ cml ci --unshallow
+$ cml ci --fetch-depth 0
 ```
 
 </tab>

--- a/content/docs/user-guide/troubleshooting.md
+++ b/content/docs/user-guide/troubleshooting.md
@@ -130,7 +130,7 @@ change their configuration to avoid shallow cloning. Common examples:
 <toggle>
 <tab title="CML">
 
-[CML](https://cml.dev) has a convenient `fetch-depth` option for its
+[CML](https://cml.dev) has a convenient `--fetch-depth` option for its
 [`ci`](https://cml.dev/doc/ref/ci) command:
 
 ```cli


### PR DESCRIPTION
Looks like `unshallow` is deprecated in https://cml.dev/doc/ref/ci#options