### PR TITLE
Studio: document export to CSV

### DIFF
--- a/content/docs/studio/user-guide/projects-and-experiments/explore-ml-experiments.md
+++ b/content/docs/studio/user-guide/projects-and-experiments/explore-ml-experiments.md
@@ -123,6 +123,16 @@ Use this toggle switch to show/hide experiments that you have not selected.
 
 Toggle between absolute values and difference from the first row.
 
+#### Export Project to CSV:
+
+Export current project table to CSV.
+
+![export to csv](https://static.iterative.ai/img/studio/project_export_to_csv.png)
+
+_Here is an example of portion of CSV file generated._
+
+![example export to csv](https://static.iterative.ai/img/studio/project_export_to_csv_example.png)
+
 #### Save changes:
 
 Save your filters or column display preferences so that these preferences remain

--- a/content/docs/studio/user-guide/projects-and-experiments/explore-ml-experiments.md
+++ b/content/docs/studio/user-guide/projects-and-experiments/explore-ml-experiments.md
@@ -30,7 +30,7 @@ The major components of the project experimentation table are:
   commits and columns, and re-arrange the table.
 - Buttons to
   [visualize, compare, and run experiments](#visualize-compare-and-run-experiments).
-- Button to [export project data](#visualize-compare-and-run-experiments).
+- Button to [export project data](#export-project-data).
 
 ### Git history and live metrics
 

--- a/content/docs/studio/user-guide/projects-and-experiments/explore-ml-experiments.md
+++ b/content/docs/studio/user-guide/projects-and-experiments/explore-ml-experiments.md
@@ -30,6 +30,7 @@ The major components of the project experimentation table are:
   commits and columns, and re-arrange the table.
 - Buttons to
   [visualize, compare, and run experiments](#visualize-compare-and-run-experiments).
+- Button to [export project data](#visualize-compare-and-run-experiments).
 
 ### Git history and live metrics
 
@@ -123,16 +124,6 @@ Use this toggle switch to show/hide experiments that you have not selected.
 
 Toggle between absolute values and difference from the first row.
 
-#### Export Project to CSV:
-
-Export current project table to CSV.
-
-![export to csv](https://static.iterative.ai/img/studio/project_export_to_csv.png)
-
-_Here is an example of portion of CSV file generated._
-
-![example export to csv](https://static.iterative.ai/img/studio/project_export_to_csv_example.png)
-
 #### Save changes:
 
 Save your filters or column display preferences so that these preferences remain
@@ -151,6 +142,17 @@ The table also contains buttons to visualize, compare and run experiments.
   [here][run-experiments] for details on how to run experiments and track
   metrics in real time.
 - **Trends:** Generate trend charts to show metric evolution over time.
+
+### Export project data
+
+The button to export data from the project table to CSV is present next to the
+[`Delta mode`](#delta-mode) button.
+
+![export to csv](https://static.iterative.ai/img/studio/project_export_to_csv.png)
+
+Below is an example of the downloaded CSV file.
+
+![example export to csv](https://static.iterative.ai/img/studio/project_export_to_csv_example.png)
 
 [run-experiments]: /doc/studio/user-guide/run-experiments
 [dvclive]: /doc/dvclive

--- a/content/docs/studio/user-guide/projects-and-experiments/visualize-and-compare.md
+++ b/content/docs/studio/user-guide/projects-and-experiments/visualize-and-compare.md
@@ -98,6 +98,13 @@ in the selected experiments will be displayed side by side for easy comparison.
 
 ![](https://static.iterative.ai/img/studio/compare.png)
 
+### Export project data
+
+You can also
+[export data from the project table as CSV](/doc/studio/user-guide/projects-and-experiments/explore-ml-experiments#export-project-data),
+so that you can use the data with any external reporting or visualization tool
+of your choice.
+
 [live-metrics-and-plots]:
   /doc/studio/user-guide/projects-and-experiments/live-metrics-and-plots
 [dvclive]: /doc/dvclive

--- a/content/docs/studio/user-guide/projects-and-experiments/visualize-and-compare.md
+++ b/content/docs/studio/user-guide/projects-and-experiments/visualize-and-compare.md
@@ -9,7 +9,11 @@ settings_ are now called _Project settings_; and so on.
 
 # Visualize and Compare Experiments
 
-You can visualize and compare experiments using plots, images, charts, etc.
+You can visualize and compare experiments using plots, images, charts, etc. You
+can also
+[export the project table as CSV](/doc/studio/user-guide/projects-and-experiments/explore-ml-experiments#export-project-data),
+so that you can use the data with any external reporting or visualization tool
+of your choice.
 
 ## Display plots and images
 
@@ -97,13 +101,6 @@ commits), and click on the `Compare` button. The metrics, parameters and files
 in the selected experiments will be displayed side by side for easy comparison.
 
 ![](https://static.iterative.ai/img/studio/compare.png)
-
-### Export project data
-
-You can also
-[export data from the project table as CSV](/doc/studio/user-guide/projects-and-experiments/explore-ml-experiments#export-project-data),
-so that you can use the data with any external reporting or visualization tool
-of your choice.
 
 [live-metrics-and-plots]:
   /doc/studio/user-guide/projects-and-experiments/live-metrics-and-plots


### PR DESCRIPTION
Add docs for studio export to CSV.

Depends on https://github.com/iterative/static/pull/17 for images.

It's how it should be after merging the above images.
<img width="1320" alt="Screenshot 2023-02-10 at 14 12 15" src="https://user-images.githubusercontent.com/20840228/218090655-254aea30-1381-4327-b8d8-10dc4369beb2.png">


Closes https://github.com/iterative/studio/issues/5064