### PR TITLE
Get Started - Condensing landing page

### DIFF
--- a/content/docs/sidebar.json
+++ b/content/docs/sidebar.json
@@ -41,7 +41,7 @@
     "children": [
       {
         "slug": "data-management",
-        "source": false,
+        "source": "data-management/index.md",
         "children": [
           "data-versioning",
           "data-pipelines",
@@ -54,7 +54,7 @@
       {
         "label": "Experiment Management",
         "slug": "experiments",
-        "source": false,
+        "source": "experiments/index.md",
         "children": [
           "experiment-tracking",
           {

--- a/content/docs/start/data-management/index.md
+++ b/content/docs/start/data-management/index.md
@@ -1,0 +1,43 @@
+---
+title: 'Get Started: Data Management'
+description:
+  'Get started with DVC data management. Version your data, build data pipelines
+  and learn about pipeline metrics, parameters and plots.'
+---
+
+# Get Started: Data Management
+
+## Chapters
+
+- **[Data and model versioning]** - Manage large files, datasets, and machine
+  learning models. Track your data and couple its versions to your code
+  versions, while keeping it stored properly outside of your Git repo.
+
+- **[Data pipelines]** - Use pipelines to describe how models and other data
+  artifacts are built, and provide an efficient way to reproduce them. Think
+  "Makefiles for data and ML projects" done right.
+
+- **[Metrics, parameters, and plots]** - Those are first class citizens in DVC
+  pipelines. Capture, evaluate, and visualize ML projects without leaving Git.
+
+[data and model versioning]: /doc/start/data-management/data-versioning
+[data pipelines]: /doc/start/data-management/data-pipelines
+[metrics, parameters, and plots]:
+  /doc/start/data-management/metrics-parameters-plots
+
+<admon type="tip">
+
+The steps and results of some of these chapters are captured in our
+[example-get-started] repo. Feel free to `git clone/checkout` any of its
+[tags][example-get-started-tags].
+
+[example-get-started]: https://github.com/iterative/example-get-started
+[example-get-started-tags]:
+  https://github.com/iterative/example-get-started/tags
+
+</admon>
+
+## Where To Go Next
+
+Pick a page from the list above, the left-side navigation bar, or just click
+`NEXT` below!

--- a/content/docs/start/data-management/index.md
+++ b/content/docs/start/data-management/index.md
@@ -41,3 +41,5 @@ The steps and results of some of these chapters are captured in our
 
 Pick a page from the list above, the left-side navigation bar, or just click
 `NEXT` below!
+
+Click [here](/doc/start/) to jump back to the Get Started landing page.

--- a/content/docs/start/experiments/index.md
+++ b/content/docs/start/experiments/index.md
@@ -1,0 +1,45 @@
+---
+title: 'Get Started: Experiment Management'
+description:
+  'Get started with DVC experiment management. Use DVCLive to instrument your
+  code for easy experiment tracking, build pipelines for reproducible
+  experiments and learn to share and collaborate on experiments with your
+  teammates'
+---
+
+# Get Started: Experiment Management
+
+## Chapters
+
+- **[Experiment tracking]** - Instrument your code to quickly start tracking
+  experiments. Manage changes to code, data, metrics, parameters and plots
+  associated with each experiment without bloating your Git repo.
+
+- **[Collaborating on experiments]** - Manage experiments the same way
+  developers manage code. Share experiments with your team over git, create
+  branches and pull requests, and compare results.
+
+- **[Experimenting using pipelines]** - Leverage DVC data pipelines as an
+  experiment management system. Split your workflow into stages, track
+  dependencies and outputs, and natively inject parameters and hyper-parameters
+  to experiment runs.
+
+[experiment tracking]: /doc/start/experiments/experiment-tracking
+[collaborating on experiments]: /doc/start/experiments/experiment-collaboration
+[experimenting using pipelines]: /doc/start/experiments/experiment-pipelines
+
+<admon type="tip">
+
+These are captured in our [example-dvc-experiments] repo (see its
+[tags][example-dvc-experiments-tags]).
+
+[example-dvc-experiments]: https://github.com/iterative/example-dvc-experiments
+[example-dvc-experiments-tags]:
+  https://github.com/iterative/example-dvc-experiments/tags
+
+</admon>
+
+## Where To Go Next
+
+Pick a page from the list above, the left-side navigation bar, or just click
+`NEXT` below!

--- a/content/docs/start/experiments/index.md
+++ b/content/docs/start/experiments/index.md
@@ -43,3 +43,5 @@ These are captured in our [example-dvc-experiments] repo (see its
 
 Pick a page from the list above, the left-side navigation bar, or just click
 `NEXT` below!
+
+Click [here](/doc/start/) to jump back to the Get Started landing page.

--- a/content/docs/start/index.md
+++ b/content/docs/start/index.md
@@ -11,8 +11,7 @@ pipelines and metrics, and manage experiments.'
 ## Get Started with DVC
 -->
 
-Assuming DVC is already [installed](/doc/install), let's initialize it by
-running `dvc init` inside a Git project:
+Before we begin, let's prepare a project for this guide
 
 <details>
 
@@ -36,6 +35,9 @@ This directory name is used in our
 
 </details>
 
+Assuming DVC is already [installed](/doc/install), initialize it by running
+`dvc init` inside a Git project:
+
 ```cli
 $ dvc init
 ```
@@ -56,88 +58,27 @@ Now you're ready to DVC!
 
 ## Following This Guide
 
-To help you understand and use DVC better, consider those two high level
-scenarios:
+To help you understand and use DVC better, consider the following two use-cases:
+**data management** and **experiment tracking**. You may pick either one to
+start learning about how DVC helps you "solve" that scenario!
 
-- **Data Management** - Track and version large amounts of data along with your
-  code, and use DVC as a build system for reproducible, data driven pipelines.
+Choose a trail to jump into its first chapter:
 
-- **Experiment Management** - Easily track your experiments and their progress
+- **[Data Management]** - Track and version large amounts of data along with
+  your code, and use DVC as a build system for reproducible, data driven
+  pipelines.
+
+- **[Experiment Management]** - Easily track your experiments and their progress
   by only instrumenting your code, and collaborate on ML experiments like
   software engineers do for code.
 
-The following chapters are grouped into the above 2 trails and are all pretty
-self-contained.
+[Data Management]: /doc/start/data-management/data-versioning
+[Experiment Management]: /doc/start/experiments/experiment-tracking
 
 <admon type="tip">
 
-Feel free to "choose your own adventure" and skip to the chapters which answer
-your specific needs. In case you're unsure where to start, we recommend going
-over the chapters in order.
+Feel free to "choose your own adventure" and follow the chapters which answer
+your specific needs. In case you're unsure where to start, we recommend starting
+with **data management**.
 
 </admon>
-
-## Data Management
-
-- **[Data and model versioning]** - Manage large files, datasets, and machine
-  learning models. Track your data and couple its versions to your code
-  versions, while keeping it stored properly outside of your Git repo.
-
-- **[Data pipelines]** - Use pipelines to describe how models and other data
-  artifacts are built, and provide an efficient way to reproduce them. Think
-  "Makefiles for data and ML projects" done right.
-
-- **[Metrics, parameters, and plots]** - Those are first class citizens in DVC
-  pipelines. Capture, evaluate, and visualize ML projects without leaving Git.
-
-[data and model versioning]: /doc/start/data-management/data-versioning
-[data pipelines]: /doc/start/data-management/data-pipelines
-[metrics, parameters, and plots]:
-  /doc/start/data-management/metrics-parameters-plots
-
-<admon type="tip">
-
-The steps and results of some of these chapters are captured in our
-[example-get-started] repo. Feel free to `git clone/checkout` any of its
-[tags][example-get-started-tags].
-
-[example-get-started]: https://github.com/iterative/example-get-started
-[example-get-started-tags]:
-  https://github.com/iterative/example-get-started/tags
-
-</admon>
-
-## Experiment Management
-
-- **[Experiment tracking]** - Instrument your code to quickly start tracking
-  experiments. Manage changes to code, data, metrics, parameters and plots
-  associated with each experiment without bloating your Git repo.
-
-- **[Collaborating on experiments]** - Manage experiments the same way
-  developers manage code. Share experiments with your team over git, create
-  branches and pull requests, and compare results.
-
-- **[Experimenting using pipelines]** - Leverage DVC data pipelines as an
-  experiment management system. Split your workflow into stages, track
-  dependencies and outputs, and natively inject parameters and hyper-parameters
-  to experiment runs.
-
-[experiment tracking]: /doc/start/experiments/experiment-tracking
-[collaborating on experiments]: /doc/start/experiments/experiment-collaboration
-[experimenting using pipelines]: /doc/start/experiments/experiment-pipelines
-
-<admon type="tip">
-
-These are captured in our [example-dvc-experiments] repo (see its
-[tags][example-dvc-experiments-tags]).
-
-[example-dvc-experiments]: https://github.com/iterative/example-dvc-experiments
-[example-dvc-experiments-tags]:
-  https://github.com/iterative/example-dvc-experiments/tags
-
-</admon>
-
-## Where To Go Next
-
-Pick a page from the list above, the left-side navigation bar, or just click
-`NEXT` below!

--- a/redirects-list.json
+++ b/redirects-list.json
@@ -40,8 +40,8 @@
   "^/doc/install/plugins(/.*)?$                                                           /doc/install/ide-plugins$1",
 
   "^/doc/get-started(/.*)?$                                                               /doc/start",
-  "^/doc/start/data-versioning$                                                           /doc/start/data-management",
-  "^/doc/start/data-and-model-versioning(/.*)?$                                           /doc/start/data-management 302",
+  "^/doc/start/data-versioning$                                                           /doc/start/data-management/data-versioning",
+  "^/doc/start/data-and-model-versioning(/.*)?$                                           /doc/start/data-management/data-versioning 302",
   "^/doc/start/sharing-data-and-model-files$                                              /doc/start/data-management#storing-and-sharing 302",
   "^/doc/start/data-access$                                                               /doc/user-guide/data-management/discovering-and-accessing-data",
   "^/doc/start/data-and-model-access(/.*)?$                                               /doc/user-guide/data-management/discovering-and-accessing-data 302",
@@ -98,9 +98,9 @@
   "^/doc/command-reference/run$                                                           /doc/command-reference/stage/add",
   "^/doc/command-reference/exp/init$                                                      /doc/command-reference/stage/add",
 
-  "^/doc/dvclive/dvclive-with-dvc$                                                        /doc/start/experiments",
+  "^/doc/dvclive/dvclive-with-dvc$                                                        /doc/start/experiments/experiment-tracking",
   "^/doc/dvclive/api-reference$                                                           /doc/dvclive/",
-  "^/doc/dvclive/get-started$                                                             /doc/start/experiments",
+  "^/doc/dvclive/get-started$                                                             /doc/start/experiments/experiment-tracking",
   "^/doc/dvclive/api-reference/ml-frameworks(/.*)?$                                       /doc/dvclive/ml-frameworks$1",
 
   "^/doc/cml(/.*)?$                                                                       https://cml.dev/doc$1",


### PR DESCRIPTION
> You may disregard these recommendations if you used the **Edit on GitHub** button from dvc.org to improve a doc in place.

❗ Please read the guidelines in the [Contributing to the Documentation](https://dvc.org/doc/user-guide/contributing/docs) list if you make any substantial changes to the documentation or JS engine.

🐛 Please make sure to mention `Fix #issue` (if applicable) in the description of the PR. This causes GitHub to close it automatically when the PR is merged.

Please choose to [allow us](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to edit your branch when creating the PR.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

Followup to https://github.com/iterative/dvc.org/pull/4460

## Main changes
- get-started index shorter, link only to first chapter of each trail
- each trail gets an index navigation page for powerful navigation, even though going from top page, you may never see it
