### PR TITLE
studio: Add section with system requirements

### DIFF
--- a/content/docs/studio/self-hosting/installation/index.md
+++ b/content/docs/studio/self-hosting/installation/index.md
@@ -13,6 +13,31 @@ Below are the supported installation methods:
 - [AMI (AWS)](/doc/studio/self-hosting/installation/aws-ami)
 - [Kubernetes (Helm)](/doc/studio/self-hosting/installation/k8s-helm)
 
+## System requirements
+
+<toggle>
+<tab title="VM (AMI)">
+
+Recommended requirements:
+
+- 32 GB RAM
+- 4 vCPUs
+- 100 GB disk space
+
+</tab>
+<tab title="Helm">
+
+We recommend deploying Studio in an auto-scaling node group with a minimum of 2
+nodes.
+
+Each node should have at least 16 GB of RAM and 4 vCPUs.
+
+Additionally, you'll need 100 GB of block storage for Studio's
+`PersistentVolume`
+
+</tab>
+</toggle>
+
 ## Studio's architecture
 
 ![](/img/studio-architecture-diagram.svg)


### PR DESCRIPTION
This PR describes the system requirements for the AMI and Helm variants on the Installation page in Studio's self-hosting section.