### PR TITLE
Studio: Remove Teams plan from pricing structure

### DIFF
--- a/content/docs/studio/get-started.md
+++ b/content/docs/studio/get-started.md
@@ -14,8 +14,8 @@ your email address.
 
 When you sign up, you're on the **Free plan**. To switch to the **Basic plan**
 [create a team] first, then go to the _Team settings_ to [change the plan]. To
-sign up for the **Teams** or **Enterprise** plan, please [schedule a call] (see
-[pricing details]).
+sign up for the **Enterprise** plan, please [schedule a call] (see [pricing
+details]).
 
 </admon>
 
@@ -99,7 +99,7 @@ You should now see that a project has been added in your dashboard.
 
 2. You can [create a team] and invite collaborators. Each team will have its own
    projects dashboard. To create teams with more than 2 team members, [sign up
-   for the **Basic**, **Teams** or **Enterprise** plan].
+   for the **Basic** or **Enterprise** plan].
 
 3. You can also [make your projects public].
 
@@ -142,7 +142,7 @@ You should now see that a project has been added in your dashboard.
 [explore ml experiments]:
   /doc/studio/user-guide/projects-and-experiments/explore-ml-experiments
 [create a team]: /doc/studio/user-guide/teams
-[sign up for the **basic**, **teams** or **enterprise** plan]:
+[sign up for the **basic** or **enterprise** plan]:
   /doc/studio/user-guide/change-team-plan-and-size
 [make your projects public]:
   /doc/studio/user-guide/projects-and-experiments/share-a-project

--- a/content/docs/studio/user-guide/account-management.md
+++ b/content/docs/studio/user-guide/account-management.md
@@ -12,10 +12,10 @@ which are described below.
 
 <admon>
 
-This does not include managing your team plan (Free, Basic, Teams, or
-Enterprise). Team plans are defined for each team separately. To manage them, go
-to the [team settings] page and scroll to the `Plan and billing` section. You
-can change plans there and increase or decrease the number of seats in it.
+This does not include managing your team plan (Free, Basic, or Enterprise). Team
+plans are defined for each team separately. To manage them, go to the [team
+settings] page and scroll to the `Plan and billing` section. You can change
+plans there and increase or decrease the number of seats in it.
 
 [team settings]: /doc/studio/user-guide/teams#settings
 

--- a/content/docs/studio/user-guide/billing-and-payment.md
+++ b/content/docs/studio/user-guide/billing-and-payment.md
@@ -10,12 +10,12 @@ Studio is free for individuals and teams with up to 2 members. The Free plan is
 designed for teams that are starting out: you can invite one other team member
 and import as many repositories as you want.
 
-For more advanced collaboration, you can switch to the Basic, Teams or
-Enterprise plans. These are paid plans, and in this page you will learn how to
-manage billing and payment for them.
+For more advanced collaboration, you can switch to the Basic or Enterprise
+plans. These are paid plans, and in this page you will learn how to manage
+billing and payment for them.
 
