### PR TITLE
drop worktree remotes

### DIFF
--- a/content/docs/command-reference/remote/modify.md
+++ b/content/docs/command-reference/remote/modify.md
@@ -141,7 +141,7 @@ options:
 
 <admon type="tip">
 
-The `version_aware` and `worktree` options require that
+The `version_aware` option requires that
 [S3 Versioning](https://docs.aws.amazon.com/AmazonS3/latest/userguide/Versioning.html)
 be enabled on the specified S3 bucket.
 
@@ -153,16 +153,6 @@ be enabled on the specified S3 bucket.
   retain their original filenames and directory hierarchy, and different
   versions of files will be stored as separate versions of the corresponding
   object in the remote.
-
-- `worktree` - Use
-  [worktree](/docs/user-guide/data-management/cloud-versioning#worktree-remotes)
-  cloud versioning features for this S3 remote. Files stored in the remote will
-  retain their original filenames and directory hierarchy, and different
-  versions of files will be stored as separate versions of the corresponding
-  object in cloud storage. DVC will also attempt to ensure that the current
-  version of objects in the remote match the latest version of files in the DVC
-  repository. When both `version_aware` and `worktree` are set, `worktree` takes
-  precedence.
 
 **Authentication**
 
@@ -409,7 +399,7 @@ storage. Whether they're effective depends on each storage platform.
 
 <admon type="tip">
 
-The `version_aware` and `worktree` options require that
+The `version_aware` option requires that
 [Blob versioning](https://learn.microsoft.com/en-us/azure/storage/blobs/versioning-overview)
 be enabled on the specified Azure storage account and container.
 
@@ -421,16 +411,6 @@ be enabled on the specified Azure storage account and container.
   will retain their original filenames and directory hierarchy, and different
   versions of files will be stored as separate versions of the corresponding
   object in the remote.
-
-- `worktree` - Use
-  [worktree](/docs/user-guide/data-management/cloud-versioning#worktree-remotes)
-  cloud versioning features for this Azure remote. Files stored in the remote
-  will retain their original filenames and directory hierarchy, and different
-  versions of files will be stored as separate versions of the corresponding
-  object in cloud storage. DVC will also attempt to ensure that the current
-  version of objects in the remote match the latest version of files in the DVC
-  repository. When both `version_aware` and `worktree` are set, `worktree` takes
-  precedence.
 
 **Authentication**
 
@@ -742,7 +722,7 @@ more information.
 
 <admon type="tip">
 
-The `version_aware` and `worktree` options require that
+The `version_aware` option requires that
 [Object versioning](https://cloud.google.com/storage/docs/object-versioning) be
 enabled on the specified bucket.
 
@@ -754,16 +734,6 @@ enabled on the specified bucket.
   in the remote will retain their original filenames and directory hierarchy,
   and different versions of files will be stored as separate versions of the
   corresponding object in the remote.
-
-- `worktree` - Use
-  [worktree](/docs/user-guide/data-management/cloud-versioning#worktree-remotes)
-  cloud versioning features for this Google Cloud Storage remote. Files stored
-  in the remote will retain their original filenames and directory hierarchy,
-  and different versions of files will be stored as separate versions of the
-  corresponding object in cloud storage. DVC will also attempt to ensure that
-  the current version of objects in the remote match the latest version of files
-  in the DVC repository. When both `version_aware` and `worktree` are set,
-  `worktree` takes precedence.
 
 **For service accounts:**
 

--- a/content/docs/command-reference/update.md
+++ b/content/docs/command-reference/update.md
@@ -2,9 +2,7 @@
 
 Update files or directories imported from external <abbr>DVC repositories</abbr>
 or [URLs](/doc/command-reference/import-url#description), and the corresponding
-import `.dvc` files, or update files or directories from a
-[worktree](/doc/user-guide/data-management/cloud-versioning#worktree-remotes)
-remote.
+import `.dvc` files.
 
 ## Synopsis
 
@@ -39,22 +37,6 @@ to update an imported artifact to a different revision.
 ```cli
 $ dvc update --rev master
 ```
-
-### Worktree update
-
-When using a
-[worktree](/doc/user-guide/data-management/cloud-versioning#worktree-remotes)
-remote, `dvc update` will update the specified target to match the current
-version of the corresponding file or directory from the remote storage. If the
-current version of the specified target is a deleted file or an empty directory,
-`dvc update` will fail.
-
-<admon type="warn">
-
-Note that the `--rev`, `--no-download` and `--to-remote` flags are not
-compatible when updating from a worktree remote.
-
-</admon>
 
 ## Options
 

--- a/content/docs/user-guide/data-management/cloud-versioning.md
+++ b/content/docs/user-guide/data-management/cloud-versioning.md
@@ -80,33 +80,6 @@ your DVC repository.
 
 </admon>
 
-## Worktree remotes
-
-`worktree` remotes behave similarly to `version_aware` remotes, but with one key
-difference. For `worktree` remotes, DVC will also attempt to ensure that the
-current version of objects in cloud storage match the latest versions of files
-in your DVC repository.
-
-So in addition to the command behaviors described for `version_aware` remotes,
-when the `worktree` option is enabled on a `dvc remote`:
-
-- `dvc push` will also ensure that the current version of objects in remote
-  storage match the latest versions of files in your DVC repository repository.
-  Additionally, DVC will delete the current version of any objects which were
-  present in cloud storage but that do not exist in your current DVC repository
-  workspace.
-- `dvc update` can be used to update a DVC-tracked file or directory in your DVC
-  repository to match the current version of the corresponding object(s) from
-  cloud storage.
-
-<admon type="info">
-
-Note that deleting current versions in cloud storage does not delete any objects
-(and does not delete any data). It only means that the current version of a
-given object will show that the object does not exist.
-
-</admon>
-
 ## Importing versioned data
 
 DVC supports importing cloud versioned data from supported storage providers.


### PR DESCRIPTION
Drops worktree remotes.

~Still need to remove remote-specific info from https://dvc.org/doc/command-reference/remote/modify#available-parameters-per-storage-type, but this info is currently being moved in #4264 and related PRs, so not sure how best to proceed.~

Edit: I also removed it from the ref for `remote modify` now, so let's merge whenever it's ready and resolve any merge conflicts as needed.