### PR TITLE
Remove a warning that DVC can only auth with SSH

### DIFF
--- a/content/docs/command-reference/exp/push.md
+++ b/content/docs/command-reference/exp/push.md
@@ -5,15 +5,6 @@ to [remote storage].
 
 [remote storage]: /doc/user-guide/data-management/remote-storage
 
-<admon type="warn">
-
-DVC can only authenticate with Git remotes using [SSH URLs].
-
-[ssh urls]:
-  https://git-scm.com/book/en/v2/Git-on-the-Server-The-Protocols#_the_protocols
-
-</admon>
-
 ## Synopsis
 
 ```usage


### PR DESCRIPTION
Removing incorrect line from docs

https://github.com/iterative/mlem/issues/616?notification_referrer_id=NT_kwDOAGe5lLI1NjkxMDk3OTc5OjY3OTc3MTY#issuecomment-1467925374