-- [Difference between Free, Basic, Teams, and Enterprise plans](#difference-between-free-basic-teams-and-enterprise-plans)
-- [How to sign up for the Basic, Teams or Enterprise plans](#how-to-sign-up-for-the-basic-teams-or-enterprise-plans)
+- [Difference between Free, Basic, and Enterprise plans](#difference-between-free-basic-and-enterprise-plans)
+- [How to sign up for the Basic or Enterprise plans](#how-to-sign-up-for-the-basic-or-enterprise-plans)
 - [How total price is calculated](#how-total-price-is-calculated), including
   effects of making changes to the plan during the billing period.
 - [Downgrading a plan](#downgrading-a-plan)
@@ -25,17 +25,17 @@ manage billing and payment for them.
 - [Accessing your payment history and invoices](#accessing-your-payment-history-and-invoices)
 - [Other questions](#other-questions)
 
-## Difference between Free, Basic, Teams, and Enterprise plans
+## Difference between Free, Basic, and Enterprise plans
 
 A detailed comparison of the different plans can be found in the Iterative
 Studio [pricing page](https://studio.iterative.ai/pricing).
 
-## How to sign up for the Basic, Teams or Enterprise plans
+## How to sign up for the Basic or Enterprise plans
 
 When you sign up, you're on the **Free plan**. To switch to the **Basic plan**
 [create a team] first, then go to the _Team settings_ to [change the plan]. To
-sign up for the **Teams** or **Enterprise** plan, please [schedule a call] (see
-[pricing details]).
+sign up for the **Enterprise** plan, please [schedule a call] (see [pricing
+details]).
 
 [change the plan]:
   /doc/studio/user-guide/teams#change-your-team-plan-and-team-size
@@ -54,7 +54,7 @@ seat, the total payable amount for the team would be $40 x 5 = $200 per month.
 Increasing or decreasing the number of seats during a billing period will result
 in prorated amount calculation (see the next section for an example).
 
-For Teams and Enterprise plans, all invoice amounts are calculated based on the
+For the Enterprise plan, all invoice amounts are calculated based on the
 agreement between you and Iterative.
 
 ### How increasing or decreasing the number of seats affects price
@@ -86,7 +86,7 @@ When you downgrade from the Basic plan to the Free plan, you will receive a
 prorated refund for the days remaining in the billing period. For inquiries
 about refunds, please [contact us].
 
-To upgrade to or downgrade from Teams or Enterprise plan, please [contact us].
+To upgrade to or downgrade from the Enterprise plan, please [contact us].
 
 ## Billing period and auto-renewal of Basic plans
 

--- a/content/docs/studio/user-guide/change-team-plan-and-size.md
+++ b/content/docs/studio/user-guide/change-team-plan-and-size.md
@@ -16,7 +16,7 @@ marked.
 
 ### If you are on the Free plan
 
-You can upgrade to the Basic, Teams or Enterprise plan.
+You can upgrade to the Basic or Enterprise plan.
 
 **To upgrade to the Basic plan**, click on the `Upgrade` button. Then select the
 number of seats (collaborators) you need in your team.
@@ -40,15 +40,15 @@ number of seats.
 
 </admon>
 
-**To upgrade to the Teams or Enterprise plan**, click on the `Contact Us` button
-to [schedule a call] with our in-house experts. They will try to understand your
+**To upgrade to the Enterprise plan**, click on the `Contact Us` button to
+[schedule a call] with our in-house experts. They will try to understand your
 needs and suggest a suitable plan and pricing.
 
 [schedule a call]: https://calendly.com/gtm-2/studio-introduction
 
 ### If you are on the Basic plan
 
-You can downgrade to the Free plan or upgrade to the Teams or Enterprise plan.
+You can downgrade to the Free plan or upgrade to the Enterprise plan.
 
 **To downgrade to the Free plan** you must first make sure that your team has
 only 1 or 2 collaborators or pending invites. Then click on the `Downgrade`
@@ -59,23 +59,23 @@ the billing period. For inquiries about refunds, please [contact us].
 
 [contact us]: /doc/studio/troubleshooting#support
 
-**To upgrade to the Teams or Enterprise plan**, click on the `Contact Us` button
-to [schedule a call] with our in-house experts. They will try to understand your
+**To upgrade to the Enterprise plan**, click on the `Contact Us` button to
+[schedule a call] with our in-house experts. They will try to understand your
 needs and suggest a suitable plan and pricing.
 
-### If you are on the Teams or Enterprise plan
+### If you are on the Enterprise plan
 
 For any changes to the plan, please ask your contact person at Iterative.
 
 ## Change the size of your team
 
-You can change the size of your team within the Basic, Teams or Enterprise plans
-at any point.
+You can change the size of your team within the Basic or Enterprise plans at any
+point.
 
 ### If you are on the Free plan
 
 To change the number of seats in your team,
-[upgrade to the Basic, Teams or Enterprise plan](#change-the-plan-your-team-is-on).
+[upgrade to the Basic or Enterprise plan](#change-the-plan-your-team-is-on).
 
 ### If you are on the Basic plan
 
@@ -93,6 +93,6 @@ select the desired number of seats.
 The total payable amount or credit balance will be displayed for you to
 `Confirm`.
 
-### If you are on the Teams or Enterprise plan
+### If you are on the Enterprise plan
 
 For any changes to the plan, please ask your contact person at Iterative.

--- a/content/docs/studio/user-guide/projects-and-experiments/create-a-project.md
+++ b/content/docs/studio/user-guide/projects-and-experiments/create-a-project.md
@@ -101,4 +101,4 @@ Each team will have its own projects dashboard, and the projects that you create
 in the team's dashboard will be accessible to all members of the team.
 
 To add more than 2 collaborators in your team, you can
-[upgrade to the **Basic**, **Teams** or **Enterprise** plan](/doc/studio/user-guide/change-team-plan-and-size).
+[upgrade to the **Basic** or **Enterprise** plan](/doc/studio/user-guide/change-team-plan-and-size).

--- a/content/docs/studio/user-guide/projects-and-experiments/share-a-project.md
+++ b/content/docs/studio/user-guide/projects-and-experiments/share-a-project.md
@@ -19,7 +19,7 @@ will have its own projects dashboard. All the projects that you create in the
 team's dashboard will be accessible to all members (collaborators) of the team.
 
 To add more than 2 collaborators in your team, you can
-[upgrade to the **Basic**, **Teams** or **Enterprise** plan](/doc/studio/user-guide/change-team-plan-and-size).
+[upgrade to the **Basic** or **Enterprise** plan](/doc/studio/user-guide/change-team-plan-and-size).
 
 ## Make a project public
 

--- a/content/docs/studio/user-guide/teams.md
+++ b/content/docs/studio/user-guide/teams.md
@@ -163,7 +163,7 @@ members.
 The number of collaborators in your team depends on your team plan. By default,
 all teams are on the Free plan, and can have 2 collaborators. To add more
 collaborators,
-[upgrade to the Basic, Teams or Enterprise plans](#change-your-team-plan).
+[upgrade to the Basic or Enterprise plans](#change-your-team-plan).
 
 All collaborators and pending invites get counted in the subscription. Suppose
 you have subscribed for a 10 member team. If you have 5 members who have
@@ -174,15 +174,15 @@ and so you will have 3 remaining seats.
 
 ### Change your team plan and team size
 
-Your team can be in the **Free**, **Basic**, **Teams** or **Enterprise** plan.
-All newly created teams are on the Free plan. This plan is designed for teams
-that are starting out: you can invite one other team member and import as many
+Your team can be in the **Free**, **Basic**, **Enterprise** plan. All newly
+created teams are on the Free plan. This plan is designed for teams that are
+starting out: you can invite one other team member and import as many
 repositories as you want. For more advanced collaboration, you can switch to the
-Basic, Teams or Enterprise plans. A detailed comparison of the different plans
-can be found in the Iterative Studio
+Basic or Enterprise plans. A detailed comparison of the different plans can be
+found in the Iterative Studio
 [pricing page](https://studio.iterative.ai/pricing).
 
-- **To upgrade** from the Free plan to the Basic, Teams or Enterprise plan or to
+- **To upgrade** from the Free plan to the Basic or Enterprise plan or to
   downgrade your team plan, refer to the section on [changing your team plan].
 
 - **To change the number of seats** in your Basic plan, refer to the section on


### PR DESCRIPTION
Make the docs consistent with the recent changes in our pricing structure (according to https://github.com/iterative/iterative.ai/issues/803).

I'll also replace the pricing screenshots in the [static repo](https://github.com/iterative/static).