### PR TITLE
Add pipelines pages to experimens start guide: alternate

### DIFF
--- a/content/docs/start/experiments/building-pipelines.md
+++ b/content/docs/start/experiments/building-pipelines.md
@@ -21,7 +21,7 @@ software engineering best practices:
 
 ## Creating stages
 
-In our example repo, we first split data preparation from the
+In our example repo, we first extract data preparation from the
 [original notebook](https://github.com/iterative/example-get-started-experiments/blob/main/notebooks/TrainSegModel.ipynb)
 into
 [`data_split.py`](https://github.com/iterative/example-get-started-experiments/blob/main/src/data_split.py).

--- a/content/docs/start/experiments/building-pipelines.md
+++ b/content/docs/start/experiments/building-pipelines.md
@@ -7,7 +7,7 @@ description:
 
 # Get Started: Building Pipelines
 
-Eventually, managing the your notebook cells may start to feel fragile, and you
+Eventually, managing your notebook cells may start to feel fragile, and you
 may want to structure your project and code. When you are ready to
 [migrate from notebooks to scripts](https://towardsdatascience.com/from-jupyter-notebook-to-sc-582978d3c0c),
 DVC <abbr>Pipelines</abbr> can help you standardize your workflow following

--- a/content/docs/start/experiments/building-pipelines.md
+++ b/content/docs/start/experiments/building-pipelines.md
@@ -34,7 +34,7 @@ from ruamel.yaml import YAML
 yaml = YAML(typ="safe")
 
 def data_split():
-    params = ConfigBox(yaml.load(open("params.yaml", encoding="utf-8")))
+    params = yaml.load(open("params.yaml", encoding="utf-8"))
 ...
 ```
 

--- a/content/docs/start/experiments/building-pipelines.md
+++ b/content/docs/start/experiments/building-pipelines.md
@@ -7,48 +7,44 @@ description:
 
 # Get Started: Building Pipelines
 
-Once you start consolidating your project and the code structure, the
-flexibility of the notebooks might start to lose its value and some parts of the
-workflow could be improved.
-
-<admon type="tip">
-
-Learn more about
-[how to migrate from Jupyter notebook to scripts](https://towardsdatascience.com/from-jupyter-notebook-to-sc-582978d3c0c)
-and the motivations behind it.
-
-</admon>
-
+Eventually, managing the your notebook cells may start to feel fragile, and you
+may want to structure your project and code. When you are ready to
+[migrate from notebooks to scripts](https://towardsdatascience.com/from-jupyter-notebook-to-sc-582978d3c0c),
 DVC <abbr>Pipelines</abbr> can help you standardize your workflow following
 software engineering best practices:
 
 - **Modularization**: split the different logical steps in your notebook into
   separate scripts.
 
-In our example repo, the
-[original notebook](https://github.com/iterative/example-get-started-experiments/blob/main/notebooks/TrainSegModel.ipynb)
-has been transformed into 3 scripts:
-[`data_split.py`](https://github.com/iterative/example-get-started-experiments/blob/main/src/data_split.py),
-[`train.py`](https://github.com/iterative/example-get-started-experiments/blob/main/src/train.py)
-and
-[`evaluate.py`](https://github.com/iterative/example-get-started-experiments/blob/main/src/evaluate.py).
-
 - **Parametrization**: adapt your scripts to decouple the configuration from the
   source code.
 
-All these scripts are configured using different sections of the
-[`params.yaml`](https://github.com/iterative/example-get-started-experiments/blob/main/params.yaml)
-file.
-
 ## Creating stages
+
+In our example repo, we first split data preparation from the
+[original notebook](https://github.com/iterative/example-get-started-experiments/blob/main/notebooks/TrainSegModel.ipynb)
+into
+[`data_split.py`](https://github.com/iterative/example-get-started-experiments/blob/main/src/data_split.py).
+We parametrize this script by reading parameters from
+[`params.yaml`](https://github.com/iterative/example-get-started-experiments/blob/main/params.yaml):
+
+```python
+from ruamel.yaml import YAML
+
+yaml = YAML(typ="safe")
+
+def data_split():
+    params = ConfigBox(yaml.load(open("params.yaml", encoding="utf-8")))
+...
+```
 
 You can use `dvc stage add` to transform a script into a <abbr>stage</abbr>:
 
 ```cli
-$ dvc stage add -n data_split \
-  -p base,data_split \
-  -d data/pool_data -d src/data_split.py \
-  -o data/train_data -o data/test_data \
+$ dvc stage add --name data_split \
+  --params base,data_split \
+  --deps data/pool_data --deps src/data_split.py \
+  --outs data/train_data --outs data/test_data \
   python src/data_split.py
 ```
 
@@ -71,6 +67,8 @@ stages:
       - data/test_data
 ```
 
+`dvc exp run` will run all stages in the `dvc.yaml` file.
+
 <admon type="info">
 
 Learn more about [Stages](/doc/user-guide/pipelines/defining-pipelines#stages)
@@ -81,11 +79,13 @@ Learn more about [Stages](/doc/user-guide/pipelines/defining-pipelines#stages)
 
 By using `dvc stage add` multiple times and defining <abbr>outputs</abbr> of a
 stage as <abbr>dependencies</abbr> of another, you describe a sequence of
-commands which gets to some desired result. This is called a
-[DAG](https://en.wikipedia.org/wiki/Directed_acyclic_graph).
+commands which forms a
+[pipeline](https://dvc.org/doc/user-guide/pipelines/defining-pipelines), also
+called a [DAG](https://en.wikipedia.org/wiki/Directed_acyclic_graph).
 
-Let's create 2 additional stages one for training and the other for evaluating
-the model:
+Let's create a `train` stage using
+[`train.py`](https://github.com/iterative/example-get-started-experiments/blob/main/src/train.py)
+to train the model:
 
 ```cli
 $ dvc stage add -n train \
@@ -94,6 +94,14 @@ $ dvc stage add -n train \
   -o models/model.pkl \
   python src/train.py
 ```
+
+`dvc exp run` checks the `prepare` stage first and then the `train` stage since
+it depends on the <abbr>outputs</abbr> of `prepare`. If you already ran
+`prepare` with the same <abbr>dependencies</abbr> and <abbr>parameters</abbr>,
+it will be retrieved from the [run cache](/doc/user-guide/pipelines/run-cache)
+and skipped.
+
+Finally, let's add an `evaluate` stage:
 
 ```cli
 $ dvc stage add -n evaluate \

--- a/content/docs/start/experiments/building-pipelines.md
+++ b/content/docs/start/experiments/building-pipelines.md
@@ -7,8 +7,8 @@ description:
 
 # Get Started: Building Pipelines
 
-Eventually, managing your notebook cells may start to feel fragile, and you
-may want to structure your project and code. When you are ready to
+Eventually, managing your notebook cells may start to feel fragile, and you may
+want to structure your project and code. When you are ready to
 [migrate from notebooks to scripts](https://towardsdatascience.com/from-jupyter-notebook-to-sc-582978d3c0c),
 DVC <abbr>Pipelines</abbr> can help you standardize your workflow following
 software engineering best practices:


### PR DESCRIPTION
Hey @daavoo, as we discussed, I tried a little more in-depth approach to the building-pipelines page. We can take pieces of this without using it completely if any of it is helpful.

It does mention `dvc exp run` in the building pipelines page, which might be a little repetitive with the experiments-iterations page. I'd be fine with:
1. Leaving in the repetition.
2. Dropping the mentions to `exp run` in building-pipelines.
3. Cutting down some of the pipeline-related info in experiments-iterations.

PTAL 🙏 