### PR TITLE
sharing exp: document studio.token

### DIFF
--- a/content/docs/command-reference/exp/push.md
+++ b/content/docs/command-reference/exp/push.md
@@ -47,6 +47,13 @@ to see experiments in the remote.
 This command will also try to `dvc push` all <abbr>cached</abbr> data associated
 with the experiments to [remote storage], unless `--no-cache` is used.
 
+If `studio.token` config or `DVC_STUDIO_TOKEN` environment variable is set, DVC
+will notify Studio about new experiments, and display a Studio project URL to
+view experiments.
+[Get the token](https://studio.iterative.ai/user/_/profile?section=accessToken)
+or check
+[this guide on how to create an access token](/doc/studio/user-guide/projects-and-experiments/live-metrics-and-plots#set-up-an-access-token).
+
 ## Options
 
 - `-A`, `--all-commits` - push all experiments in the repository (overrides

--- a/content/docs/studio/user-guide/projects-and-experiments/live-metrics-and-plots.md
+++ b/content/docs/studio/user-guide/projects-and-experiments/live-metrics-and-plots.md
@@ -12,11 +12,11 @@ This requires a 2-step process:
 
 ## Set up an access token
 
-Iterative Studio uses access tokens to authorize [DVCLive] to send live updates
-to the metrics and plots. The access token must be present in any request that
-sends data to the Iterative Studio ingestion endpoint. Requests with missing or
-incorrect access tokens are rejected with an appropriate HTTP error code and
-error message.
+Iterative Studio uses access tokens to authorize DVC and [DVCLive] to send
+experiments and live updates to the metrics and plots. The access token must be
+present in any request that sends data to the Iterative Studio ingestion
+endpoint. Requests with missing or incorrect access tokens are rejected with an
+appropriate HTTP error code and error message.
 
 ### Create and manage access token
 
@@ -29,14 +29,14 @@ handy if you suspect that your account security may have been compromised.
 
 ### Provide access token to experiment
 
-DVCLive expects the access token to be set in the `STUDIO_TOKEN` environment
+DVCLive expects the access token to be set in the `DVC_STUDIO_TOKEN` environment
 variable.
 
 If you are running the experiment locally, you can set this environment variable
 when submitting the training job.
 
 ```cli
-$ STUDIO_TOKEN=**** dvc exp run
+$ DVC_STUDIO_TOKEN=**** dvc exp run
 ```
 
 If you are running the experiment as part of a CI job, a secure way to provide
@@ -49,7 +49,7 @@ example below).
 steps:
   - name: Train model
     env:
-      STUDIO_TOKEN: ${{ secrets.STUDIO_TOKEN }}
+      DVC_STUDIO_TOKEN: ${{ secrets.DVC_STUDIO_TOKEN }}
 ```
 
 ## Send and view live metrics and plots

--- a/content/docs/user-guide/project-structure/configuration.md
+++ b/content/docs/user-guide/project-structure/configuration.md
@@ -65,6 +65,8 @@ within:
 - [`plots`](#plots) - options for configuring `dvc plots`.
 - [`state`](#state) - see [Internal directories and files][internals] to learn
   more about the state database.
+- [`studio`](#studio) - options for configuring
+  [Iterative Studio](https://studio.iterative.ai/) token
 - [`index`](#index) - see [Internal directories and files][internals] to learn
   more about remote index files.
 
@@ -373,6 +375,24 @@ Composition].
   `md5/` directories), by default in `.dvc/tmp`. This may be necessary when
   using DVC on NFS or other mounted volumes where SQLite encounters file
   permission errors.
+
+</details>
+
+<details>
+
+## studio
+
+- `studio.token` - Studio access token to use. When this is set, DVC uses this
+  to notify Studio of new experiments. For security reasons, we advise setting
+  token to either a local or a global config. This can also be specified through
+  `DVC_STUDIO_TOKEN` environment variable.
+
+  [Get the token](https://studio.iterative.ai/user/_/profile?section=accessToken)
+  or check
+  [this guide on how to create an access token](/doc/studio/user-guide/projects-and-experiments/live-metrics-and-plots#set-up-an-access-token).
+
+- `studio.url` - URL of Studio to use (in case of self-hosted Studio instance).
+  This can also be specified through `DVC_STUDIO_URL` environment variable.
 
 </details>
 


### PR DESCRIPTION
Related #4440.

I did not add any visuals for `exp push` as I did not see if it fit into command reference. Maybe that should be accommodated in the guide or tutorials.