### PR TITLE
Fix more links

### DIFF
--- a/config/link-check/excluded-links.yml
+++ b/config/link-check/excluded-links.yml
@@ -7,3 +7,8 @@
 - '/img/<filename>.gif'
 - '/uploads/images/2020-02-10/image.png'
 - 'https://medium.com**'
+- 'src/*'
+- 'data/*'
+- 'models/*'
+- 'mailto:*'
+- 'https://machinelearningmastery.com/*'

--- a/content/docs/command-reference/data/status.md
+++ b/content/docs/command-reference/data/status.md
@@ -85,7 +85,7 @@ default but this can be enabled with the `--granular` flag.
 - `--granular` - show granular file-level changes inside DVC-tracked
   directories. Note that some granular changes may be reported as `unknown` as
   DVC tracks
-  [directory-level hash values](doc/user-guide/project-structure/internal-files#directories).
+  [directory-level hash values](/doc/user-guide/project-structure/internal-files#directories).
 
 - `--untracked-files` - show files that are not being tracked by DVC and Git.
 

--- a/content/docs/user-guide/basic-concepts/dvc-project.md
+++ b/content/docs/user-guide/basic-concepts/dvc-project.md
@@ -14,8 +14,7 @@ match:
 tooltip: >-
   Initialized by running `dvc init` in the **workspace** (typically a Git
   repository). It will contain the `.dvc/` directory, as well as `dvc.yaml` and
-  `.dvc` files created with commands such as `dvc add` or `dvc stage add`.  
-  [More info](/doc/user-guide/basic-concepts/dvc-project)
+  `.dvc` files created with commands such as `dvc add` or `dvc stage add`.
 ---
 
 # DVC Project


### PR DESCRIPTION
Following up #4302, this PR targets the remaining broken links on dvc.org

This has also revealed that our feature for making `basic-concepts` pages is currently broken, so I'll go to the theme repo to do that next.