### PR TITLE
include custom auth header for webdav

### DIFF
--- a/content/docs/command-reference/remote/modify.md
+++ b/content/docs/command-reference/remote/modify.md
@@ -1217,9 +1217,11 @@ by HDFS. Read more about by expanding the WebHDFS section in
   $ dvc remote modify --local myremote password mypassword
   ```
 
-> Note that `user/password`, `custom_auth_header/password` and `token` authentication are incompatible. You
-> should authenticate against your WebDAV remote by either `user/password`, `custom_auth_header/password` or
-> `token`.
+  <admon type="info">
+
+  `user/custom_auth_header`, `password` auth is incompatible with `token` auth.
+
+  </admon>
 
 - `ask_password` - ask each time for the password to use for `user/password`
   authentication. This has no effect if `password` or `token` are set.

--- a/content/docs/command-reference/remote/modify.md
+++ b/content/docs/command-reference/remote/modify.md
@@ -1202,15 +1202,21 @@ by HDFS. Read more about by expanding the WebHDFS section in
   1. `user` parameter set with this command (found in `.dvc/config`);
   2. User defined in the URL (e.g. `webdavs://user@example.com/endpoint/path`)
 
-- `password` - password for WebDAV server, can be empty in case of using `token`
-  authentication.
+- `custom_auth_header` - custom header field name to use for authentication. Value is set via `password`.
+
+  ```cli
+  $ dvc remote modify --local myremote \
+                      custom_auth_header 'My-Header'
+  ```
+
+- `password` - password for WebDAV server, used with `user` or `custom_auth_header`, can be empty in case of using `token` authentication.
 
   ```cli
   $ dvc remote modify --local myremote password mypassword
   ```
 
-> Note that `user/password` and `token` authentication are incompatible. You
-> should authenticate against your WebDAV remote by either `user/password` or
+> Note that `user/password`, `custom_auth_header/password` and `token` authentication are incompatible. You
+> should authenticate against your WebDAV remote by either `user/password`, `custom_auth_header/password` or
 > `token`.
 
 - `ask_password` - ask each time for the password to use for `user/password`

--- a/content/docs/command-reference/remote/modify.md
+++ b/content/docs/command-reference/remote/modify.md
@@ -1202,7 +1202,7 @@ by HDFS. Read more about by expanding the WebHDFS section in
   1. `user` parameter set with this command (found in `.dvc/config`);
   2. User defined in the URL (e.g. `webdavs://user@example.com/endpoint/path`)
 
-- `custom_auth_header` - custom header field name to use for authentication. Value is set via `password`.
+- `custom_auth_header` - HTTP header field name to use for authentication. Value is set via `password`.
 
   ```cli
   $ dvc remote modify --local myremote \

--- a/content/docs/command-reference/remote/modify.md
+++ b/content/docs/command-reference/remote/modify.md
@@ -1206,10 +1206,12 @@ by HDFS. Read more about by expanding the WebHDFS section in
   is set via `password`.
 
   ```cli
-  $ dvc remote modify --local myremote custom_auth_header 'My-Header'
+  $ dvc remote modify --local myremote \
+                      custom_auth_header 'My-Header'
   ```
 
-- `password` - password for WebDAV server, used with `user` or `custom_auth_header`, can be empty in case of using `token` authentication.
+- `password` - password for WebDAV server, combined either with `user` or
+  `custom_auth_header`. Leave empty for `token` authentication.
 
   ```cli
   $ dvc remote modify --local myremote password mypassword

--- a/content/docs/command-reference/remote/modify.md
+++ b/content/docs/command-reference/remote/modify.md
@@ -1219,7 +1219,8 @@ by HDFS. Read more about by expanding the WebHDFS section in
 
   <admon type="info">
 
-  `user/custom_auth_header`, `password` auth is incompatible with `token` auth.
+  Auth based on `user` or `custom_auth_header` (with `password`) is incompatible
+  with `token` auth.
 
   </admon>
 

--- a/content/docs/command-reference/remote/modify.md
+++ b/content/docs/command-reference/remote/modify.md
@@ -1202,11 +1202,11 @@ by HDFS. Read more about by expanding the WebHDFS section in
   1. `user` parameter set with this command (found in `.dvc/config`);
   2. User defined in the URL (e.g. `webdavs://user@example.com/endpoint/path`)
 
-- `custom_auth_header` - HTTP header field name to use for authentication. Value is set via `password`.
+- `custom_auth_header` - HTTP header field name to use for authentication. Value
+  is set via `password`.
 
   ```cli
-  $ dvc remote modify --local myremote \
-                      custom_auth_header 'My-Header'
+  $ dvc remote modify --local myremote custom_auth_header 'My-Header'
   ```
 
 - `password` - password for WebDAV server, used with `user` or `custom_auth_header`, can be empty in case of using `token` authentication.


### PR DESCRIPTION
@skshetry I added the additional option for using custom auth header with webdav remote to the documentation.

> You may disregard these recommendations if you used the **Edit on GitHub** button from dvc.org to improve a doc in place.

❗ Please read the guidelines in the [Contributing to the Documentation](https://dvc.org/doc/user-guide/contributing/docs) list if you make any substantial changes to the documentation or JS engine.

🐛 Please make sure to mention `Fix #issue` (if applicable) in the description of the PR. This causes GitHub to close it automatically when the PR is merged.

Please choose to [allow us](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to edit your branch when creating the PR.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
