### PR TITLE
studio: Add page about creating a support bundle

### DIFF
--- a/content/docs/sidebar.json
+++ b/content/docs/sidebar.json
@@ -706,6 +706,10 @@
               {
                 "label": "502 Service Unavailable",
                 "slug": "502"
+              },
+              {
+                "label": "Providing data to our support",
+                "slug": "support-bundle"
               }
             ]
           }

--- a/content/docs/studio/self-hosting/troubleshooting/support-bundle.md
+++ b/content/docs/studio/self-hosting/troubleshooting/support-bundle.md
@@ -1,0 +1,39 @@
+# Providing data to our support
+
+To help you troubleshoot issues with Studio, we may request a support bundle,
+which contains Studio's application logs.
+
+This guide will walk you through how to create the support bundle.
+
+## Prerequisites
+
+<toggle>
+<tab title="VM (AMI)">
+
+If you've deployed Studio using a VM image, please launch an SSH session to the
+instance before continuing.
+
+</tab>
+
+<tab title="Helm">
+
+If you've deployed Studio directly with Helm, please download the
+`create-support-bundle` script before continuing.
+
+```cli
+$ curl -o create-support-bundle https://raw.githubusercontent.com/iterative/studio-selfhosted/main/packer/create-support-bundle.sh
+```
+
+</tab>
+</toggle>
+
+## Creating the support bundle
+
+Run the `create-support-bundle` script to create the support bundle ZIP file.
+
+```cli
+$ create-support-bundle
+```
+
+Copy the ZIP file from `/tmp/studio-support.tar.gz` to your local machine. To do
+this, you can use SFTP or rsync.


### PR DESCRIPTION
This PR creates a new page in the Studio Self-hosting section about creating a support bundle that contains Studio's application logs. This support bundle can be shared with our support engineers for faster resolution of issues.