### PR TITLE
Update start/index.md

### DIFF
--- a/content/docs/start/index.md
+++ b/content/docs/start/index.md
@@ -86,10 +86,12 @@ perspective:
 <admon type="tip">
 
 The steps and results of some of these chapters are captured in our
-[example-get-started] repo. Feel free to `git clone/checkout` any of its [tags][example-get-started-tags].
+[example-get-started] repo. Feel free to `git clone/checkout` any of its
+[tags][example-get-started-tags].
 
 [example-get-started]: https://github.com/iterative/example-get-started
-[example-get-started-tags]: https://github.com/iterative/example-get-started/tags
+[example-get-started-tags]:
+  https://github.com/iterative/example-get-started/tags
 
 </admon>
 
@@ -108,10 +110,12 @@ The steps and results of some of these chapters are captured in our
 
 <admon type="tip">
 
-These are captured in our [example-dvc-experiments] repo (see its [tags][example-dvc-experiments-tags]).
+These are captured in our [example-dvc-experiments] repo (see its
+[tags][example-dvc-experiments-tags]).
 
 [example-dvc-experiments]: https://github.com/iterative/example-dvc-experiments
-[example-dvc-experiments-tags]: https://github.com/iterative/example-dvc-experiments/tags
+[example-dvc-experiments-tags]:
+  https://github.com/iterative/example-dvc-experiments/tags
 
 </admon>
 

--- a/content/docs/start/index.md
+++ b/content/docs/start/index.md
@@ -86,10 +86,10 @@ perspective:
 <admon type="tip">
 
 The steps and results of some of these chapters are captured in our
-[example-get-started] repo. Feel free to `git clone/checkout` any of its [tags].
+[example-get-started] repo. Feel free to `git clone/checkout` any of its [tags][example-get-started-tags].
 
 [example-get-started]: https://github.com/iterative/example-get-started
-[tags]: https://github.com/iterative/example-get-started/tags
+[example-get-started-tags]: https://github.com/iterative/example-get-started/tags
 
 </admon>
 
@@ -108,10 +108,10 @@ The steps and results of some of these chapters are captured in our
 
 <admon type="tip">
 
-These are captured in our [example-dvc-experiments] repo (see its [tags]).
+These are captured in our [example-dvc-experiments] repo (see its [tags][example-dvc-experiments-tags]).
 
 [example-dvc-experiments]: https://github.com/iterative/example-dvc-experiments
-[tags]: https://github.com/iterative/example-dvc-experiments/tags
+[example-dvc-experiments-tags]: https://github.com/iterative/example-dvc-experiments/tags
 
 </admon>
 


### PR DESCRIPTION
This PR removes re-definition of the `[tags]` ref-link label, which caused its second reference (see below) to point to an incorrect URL:
> These are captured in our example-dvc-experiments repo (see its **tags**)

> You may disregard these recommendations if you used the **Edit on GitHub** button from dvc.org to improve a doc in place.

❗ Please read the guidelines in the [Contributing to the Documentation](https://dvc.org/doc/user-guide/contributing/docs) list if you make any substantial changes to the documentation or JS engine.

🐛 Please make sure to mention `Fix #issue` (if applicable) in the description of the PR. This causes GitHub to close it automatically when the PR is merged.

Please choose to [allow us](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to edit your branch when creating the PR.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
