### PR TITLE
dvclive: 2.0 docs (adds make_dvcyaml)

### DIFF
--- a/content/docs/dvclive/api-reference/index.md
+++ b/content/docs/dvclive/api-reference/index.md
@@ -94,7 +94,7 @@ live.next_step()
 See `Live.next_step()`.
 
 Under the hood, `Live.next_step()` calls `Live.make_summary()`,
-`Live.make_dvcyaml`, and `Live.make_report()`.
+`Live.make_dvcyaml()`, and `Live.make_report()`.
 
 If you want to decouple the `step` update from the rest of the calls, you can
 manually modify the `Live.step` property and call `Live.make_summary()` / /

--- a/content/docs/dvclive/api-reference/index.md
+++ b/content/docs/dvclive/api-reference/index.md
@@ -97,7 +97,7 @@ Under the hood, `Live.next_step()` calls `Live.make_summary()`,
 `Live.make_dvcyaml()`, and `Live.make_report()`.
 
 If you want to decouple the `step` update from the rest of the calls, you can
-manually modify the `Live.step` property and call `Live.make_summary()` / /
+manually modify the `Live.step` property and call `Live.make_summary()` /
 `Live.make_dvcyaml()` / `Live.make_report()`.
 
 ## Putting it all together

--- a/content/docs/dvclive/api-reference/index.md
+++ b/content/docs/dvclive/api-reference/index.md
@@ -93,12 +93,12 @@ live.next_step()
 
 See `Live.next_step()`.
 
-Under the hood, `Live.next_step()` calls `Live.make_summary()` and
-`Live.make_report()`.
+Under the hood, `Live.next_step()` calls `Live.make_summary()`,
+`Live.make_dvcyaml`, and `Live.make_report()`.
 
 If you want to decouple the `step` update from the rest of the calls, you can
-manually modify the `Live.step` property and call `Live.make_summary()` /
-`Live.make_report()`.
+manually modify the `Live.step` property and call `Live.make_summary()` / /
+`Live.make_dvcyaml()` / `Live.make_report()`.
 
 ## Putting it all together
 

