### PR TITLE
ref: document `exp apply` behavior change

### DIFF
--- a/content/docs/command-reference/exp/apply.md
+++ b/content/docs/command-reference/exp/apply.md
@@ -6,7 +6,7 @@ Put the results from an [experiment](/doc/command-reference/exp) in the
 ## Synopsis
 
 ```usage
-usage: dvc exp apply [-h] [-q | -v] [--no-force] experiment
+usage: dvc exp apply [-h] [-q | -v] experiment
 
 positional arguments:
   experiment     Experiment to be applied
@@ -14,17 +14,13 @@ positional arguments:
 
 ## Description
 
-Restores an `experiment` into the workspace, as long as we're on the same
-project baseline (Git `HEAD`) as when the target experiment was run. The
-experiment can be referenced by name or hash (see `dvc exp run` for details).
+Restores an `experiment` into the workspace. The experiment can be referenced by
+name or hash (see `dvc exp run` for details).
 
-Specifically, `dvc exp apply` restores any files or directories needed to
-reflect the experiment conditions and results. This means checking out files
+Specifically, `dvc exp apply` restores any files or directories which exist in
+the experiment, to their exact states from the experiment. This includes files
 tracked both with DVC and Git: code, raw data, <abbr>parameters</abbr>,
 <abbr>metrics</abbr>, resulting artifacts, etc.
-
-⚠️ Conflicting changes in the workspace are overwritten unless `--no-force` is
-used.
 
 This is typically used after choosing a target `experiment` with `dvc exp show`
 or `dvc exp diff`, and before committing it to Git (making it [persistent].
@@ -32,13 +28,66 @@ or `dvc exp diff`, and before committing it to Git (making it [persistent].
 > Note that any [checkpoints] found in the `experiment` will **not** be
 > preserved when applying and committing it. Use `dvc exp branch` instead.
 
+<details>
+
+### Expand for `dvc exp apply` implementation details
+
+`dvc exp apply` is approximately equivalent to the following Git + DVC workflow:
+
+```cli
+$ git stash --include-untracked
+$ git checkout --detach experiment
+$ git reset HEAD^1
+$ git checkout stash@{0} --ours
+$ git stash drop
+$ dvc checkout
+```
+
+The resulting Git + DVC workspace after `dvc exp apply` will contain the
+contents of `experiment`, plus any files from the workspace prior to
+`dvc exp apply` that did not exist in `experiment`.
+
+<admon type="info">
+
+Note that `dvc exp apply` does not actually use the standard Git stash (and does
+not modify `.git/refs/stash`).
+
+</admon>
+
+</details>
+
+<admon type="warn">
+
+Conflicting changes in the workspace are overwritten, but the result of
+`dvc exp apply` can be reverted using Git.
+
+</admon>
+
+<details>
+
+### Expand for details on reverting `dvc exp apply`
+
+`dvc exp apply` can be reverted with the following Git workflow:
+
+```cli
+$ git reset --hard
+$ git stash apply refs/exps/apply/stash
+```
+
+<admon type="info">
+
+Note that this workflow is only valid as long no Git commands which affect
+`HEAD` (such as `git commit` or `git checkout`) have been used since
+`dvc exp apply` was run.
+
+</admon>
+
+</details>
+
 [persistent]: /doc/user-guide/experiment-management/persisting-experiments
 [checkpoints]: /doc/user-guide/experiment-management/checkpoints
 
 ## Options
-
-- `--no-force` - fail if this command would overwrite conflicting differences
-  between the `experiment` and the workspace.
 
 - `-h`, `--help` - shows the help message and exit.
 


### PR DESCRIPTION
> You may disregard these recommendations if you used the **Edit on GitHub** button from dvc.org to improve a doc in place.

❗ Please read the guidelines in the [Contributing to the Documentation](https://dvc.org/doc/user-guide/contributing/docs) list if you make any substantial changes to the documentation or JS engine.

🐛 Please make sure to mention `Fix #issue` (if applicable) in the description of the PR. This causes GitHub to close it automatically when the PR is merged.

Please choose to [allow us](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to edit your branch when creating the PR.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

Docs PR for https://github.com/iterative/dvc/pull/8994