### PR TITLE
Support for `Path` and `str` to an existing image in `dvclive.log_image`

### DIFF
--- a/content/docs/dvclive/live/log_image.md
+++ b/content/docs/dvclive/live/log_image.md
@@ -12,22 +12,32 @@ def log_image(name: str, val):
 from dvclive import Live
 
 with Live() as live:
+    # 1. Log an image from a numpy array:
     import numpy as np
     img_numpy = np.ones((500, 500), np.uint8) * 255
     live.log_image("numpy.png", img_numpy)
 
+    # 2. Or log a `PIL.image`:
     from PIL import Image
     img_pil = Image.new("RGB", (500, 500), (250, 250, 250))
     live.log_image("pil.png", img_pil)
+
+    # 3. Or log an existing image:
+    from PIL import Image
+    live.log_image("sample.png", "run/batch_0_sample.png")
 ```
 
 ## Description
 
 Supported values for `val` are:
 
-- A valid NumPy array (convertible to image via
+- A valid NumPy array (convertible to an image via
   [PIL.Image.fromarray](https://pillow.readthedocs.io/en/stable/reference/Image.html#PIL.Image.fromarray))
-- A `PIL.Image` instance.
+- A `PIL.Image` instance
+- A path to an image file (`str` or
+  [`Path`](https://docs.python.org/3/library/pathlib.html#pathlib.Path)). It
+  should be in a format that is readable by
+  [`PIL.Image.open()`](https://pillow.readthedocs.io/en/stable/reference/Image.html#PIL.Image.open)
 
 The images will be saved in `{Live.plots_dir}/images/{name}`:
 
@@ -53,7 +63,8 @@ $ dvc plots diff dvclive/plots
 
 - `name` - name of the image file that this command will output
 
-- `val` - image to be saved
+- `val` - image to be saved. See the list of supported values in the
+  [Description](#description).
 
 ## Exceptions
 


### PR DESCRIPTION
Docs for the https://github.com/iterative/dvclive/pull/518

--------

> You may disregard these recommendations if you used the **Edit on GitHub** button from dvc.org to improve a doc in place.

❗ Please read the guidelines in the [Contributing to the Documentation](https://dvc.org/doc/user-guide/contributing/docs) list if you make any substantial changes to the documentation or JS engine.

🐛 Please make sure to mention `Fix #issue` (if applicable) in the description of the PR. This causes GitHub to close it automatically when the PR is merged.

Please choose to [allow us](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to edit your branch when creating the PR.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