--- a/content/docs/dvclive/api-reference/live/end.md
+++ b/content/docs/dvclive/api-reference/live/end.md
@@ -34,8 +34,8 @@ model.fit(
 
 ## Description
 
-By default, `Live.end()` will call `Live.make_summary()` and
-`Live.make_report()`.
+By default, `Live.end()` will call `Live.make_summary()`, `Live.make_dvcyaml()`,
+and `Live.make_report()`.
 
 If `save_dvc_exp=True` has been passed to `Live`, it will
 [save a new DVC experiment](/doc/dvclive/how-it-works#track-the-results) and

--- a/content/docs/dvclive/api-reference/live/index.md
+++ b/content/docs/dvclive/api-reference/live/index.md
@@ -77,8 +77,7 @@ You can use `Live()` as a context manager. When exiting the context manager,
 
 - `save_dvc_exp` - If `True`, DVCLive will create a new
   [DVC experiment](/doc/dvclive/how-it-works#track-the-results) as part of
-  `Live.end()`. Ignored if your repo already has a
-  [DVC pipeline](/doc/user-guide/pipelines). Defaults to `False`.
+  `Live.end()`. Defaults to `False`.
 
 - `dvcyaml` - If `True`, DVCLive will write
   [DVC configuration](/doc/user-guide/project-structure/dvcyaml-files) for

--- a/content/docs/dvclive/api-reference/live/index.md
+++ b/content/docs/dvclive/api-reference/live/index.md
@@ -86,6 +86,13 @@ You can use `Live()` as a context manager. When exiting the context manager,
   [`Live.dvc_file`](/doc/dvclive/api-reference/live#properties). See
   `Live.make_dvcyaml()`. Defaults to `True`.
 
+<admon type="tip">
+
+If you have custom DVC configuration of metrics, plots, and parameters in your
+own `dvc.yaml` file, set `dvcyaml=False` to avoid duplication.
+
+</admon>
+
 ## Methods
 
 - `Live.log_image()`

--- a/content/docs/dvclive/api-reference/live/index.md
+++ b/content/docs/dvclive/api-reference/live/index.md
@@ -88,7 +88,7 @@ You can use `Live()` as a context manager. When exiting the context manager,
 
 <admon type="tip">
 
-If you have custom DVC configuration of metrics, plots, and parameters in your
+If you are already tracking DVCLive metrics, plots, and parameters in your
 own `dvc.yaml` file, set `dvcyaml=False` to avoid duplication.
 
 </admon>

--- a/content/docs/dvclive/api-reference/live/index.md
+++ b/content/docs/dvclive/api-reference/live/index.md
@@ -11,6 +11,7 @@ class Live:
         resume: bool = False,
         report: Optional[str] = "auto",
         save_dvc_exp: bool = False,
+        dvcyaml: bool = True,
     ):
 ```
 
@@ -79,6 +80,12 @@ You can use `Live()` as a context manager. When exiting the context manager,
   `Live.end()`. Ignored if your repo already has a
   [DVC pipeline](/doc/user-guide/pipelines). Defaults to `False`.
 
+- `dvcyaml` - If `True`, DVCLive will write
+  [DVC configuration](/doc/user-guide/project-structure/dvcyaml-files) for
+  metrics, plots, and parameters to
+  [`Live.dvc_file`](/doc/dvclive/api-reference/live#properties). See
+  `Live.make_dvcyaml()`. Defaults to `True`.
+
 ## Methods
 
 - `Live.log_image()`
@@ -86,6 +93,7 @@ You can use `Live()` as a context manager. When exiting the context manager,
 - `Live.log_param()`
 - `Live.log_params()`
 - `Live.log_sklearn_plot()`
+- `Live.make_dvcyaml()`
 - `Live.make_report()`
 - `Live.make_summary()`
 - `Live.next_step()`

--- a/content/docs/dvclive/api-reference/live/index.md
+++ b/content/docs/dvclive/api-reference/live/index.md
@@ -83,13 +83,14 @@ You can use `Live()` as a context manager. When exiting the context manager,
 - `dvcyaml` - If `True`, DVCLive will write
   [DVC configuration](/doc/user-guide/project-structure/dvcyaml-files) for
   metrics, plots, and parameters to
-  [`Live.dvc_file`](/doc/dvclive/api-reference/live#properties). See
-  `Live.make_dvcyaml()`. Defaults to `True`.
+  [`Live.dvc_file`](/doc/dvclive/api-reference/live#properties) as part of
+  `Live.next_step()` and `Live.end()`. See `Live.make_dvcyaml()`. Defaults to
+  `True`.
 
 <admon type="tip">
 
-If you are already tracking DVCLive metrics, plots, and parameters in your
-own `dvc.yaml` file, set `dvcyaml=False` to avoid duplication.
+If you are already tracking DVCLive metrics, plots, and parameters in your own
+`dvc.yaml` file, set `dvcyaml=False` to avoid duplication.
 
 </admon>
 

--- a/content/docs/dvclive/api-reference/live/make_dvcyaml.md
+++ b/content/docs/dvclive/api-reference/live/make_dvcyaml.md
@@ -22,8 +22,8 @@ live.make_dvcyaml()
 
 ## Description
 
-If `Live(dvcyaml=True)`, DVCLive will collect all the data logged in
-`{Live.dir}` and save the DVC configuration for it in `{Live.dir}/dvc.yaml`.
+DVCLive will collect all the data logged in `{Live.dir}` and save the DVC
+configuration for it in `{Live.dir}/dvc.yaml`.
 
 ```yaml
 params:

--- a/content/docs/dvclive/api-reference/live/make_dvcyaml.md
+++ b/content/docs/dvclive/api-reference/live/make_dvcyaml.md
@@ -1,0 +1,42 @@
+# Live.make_dvcyaml()
+
+Writes [DVC configuration](/doc/user-guide/project-structure/dvcyaml-files) for
+metrics, plots, and parameters to
+[`Live.dvc_file`](/doc/dvclive/api-reference/live#properties).
+
+```py
+def make_dvcyaml()
+```
+
+## Usage
+
+```py
+from dvclive import Live
+
+live = Live()
+live.log_param("lr", 0.01)
+live.log_metric("acc", 0.9)
+live.log_sklearn_plot("confusion_matrix", [0, 0, 1, 1], [1, 0, 0, 1])
+live.make_dvcyaml()
+```
+
+## Description
+
+If `Live(dvcyaml=True)`, DVCLive will collect all the data logged in
+`{Live.dir}` and save the DVC configuration for it in `{Live.dir}/dvc.yaml`.
+
+```yaml
+params:
+  - params.yaml
+metrics:
+  - metrics.json
+plots:
+  - plots/metrics
+  - plots/sklearn/confusion_matrix.json:
+      template: confusion
+      x: actual
+      y: predicted
+      title: Confusion Matrix
+      x_label: True Label
+      y_label: Predicted Label
+```

--- a/content/docs/dvclive/api-reference/live/make_dvcyaml.md
+++ b/content/docs/dvclive/api-reference/live/make_dvcyaml.md
@@ -22,8 +22,15 @@ live.make_dvcyaml()
 
 ## Description
 
-DVCLive will collect all the data logged in `{Live.dir}` and save the DVC
-configuration for it in `{Live.dir}/dvc.yaml`.
+Creates `{Live.dir}/dvc.yaml`, which describes and configures metrics, plots,
+and parameters. DVC tools use this file to show reports and experiments tables.
+
+<admon type="info">
+
+If `Live(dvcyaml=True)`, `Live.next_step()` and `Live.end()` will call
+`Live.make_dvcyaml()` internally, so you don't need to call both.
+
+</admon>
 
 ```yaml
 params:

--- a/content/docs/dvclive/api-reference/live/make_report.md
+++ b/content/docs/dvclive/api-reference/live/make_report.md
@@ -24,4 +24,11 @@ a report and save it in `{Live.dir}/report.{format}`.
 The `format` can be HTML or Markdown depending on the value of the `report`
 argument passed to [`Live()`](/doc/dvclive/api-reference/live#parameters).
 
+<admon type="info">
+
+`Live.next_step()` and `Live.end()` will call `Live.make_report()` internally,
+so you don't need to call both.
+
+</admon>
+
 ![](/img/dvclive-html.gif)

--- a/content/docs/dvclive/api-reference/live/make_summary.md
+++ b/content/docs/dvclive/api-reference/live/make_summary.md
@@ -25,8 +25,8 @@ above.
 
 <admon type="info">
 
-`Live.next_step()` will call `Live.make_summary()` internally, so you don't need
-to call both.
+`Live.next_step()` and `Live.end()` will call `Live.make_summary()` internally,
+so you don't need to call both.
 
 </admon>
 

--- a/content/docs/dvclive/api-reference/live/next_step.md
+++ b/content/docs/dvclive/api-reference/live/next_step.md
@@ -26,12 +26,8 @@ DVCLive uses `step` to track the history of the metrics logged with
 
 You can use `Live.next_step()` to increase the `step` by 1 (one).
 
-In addition to increasing the `step` number, it will call `Live.make_report()`
-and `Live.make_summary()`.
-
-If `save_dvc_exp=True` has been passed to `Live()`, `Live.next_step()` will
-write a `dvc.yaml` file configuring what DVC will show for logged plots,
-metrics, and parameters.
+In addition to increasing the `step` number, it will call `Live.make_report()`,
+`Live.make_dvcyaml()`, and `Live.make_summary()`.
 
 ### Manual step updates
 

--- a/content/docs/dvclive/api-reference/live/next_step.md
+++ b/content/docs/dvclive/api-reference/live/next_step.md
@@ -27,7 +27,7 @@ DVCLive uses `step` to track the history of the metrics logged with
 You can use `Live.next_step()` to increase the `step` by 1 (one).
 
 In addition to increasing the `step` number, it will call `Live.make_report()`,
-`Live.make_dvcyaml()`, and `Live.make_summary()`.
+`Live.make_dvcyaml()`, and `Live.make_summary()` by default.
 
 ### Manual step updates
 

--- a/content/docs/dvclive/how-it-works.md
+++ b/content/docs/dvclive/how-it-works.md
@@ -12,7 +12,7 @@ The contents of the directory will depend on the methods used:
 | `Live.log_image()`        | `dvclive/plots/images`                                                     |
 | `Live.log_param()`        | `dvclive/params.yaml`                                                      |
 | `Live.log_sklearn_plot()` | `dvclive/plots/sklearn`                                                    |
-| `Live.make_dvcyaml()`     | `dvclive/dvcyaml`                                                          |
+| `Live.make_dvcyaml()`     | `dvclive/dvc.yaml`                                                          |
 | `Live.make_report()`      | `dvclive/report.{md/html}`                                                 |
 | `Live.make_summary()`     | `dvclive/metrics.json`                                                     |
 | `Live.next_step()`        | dvclive/dvc.yaml`<br>`dvclive/metrics.json`<br>`dvclive/report.{md/html}`  |

--- a/content/docs/dvclive/how-it-works.md
+++ b/content/docs/dvclive/how-it-works.md
@@ -12,7 +12,7 @@ The contents of the directory will depend on the methods used:
 | `Live.log_image()`        | `dvclive/plots/images`                                                     |
 | `Live.log_param()`        | `dvclive/params.yaml`                                                      |
 | `Live.log_sklearn_plot()` | `dvclive/plots/sklearn`                                                    |
-| `Live.make_dvcyaml()`     | `dvclive/dvc.yaml`                                                          |
+| `Live.make_dvcyaml()`     | `dvclive/dvc.yaml`                                                         |
 | `Live.make_report()`      | `dvclive/report.{md/html}`                                                 |
 | `Live.make_summary()`     | `dvclive/metrics.json`                                                     |
 | `Live.next_step()`        | dvclive/dvc.yaml`<br>`dvclive/metrics.json`<br>`dvclive/report.{md/html}`  |

--- a/content/docs/dvclive/how-it-works.md
+++ b/content/docs/dvclive/how-it-works.md
@@ -6,16 +6,17 @@ used by default.
 
 The contents of the directory will depend on the methods used:
 
-| Method                    | Writes to                                                                                           |
-| ------------------------- | --------------------------------------------------------------------------------------------------- |
-| `Live.log_metric()`       | `dvclive/plots/metrics`                                                                             |
-| `Live.log_image()`        | `dvclive/plots/images`                                                                              |
-| `Live.log_param()`        | `dvclive/params.yaml`                                                                               |
-| `Live.log_sklearn_plot()` | `dvclive/plots/sklearn`                                                                             |
-| `Live.make_report()`      | `dvclive/report.{md/html}`                                                                          |
-| `Live.make_summary()`     | `dvclive/metrics.json`                                                                              |
-| `Live.next_step()`        | `dvclive/dvc.yaml` (if `save_dvc_exp=True`)<br>`dvclive/metrics.json`<br>`dvclive/report.{md/html}` |
-| `Live.end()`              | `dvclive/dvc.yaml` (if `save_dvc_exp=True`)<br>`dvclive/metrics.json`<br>`dvclive/report.{md/html}` |
+| Method                    | Writes to                                                                  |
+| ------------------------- | -------------------------------------------------------------------------- |
+| `Live.log_metric()`       | `dvclive/plots/metrics`                                                    |
+| `Live.log_image()`        | `dvclive/plots/images`                                                     |
+| `Live.log_param()`        | `dvclive/params.yaml`                                                      |
+| `Live.log_sklearn_plot()` | `dvclive/plots/sklearn`                                                    |
+| `Live.make_dvcyaml()`     | `dvclive/dvcyaml`                                                          |
+| `Live.make_report()`      | `dvclive/report.{md/html}`                                                 |
+| `Live.make_summary()`     | `dvclive/metrics.json`                                                     |
+| `Live.next_step()`        | dvclive/dvc.yaml`<br>`dvclive/metrics.json`<br>`dvclive/report.{md/html}`  |
+| `Live.end()`              | `dvclive/dvc.yaml`<br>`dvclive/metrics.json`<br>`dvclive/report.{md/html}` |
 
 ## Example
 
@@ -74,7 +75,4 @@ your repo.
 
 If you don't have a DVC pipeline, you can include
 [`save_dvc_exp=True`](/doc/dvclive/api-reference/live#parameters) to save the
-results as a DVC experiment. `save_dvc_exp=True` also writes out configuration
-for your plots, metrics, and parameters to a
-[`dvc.yaml`](/doc/user-guide/project-structure/dvcyaml-files) so that DVC knows
-how to visualize and compare them.
+results as a DVC experiment.

--- a/content/docs/sidebar.json
+++ b/content/docs/sidebar.json
@@ -656,6 +656,10 @@
                 "label": "log_sklearn_plot()"
               },
               {
+                "slug": "make_dvcyaml",
+                "label": "make_dvcyaml()"
+              },
+              {
                 "slug": "make_report",
                 "label": "make_report()"
               },


### PR DESCRIPTION
Context:

We are working to quickly do a DVCLive 2.0 release, primarily to smooth the onboarding experience for existing DVC users. Onboarding worked well for new users but was being ignored in existing DVC projects. This was a conscious choice to avoid being overly intrusive for users who didn’t need the onboarding, but users find it unexpected and want to still get the benefits (like auto config of metrics/plots/params).

~I'm missing how to make `Live.make_dvcyaml()` appear as a hyperlink.~ Edit: resolved