### PR TITLE
Studio - Change "Experiment" button back to "Run"

### DIFF
--- a/content/docs/studio/user-guide/projects-and-experiments/explore-ml-experiments.md
+++ b/content/docs/studio/user-guide/projects-and-experiments/explore-ml-experiments.md
@@ -138,7 +138,7 @@ The table also contains buttons to visualize, compare and run experiments.
 - **Show plots:** Show plots for the selected commits. When you click on this
   button, plots for the selected commits are displayed in a `Plots ` pane.
 - **Compare:** Compare different experiments side by side.
-- **Experiment:** Run experiments by selecting any one commit. Refer
+- **Run:** Run experiments by selecting any one commit. Refer
   [here][run-experiments] for details on how to run experiments and track
   metrics in real time.
 - **Trends:** Generate trend charts to show metric evolution over time.

--- a/content/docs/studio/user-guide/projects-and-experiments/run-experiments.md
+++ b/content/docs/studio/user-guide/projects-and-experiments/run-experiments.md
@@ -41,8 +41,8 @@ you should do the following:
 
 ## Use the Iterative Studio wizard to set up your CI action
 
-Select a commit and click **Experiment**. You will see a message that invites
-you to set up your CI.
+Select a commit and click **Run**. You will see a message that invites you to
+set up your CI.
 
 ![](https://static.iterative.ai/img/studio/set_up_cml_message.png)
 
@@ -98,8 +98,8 @@ Studio and Views to Projects._
 
 To run experiments from Iterative Studio, first you need to determine the Git
 commit (experiment) on which you want to iterate. Select the commit that you
-want to use and click the `Experiment` button. A form will let you specify all
-the changes that you want to make to your experiment. On this form, there are 2
+want to use and click the `Run` button. A form will let you specify all the
+changes that you want to make to your experiment. On this form, there are 2
 types of inputs that you can change:
 
 1. **Input data files**: You can change datasets that are used for model


### PR DESCRIPTION
> You may disregard these recommendations if you used the **Edit on GitHub** button from dvc.org to improve a doc in place.

❗ Please read the guidelines in the [Contributing to the Documentation](https://dvc.org/doc/user-guide/contributing/docs) list if you make any substantial changes to the documentation or JS engine.

🐛 Please make sure to mention `Fix #issue` (if applicable) in the description of the PR. This causes GitHub to close it automatically when the PR is merged.

Please choose to [allow us](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to edit your branch when creating the PR.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

## description
Reverts https://github.com/iterative/dvc.org/pull/4263
Due to changing it back in Studio:
- Studio change: https://github.com/iterative/studio/pull/5022
- Studio docs issue: https://github.com/iterative/studio/issues/5027

cc @tapadipti 