### PR TITLE
Fix cloud versioning params location

### DIFF
--- a/content/docs/command-reference/remote/modify.md
+++ b/content/docs/command-reference/remote/modify.md
@@ -139,6 +139,33 @@ options:
   $ dvc remote modify myremote connect_timeout 300
   ```
 
+<admon type="tip">
+
+The `version_aware` and `worktree` options require that
+[S3 Versioning](https://docs.aws.amazon.com/AmazonS3/latest/userguide/Versioning.html)
+be enabled on the specified S3 bucket.
+
+</admon>
+
+- `version_aware` - Use
+  [version-aware](/docs/user-guide/data-management/cloud-versioning#version-aware-remotes)
+  cloud versioning features for this S3 remote. Files stored in the remote will
+  retain their original filenames and directory hierarchy, and different
+  versions of files will be stored as separate versions of the corresponding
+  object in the remote.
+
+- `worktree` - Use
+  [worktree](/docs/user-guide/data-management/cloud-versioning#worktree-remotes)
+  cloud versioning features for this S3 remote. Files stored in the remote will
+  retain their original filenames and directory hierarchy, and different
+  versions of files will be stored as separate versions of the corresponding
+  object in cloud storage. DVC will also attempt to ensure that the current
+  version of objects in the remote match the latest version of files in the DVC
+  repository. When both `version_aware` and `worktree` are set, `worktree` takes
+  precedence.
+
+**Authentication**
+
 By default, DVC authenticates using your AWS CLI
 [configuration](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-configure.html)
 (if set). This uses the default AWS credentials file. Use the following
@@ -334,31 +361,6 @@ $ dvc push
 For more on the supported env vars, please see the
 [boto3 docs](https://boto3.amazonaws.com/v1/documentation/api/latest/guide/configuration.html#using-environment-variables)
 
-- `version_aware` - Use
-  [version-aware](/docs/user-guide/data-management/cloud-versioning#version-aware-remotes)
-  cloud versioning features for this S3 remote. Files stored in the remote will
-  retain their original filenames and directory hierarchy, and different
-  versions of files will be stored as separate versions of the corresponding
-  object in the remote.
-
-- `worktree` - Use
-  [worktree](/docs/user-guide/data-management/cloud-versioning#worktree-remotes)
-  cloud versioning features for this S3 remote. Files stored in the remote will
-  retain their original filenames and directory hierarchy, and different
-  versions of files will be stored as separate versions of the corresponding
-  object in cloud storage. DVC will also attempt to ensure that the current
-  version of objects in the remote match the latest version of files in the DVC
-  repository. When both `version_aware` and `worktree` are set, `worktree` takes
-  precedence.
-
-<admon type="tip">
-
-The `version_aware` and `worktree` options require that
-[S3 Versioning](https://docs.aws.amazon.com/AmazonS3/latest/userguide/Versioning.html)
-be enabled on the specified S3 bucket.
-
-</admon>
-
 </details>
 
 <details>
@@ -404,6 +406,33 @@ storage. Whether they're effective depends on each storage platform.
   ```cli
   $ dvc remote modify myremote account_name 'myaccount'
   ```
+
+<admon type="tip">
+
+The `version_aware` and `worktree` options require that
+[Blob versioning](https://learn.microsoft.com/en-us/azure/storage/blobs/versioning-overview)
+be enabled on the specified Azure storage account and container.
+
+</admon>
+
+- `version_aware` - Use
+  [version-aware](/docs/user-guide/data-management/cloud-versioning#version-aware-remotes)
+  cloud versioning features for this Azure remote. Files stored in the remote
+  will retain their original filenames and directory hierarchy, and different
+  versions of files will be stored as separate versions of the corresponding
+  object in the remote.
+
+- `worktree` - Use
+  [worktree](/docs/user-guide/data-management/cloud-versioning#worktree-remotes)
+  cloud versioning features for this Azure remote. Files stored in the remote
+  will retain their original filenames and directory hierarchy, and different
+  versions of files will be stored as separate versions of the corresponding
+  object in cloud storage. DVC will also attempt to ensure that the current
+  version of objects in the remote match the latest version of files in the DVC
+  repository. When both `version_aware` and `worktree` are set, `worktree` takes
+  precedence.
+
+**Authentication**
 
 By default, DVC authenticates using an `account_name` and its [default
 credential] (if any), which uses environment variables (e.g. set by `az cli`) or
@@ -561,31 +590,6 @@ can propagate from an Azure configuration file (typically managed with
 `container_name`. The default directory where it will be searched for is
 `~/.azure` but this can be customized with the `AZURE_CONFIG_DIR` env var.
 
-- `version_aware` - Use
-  [version-aware](/docs/user-guide/data-management/cloud-versioning#version-aware-remotes)
-  cloud versioning features for this Azure remote. Files stored in the remote
-  will retain their original filenames and directory hierarchy, and different
-  versions of files will be stored as separate versions of the corresponding
-  object in the remote.
-
-- `worktree` - Use
-  [worktree](/docs/user-guide/data-management/cloud-versioning#worktree-remotes)
-  cloud versioning features for this Azure remote. Files stored in the remote
-  will retain their original filenames and directory hierarchy, and different
-  versions of files will be stored as separate versions of the corresponding
-  object in cloud storage. DVC will also attempt to ensure that the current
-  version of objects in the remote match the latest version of files in the DVC
-  repository. When both `version_aware` and `worktree` are set, `worktree` takes
-  precedence.
-
-<admon type="tip">
-
-The `version_aware` and `worktree` options require that
-[Blob versioning](https://learn.microsoft.com/en-us/azure/storage/blobs/versioning-overview)
-be enabled on the specified Azure storage account and container.
-
-</admon>
-
 </details>
 
 <details>
@@ -736,6 +740,31 @@ more information.
   $ dvc remote modify myremote projectname myproject
   ```
 
