### PR TITLE
remove deprecated warning about ruamel.yaml

### DIFF
--- a/content/docs/command-reference/params/index.md
+++ b/content/docs/command-reference/params/index.md
@@ -131,13 +131,6 @@ epochs = params['train']['epochs']
 layers = params['train']['layers']
 ```
 
-<admon type="info">
-
-We use [ruamel.yaml](https://pypi.org/project/ruamel.yaml/) which supports YAML
-1.2 (unlike the more popular PyYAML).
-
-</admon>
-
 You can find that each parameter was defined in `dvc.yaml`, as well as saved to
 `dvc.lock` along with the values. These are compared to the params files when
 `dvc repro` is used, to determine if the parameter dependency has changed.


### PR DESCRIPTION
The warning refers to an earlier code snippet where ruamel.yaml was in fact used. With introduction of params_show (https://github.com/iterative/dvc.org/commit/a43701b372f9f3edb34ae6d10de12f3a513094ca), this remark/warning does not make sense anymore.