### PR TITLE
start: drop ref to next page that doesn't exist

### DIFF
--- a/content/docs/start/data-management/metrics-parameters-plots.md
+++ b/content/docs/start/data-management/metrics-parameters-plots.md
@@ -330,6 +330,3 @@ file:///Users/dvc/example-get-started/plots.html
 > All these commands also accept
 > [Git revisions](https://git-scm.com/docs/gitrevisions) (commits, tags, branch
 > names) to compare.
-
-On the next page, you can learn advanced ways to track, organize, and compare
-more experiment iterations.


### PR DESCRIPTION
We mention a next page at the end of the data mgmt trail that we have long since removed.