### PR TITLE
update definition of experiment

### DIFF
--- a/content/basic-concepts/experiment.md
+++ b/content/basic-concepts/experiment.md
@@ -2,9 +2,8 @@
 name: Experiment
 match: [experiment, experiments, 'DVC experiments']
 tooltip: >-
-  An attempt to reach desired/better/interesting results during data pipelining
-  or ML model development. DVC is designed to help [manage
-  experiments](/doc/start/experiment-management), having built-in mechanisms
-  like the [run cache](/doc/user-guide/pipelines/run-cache)  and `dvc exp`
-  commands.
+  A versioned iteration of ML model development. DVC tracks experiments as Git
+  commits that DVC can find but that don't clutter your Git history or branches.
+  Experiments may include code, metrics, parameters, plots, and data and model
+  artifacts.
 ---


### PR DESCRIPTION
Related to #4393 and #4389. Updating the definition shown in the tooltip for DVC experiments should make it easier to grasp throughout the docs.