+<admon type="tip">
+
+The `version_aware` and `worktree` options require that
+[Object versioning](https://cloud.google.com/storage/docs/object-versioning) be
+enabled on the specified bucket.
+
+</admon>
+
+- `version_aware` - Use
+  [version-aware](/docs/user-guide/data-management/cloud-versioning#version-aware-remotes)
+  cloud versioning features for this Google Cloud Storage remote. Files stored
+  in the remote will retain their original filenames and directory hierarchy,
+  and different versions of files will be stored as separate versions of the
+  corresponding object in the remote.
+
+- `worktree` - Use
+  [worktree](/docs/user-guide/data-management/cloud-versioning#worktree-remotes)
+  cloud versioning features for this Google Cloud Storage remote. Files stored
+  in the remote will retain their original filenames and directory hierarchy,
+  and different versions of files will be stored as separate versions of the
+  corresponding object in cloud storage. DVC will also attempt to ensure that
+  the current version of objects in the remote match the latest version of files
+  in the DVC repository. When both `version_aware` and `worktree` are set,
+  `worktree` takes precedence.
+
 **For service accounts:**
 
 A service account is a Google account associated with your GCP project, and not
@@ -759,31 +788,6 @@ set:
 ```cli
 $ export GOOGLE_APPLICATION_CREDENTIALS='.../project-XXX.json'
 ```
-
-- `version_aware` - Use
-  [version-aware](/docs/user-guide/data-management/cloud-versioning#version-aware-remotes)
-  cloud versioning features for this Google Cloud Storage remote. Files stored
-  in the remote will retain their original filenames and directory hierarchy,
-  and different versions of files will be stored as separate versions of the
-  corresponding object in the remote.
-
-- `worktree` - Use
-  [worktree](/docs/user-guide/data-management/cloud-versioning#worktree-remotes)
-  cloud versioning features for this Google Cloud Storage remote. Files stored
-  in the remote will retain their original filenames and directory hierarchy,
-  and different versions of files will be stored as separate versions of the
-  corresponding object in cloud storage. DVC will also attempt to ensure that
-  the current version of objects in the remote match the latest version of files
-  in the DVC repository. When both `version_aware` and `worktree` are set,
-  `worktree` takes precedence.
-
-<admon type="tip">
-
-The `version_aware` and `worktree` options require that
-[Object versioning](https://cloud.google.com/storage/docs/object-versioning) be
-enabled on the specified bucket.
-
-</admon>
 
 </details>
 


### PR DESCRIPTION
Minor fix of the parameters location:


https://user-images.githubusercontent.com/3659196/216786093-7f29b82a-9c2b-463b-a4c3-b7af3215ad74.mov




