### PR TITLE
Studio: Live metrics - make STUDIO_REPO_URL mandatory in CI job

### DIFF
--- a/content/docs/studio/user-guide/projects-and-experiments/live-metrics-and-plots.md
+++ b/content/docs/studio/user-guide/projects-and-experiments/live-metrics-and-plots.md
@@ -63,9 +63,9 @@ job:
     `STUDIO_REPO_URL` should be set to the following value:
 
     - If you are using GitHub.com, GitLab.com or Bitbucket.org, set it to
-      `github:iterative/example-get-started`,
-      `gitlab:iterative/example-get-started`,
-      `bitbucket:iterative/example-get-started` respectively.
+      `git@github.com:iterative/example-get-started.git`,
+      `git@gitlab.com:iterative/example-get-started.git`,
+      `git@bitbucket.org:iterative/example-get-started.git` respectively.
     - If you are using a custom (self-hosted) GitLab server, set it to
       `custom-gitlab:iterative/example-get-started`.
     - If you are using a GitHub enterprise server, set it to

--- a/content/docs/studio/user-guide/projects-and-experiments/live-metrics-and-plots.md
+++ b/content/docs/studio/user-guide/projects-and-experiments/live-metrics-and-plots.md
@@ -55,14 +55,17 @@ job:
     ...
     ```
 
-2.  `STUDIO_REPO_URL`: If you are running the experiment locally, or your
-    repository is on github.com, gitlab.com or bitbucket.org, you do not need to
-    set this environment variable. But if you are using some other Git provider,
-    then you should set the repository url in this format:
+2.  `STUDIO_REPO_URL`: If you are running the experiment locally, you do not
+    need to set this environment variable. But if you are running it in a CI
+    job, then you should set the repository url in this format:
     `{remote-type}:{namespace}/{repo-name}`. For example, for the
     `example-get-started` repository in the `iterative` namespace,
     `STUDIO_REPO_URL` should be set to the following value:
 
+    - If you are using GitHub.com, GitLab.com or Bitbucket.org, set it to
+      `github:iterative/example-get-started`,
+      `gitlab:iterative/example-get-started`,
+      `bitbucket:iterative/example-get-started` respectively.
     - If you are using a custom (self-hosted) GitLab server, set it to
       `custom-gitlab:iterative/example-get-started`.
     - If you are using a GitHub enterprise server, set it to


### PR DESCRIPTION
Make STUDIO_REPO_URL mandatory in CI job as per [this discussion](https://iterativeai.slack.com/archives/C03Q04KL6LQ/p1675429041743359?thread_ts=1675422386.926439&cid=C03Q04KL6LQ)