### PR TITLE
guide: add running-pipelines page

### DIFF
--- a/content/docs/sidebar.json
+++ b/content/docs/sidebar.json
@@ -163,7 +163,14 @@
       {
         "slug": "pipelines",
         "source": "pipelines/index.md",
-        "children": ["defining-pipelines", "run-cache"]
+        "children": [
+          "defining-pipelines",
+          "running-pipelines",
+          {
+            "label": "Caching Stages",
+            "slug": "run-cache"
+          }
+        ]
       },
       {
         "label": "Experiment Management",

--- a/content/docs/sidebar.json
+++ b/content/docs/sidebar.json
@@ -163,14 +163,7 @@
       {
         "slug": "pipelines",
         "source": "pipelines/index.md",
-        "children": [
-          "defining-pipelines",
-          "running-pipelines",
-          {
-            "label": "Caching Stages",
-            "slug": "run-cache"
-          }
-        ]
+        "children": ["defining-pipelines", "running-pipelines", "run-cache"]
       },
       {
         "label": "Experiment Management",

--- a/content/docs/user-guide/pipelines/defining-pipelines.md
+++ b/content/docs/user-guide/pipelines/defining-pipelines.md
@@ -55,7 +55,7 @@ run a pipeline, its topology should be _acyclic_ -- because executing cycles
 
 Use `dvc dag` to visualize (or export) them.
 
-[more about dags]: https://en.wikipedia.org/wiki/Directed_acyclic_graph
+[more about dags]: /doc/user-guide/pipelines/running-pipelines#dag
 
 </details>
 

--- a/content/docs/user-guide/pipelines/run-cache.md
+++ b/content/docs/user-guide/pipelines/run-cache.md
@@ -1,11 +1,4 @@
-# Caching Stages
-
-DVC will try to avoid recomputing stages that have been
-[run](/doc/user-guide/running-pipelines) before. If you run a stage without
-changing the command, dependencies, or parameters, DVC will skip that stage. DVC
-will also recover the outputs from previous runs using the run cache.
-
-## Run Cache: Automatic Log of Stage Runs
+# Run Cache: Automatic Log of Stage Runs
 
 Every time you run a pipeline with DVC, it logs the unique signature of each
 stage run (in `.dvc/cache/runs`). If it never happened before, its command(s)

--- a/content/docs/user-guide/pipelines/run-cache.md
+++ b/content/docs/user-guide/pipelines/run-cache.md
@@ -1,10 +1,17 @@
-# Run Cache: Automatic Log of Stage Runs
+# Caching Stages
 
-Every time you [reproduce](/doc/command-reference/repro) a pipeline with DVC, it
-logs the unique signature of each stage run (in `.dvc/cache/runs`). If it never
-happened before, its command(s) are executed normally. Every subsequent time a
-<abbr>stage<abbr> runs under the same conditions, the previous results can be
-restored instantly -- without wasting time or computing resources.
+DVC will try to avoid recomputing stages that have been
+[run](/doc/user-guide/running-pipelines) before. If you run a stage without
+changing the command, dependencies, or parameters, DVC will skip that stage. DVC
+will also recover the outputs from previous runs using the run cache.
+
+## Run Cache: Automatic Log of Stage Runs
+
+Every time you run a pipeline with DVC, it logs the unique signature of each
+stage run (in `.dvc/cache/runs`). If it never happened before, its command(s)
+are executed normally. Every subsequent time a <abbr>stage<abbr> runs under the
+same conditions, the previous results can be restored instantly -- without
+wasting time or computing resources.
 [More details](/doc/user-guide/project-structure/internal-files#run-cache)
 
 ✅ This built-in feature is called **run cache** and it can dramatically improve

--- a/content/docs/user-guide/pipelines/running-pipelines.md
+++ b/content/docs/user-guide/pipelines/running-pipelines.md
@@ -1,0 +1,35 @@
+# Running pipelines
+
+To run a pipeline, you can use `dvc exp run`. This will run the pipeline and
+save the results as an [experiment](/doc/user-guide/experiment-management):
+
+```cli
+$ dvc exp run
+'data/data.xml.dvc' didn't change, skipping
+Running stage 'prepare':
+> python src/prepare.py data/data.xml
+Updating lock file 'dvc.lock'
+
+Running stage 'featurize':
+> python src/featurization.py data/prepared data/features
+Updating lock file 'dvc.lock'
+
+Running stage 'train':
+> python src/train.py data/features model.pkl
+Updating lock file 'dvc.lock'
+
+Running stage 'evaluate':
+> python src/evaluate.py model.pkl data/features
+Updating lock file 'dvc.lock'
+
+Ran experiment(s): barer-acts
+Experiment results have been applied to your workspace.
+```
+
+<admon type="tip">
+
+If you do not want to save the results as an experiment, you can use
+`dvc repro`, which is similar but does not save an experiment or have the other
+experiment-related features of `dvc exp run`.
+
+</admon>

--- a/content/docs/user-guide/pipelines/running-pipelines.md
+++ b/content/docs/user-guide/pipelines/running-pipelines.md
@@ -26,10 +26,83 @@ Ran experiment(s): barer-acts
 Experiment results have been applied to your workspace.
 ```
 
-<admon type="tip">
-
 If you do not want to save the results as an experiment, you can use
 `dvc repro`, which is similar but does not save an experiment or have the other
 experiment-related features of `dvc exp run`.
 
+<admon type="info">
+
+Stage outputs are deleted from the <abbr>workspace</abbr> before executing the
+stage commands that produce them (unless `persist: true` is used in `dvc.yaml`).
+
 </admon>
+
+## DAG
+
+DVC runs the [DAG](https://en.wikipedia.org/wiki/Directed_acyclic_graph) stages
+sequentially, in the order defined by the
+[dependencies](/doc/user-guide/defining-pipelines#simple-dependencies) and
+[outputs](/doc/user-guide/defining-pipelines#outputs). Consider this example
+`dvc.yaml`:
+
+```yaml
+stages:
+  prepare:
+    cmd: python src/prepare.py data/data.xml
+    deps:
+      - data/data.xml
+      - src/prepare.py
+    params:
+      - prepare.seed
+      - prepare.split
+    outs:
+      - data/prepared
+  featurize:
+    cmd: python src/featurization.py data/prepared data/features
+    deps:
+      - data/prepared
+      - src/featurization.py
+    params:
+      - featurize.max_features
+      - featurize.ngrams
+    outs:
+      - data/features
+```
+
+The `prepare` stage will always precede the `featurize` stage because
+`data/prepared` is an **output** of `prepare` and a **dependency** of
+`featurize`.
+
+## Caching Stages
+
+DVC will try to avoid recomputing stages that have been run before. If you run a
+stage without changing its commands,
+[dependencies](/doc/user-guide/defining-pipelines#simple-dependencies), or
+[parameters](/doc/user-guide/defining-pipelines#parameter-dependencies), DVC
+will skip that stage:
+
+```cli
+Stage 'prepare' didn't change, skipping
+```
+
+DVC will also recover the outputs from previous runs using the
+[run cache](/doc/user-guide/pipelines/run-cache):
+
+```
+Stage 'prepare' is cached - skipping run, checking out outputs
+```
+
+If you want a stage to run every time, you can use
+[always changed](/doc/user-guide/project-structure/dvcyaml-files#stage-entries)
+in `dvc.yaml`:
+
+```yaml
+stages:
+  pull_latest:
+    cmd: python pull_latest.py
+    deps:
+      - pull_latest.py
+    outs:
+      - latest_results.csv
+    always_changed: true
+```

--- a/content/docs/user-guide/pipelines/running-pipelines.md
+++ b/content/docs/user-guide/pipelines/running-pipelines.md
@@ -41,9 +41,9 @@ stage commands that produce them (unless `persist: true` is used in `dvc.yaml`).
 
 DVC runs the [DAG](https://en.wikipedia.org/wiki/Directed_acyclic_graph) stages
 sequentially, in the order defined by the
-[dependencies](/doc/user-guide/defining-pipelines#simple-dependencies) and
-[outputs](/doc/user-guide/defining-pipelines#outputs). Consider this example
-`dvc.yaml`:
+[dependencies](/doc/user-guide/pipelines/defining-pipelines#simple-dependencies)
+and [outputs](/doc/user-guide/pipelines/defining-pipelines#outputs). Consider
+this example `dvc.yaml`:
 
 ```yaml
 stages:
@@ -77,9 +77,10 @@ The `prepare` stage will always precede the `featurize` stage because
 
 DVC will try to avoid recomputing stages that have been run before. If you run a
 stage without changing its commands,
-[dependencies](/doc/user-guide/defining-pipelines#simple-dependencies), or
-[parameters](/doc/user-guide/defining-pipelines#parameter-dependencies), DVC
-will skip that stage:
+[dependencies](/doc/user-guide/pipelines/defining-pipelines#simple-dependencies),
+or
+[parameters](/doc/user-guide/pipelines/defining-pipelines#parameter-dependencies),
+DVC will skip that stage:
 
 ```cli
 Stage 'prepare' didn't change, skipping


### PR DESCRIPTION
This started as a way to address #4431, but it expanded into a page on running pipelines generally.