### PR TITLE
exp sharing updates - Studio docs

### DIFF
--- a/content/docs/studio/get-started.md
+++ b/content/docs/studio/get-started.md
@@ -42,13 +42,21 @@ details]).
 
    </admon>
 
-3. Iterative Studio parses your project's `dvc.yaml` file to identify data,
-   metrics, plots and hyperparameters.
+3. Iterative Studio identifies experiments and their data, metrics, plots and
+   hyperparameters form the following sources:
 
-   If you are not using DVC, you can separately
-   [indicate which files contain metrics and hyperparameters](/doc/studio/user-guide/projects-and-experiments/configure-a-project#custom-metrics-and-parameters).
-   However, we strongly recommend using DVC to avail of all the features of
-   Iterative Studio.
+   1. **`dvc.yaml` file**: Details of experiments saved as Git commits are
+      fetched from this file.
+   2. **Git refs**: Details of experiments pushed using `dvc exp push` are
+      fetched from here.
+   3. **Metrics and plots logged by [DVCLive]**: To [track live metrics and
+      plots][live-metrics-and-plots] of running experiments, you should set the
+      `DVC_STUDIO_TOKEN` environment variable and use [DVCLive] in your training
+      pipeline.
+   4. **Files that you
+      [indicate as custom metrics and parameters files](/doc/studio/user-guide/projects-and-experiments/configure-a-project#custom-metrics-and-parameters)**:
+      These are useful if you are not using DVC. However, we strongly recommend
+      using DVC to avail of all the features of Iterative Studio.
 
 4. Each project on the Projects dashboard displays the metrics of the first
    three columns in your project (such as `avg_prec` and `roc_auc` in the
@@ -65,10 +73,6 @@ details]).
 6. You can [submit new experiments] by changing hyperparameters and datasets.
    This triggers model training if your repository has appropriate CI/CD actions
    set up.
-
-7. To [track live metrics and plots][live-metrics-and-plots] of running
-   experiments, set the `STUDIO_ACCESS_TOKEN` environment variable and use
-   [DVCLive] in your training pipeline.
 
 ## Manage models
 

--- a/content/docs/studio/troubleshooting.md
+++ b/content/docs/studio/troubleshooting.md
@@ -23,6 +23,7 @@ Iterative Studio.
 - [Project does not contain some of my commits or branches](#project-does-not-contain-some-of-my-commits-or-branches)
 - [Error: Failed to push experiment to repository](#error-failed-to-push-experiment-to-repository)
 - [Project does not display live metrics and plots](#project-does-not-display-live-metrics-and-plots)
+- [Project does not display DVC experiments](#project-does-not-display-dvc-experiments)
 
 **Model registry**
 
@@ -236,6 +237,16 @@ Also note that live metrics and plots for an experiment are displayed only if
 its parent Git commit is present in the project table. So, before you run the
 experiment, make sure that its parent commit is pushed to Git and shown in the
 project table.
+
+## Project does not display DVC experiments
+
+Iterative Studio automatically checks for updates to your repository using
+webhooks, but it can not rely on this mechanism for custom git objects, like DVC
+experiment references. So the experiments you push using `dvc exp push` may not
+automatically display in your project table.
+
+To manually check for updates in your repository, use the `Reload` button 🔄
+located above the project table.
 
 ## I cannot find my desired Git repository in the form to add a model
 

--- a/content/docs/studio/user-guide/projects-and-experiments/explore-ml-experiments.md
+++ b/content/docs/studio/user-guide/projects-and-experiments/explore-ml-experiments.md
@@ -38,11 +38,13 @@ The branches and commits in your Git repository are displayed along with the
 corresponding models, metrics, hyperparameters, and DVC-tracked files.
 
 [New experiments submitted from Iterative Studio][run-experiments] appear as
-experiment commits, which are eventually pushed to Git. Any live metrics that
-you send using [DVCLive] are displayed in a special experiment row nested under
-the parent Git commit. More details of how live metrics are displayed can be
-found
+experiment commits, which are eventually pushed to Git. Experiments that you
+push using the `dvc exp push` command as well as any live metrics that you send
+using [DVCLive] are displayed in a special experiment row nested under the
+parent Git commit. More details of how live metrics are displayed can be found
 [here](/doc/studio/user-guide/projects-and-experiments/live-metrics-and-plots#view-live-metrics-and-plots).
+
+<!-- To do: Replace the following image with one that contains dvc exp and live experiment rows.-->
 
 ![](https://static.iterative.ai/img/studio/view_components_1.gif)
 

--- a/content/docs/studio/user-guide/projects-and-experiments/explore-ml-experiments.md
+++ b/content/docs/studio/user-guide/projects-and-experiments/explore-ml-experiments.md
@@ -44,6 +44,9 @@ using [DVCLive] are displayed in a special experiment row nested under the
 parent Git commit. More details of how live metrics are displayed can be found
 [here](/doc/studio/user-guide/projects-and-experiments/live-metrics-and-plots#view-live-metrics-and-plots).
 
+To manually check for updates in your repository, use the `Reload` button 🔄
+located above the project table.
+
 <!-- To do: Replace the following image with one that contains dvc exp and live experiment rows.-->
 
 ![](https://static.iterative.ai/img/studio/view_components_1.gif)

--- a/content/docs/studio/user-guide/projects-and-experiments/live-metrics-and-plots.md
+++ b/content/docs/studio/user-guide/projects-and-experiments/live-metrics-and-plots.md
@@ -18,6 +18,9 @@ present in any request that sends data to the Iterative Studio ingestion
 endpoint. Requests with missing or incorrect access tokens are rejected with an
 appropriate HTTP error code and error message.
 
+The access token is also used by DVC to notify Iterative Studio when you push
+experiments using `dvc exp push`.
+
 ### Create and manage access token
 
 Open your user profile page. In the `Studio access token` section, click on

--- a/content/docs/studio/user-guide/projects-and-experiments/what-is-a-project.md
+++ b/content/docs/studio/user-guide/projects-and-experiments/what-is-a-project.md
@@ -24,13 +24,15 @@ To **display your project's content** in Iterative Studio,
 create `dvc.yaml`. When running model training and evaluation, save metrics and
 plots in the files defined in `dvc.yaml`.
 
+You can also use the `dvc exp push` command to **push experiments without
+creating separate Git commits** for them. To notify Iterative Studio when you
+push experiments using `dvc exp push`,
+[configure the `DVC_STUDIO_TOKEN` environment variable](/doc/studio/user-guide/projects-and-experiments/live-metrics-and-plots#set-up-an-access-token).
+
 If you are working with a **non-DVC repository**, you can
 [indicate which files contain metrics and hyperparameters](/doc/studio/user-guide/projects-and-experiments/configure-a-project#custom-metrics-and-parameters)
 that Iterative Studio should display in the project. However, we strongly
 recommend using DVC to avail of all the features of Iterative Studio.
-
-To **add model metadata** to your repositories, you can use Iterative Studio
-Model Registry, or the underlying [GTO] or [MLEM]. [Learn more][model-registry]
 
 To **run new experiments** from Iterative Studio, integrate your repositories
 with a CI setup that includes a model training process. You can
@@ -39,10 +41,13 @@ to automatically generate the workflow configuration for the model training CI
 job. [Learn more][run-experiments]
 
 To **track live metrics and plots** of running experiments, configure the
-`STUDIO_ACCESS_TOKEN` environment variable and use DVCLive in your training
+`DVC_STUDIO_TOKEN` environment variable and use DVCLive in your training
 pipeline. You can also do this for experiments that you run from Iterative
 Studio if you configure the CI job accordingly. [Learn
 more][live-metrics-and-plots]
+
+To **add model metadata** to your repositories, you can use Iterative Studio
+Model Registry, or the underlying [GTO] or [MLEM]. [Learn more][model-registry]
 
 [on project settings]:
   /doc/studio/user-guide/projects-and-experiments/configure-a-project#non-dvc-repositories


### PR DESCRIPTION
This contains changes to the Studio docs, related to `dvc exp push`.