### PR TITLE
Add long path guide to run-dvc-on-windows.md

### DIFF
--- a/content/docs/user-guide/how-to/run-dvc-on-windows.md
+++ b/content/docs/user-guide/how-to/run-dvc-on-windows.md
@@ -66,11 +66,13 @@ processes.
 
 ## Enable long folder/file paths
 
-`dvc pull` may fail in some cases when the folder path is longer than 260
-characters. In the Windows API, the maximum allowed length for a path is 260
-characters. If required, the user can explicitly enable long paths by following
+`dvc pull` or `dvc repro` may fail in some cases when the folder path is longer than 260
+characters. This may happen with the error ``[Errno 2] No such file or directory``. 
+In the Windows API, the maximum allowed length for a path is 260
+characters. If required, the user can explicitly enable long paths either by editing group policies following
 [this](https://blogs.msdn.microsoft.com/jeremykuhne/2016/07/30/net-4-6-2-and-long-paths-on-windows-10/)
-guide.
+guide or by editing registry keys following 
+[this](https://www.howtogeek.com/266621/how-to-make-windows-10-accept-file-paths-over-260-characters/) guide.
 
 ## Fix or disable Search Indexing
 

--- a/content/docs/user-guide/how-to/run-dvc-on-windows.md
+++ b/content/docs/user-guide/how-to/run-dvc-on-windows.md
@@ -66,13 +66,14 @@ processes.
 
 ## Enable long folder/file paths
 
-`dvc pull` or `dvc repro` may fail in some cases when the folder path is longer than 260
-characters. This may happen with the error ``[Errno 2] No such file or directory``. 
-In the Windows API, the maximum allowed length for a path is 260
-characters. If required, the user can explicitly enable long paths either by editing group policies following
-[this](https://blogs.msdn.microsoft.com/jeremykuhne/2016/07/30/net-4-6-2-and-long-paths-on-windows-10/)
-guide or by editing registry keys following 
-[this](https://www.howtogeek.com/266621/how-to-make-windows-10-accept-file-paths-over-260-characters/) guide.
+DVC commands (e.g. `dvc pull`, `dvc repro`) may fail when the folder path is
+longer than 260 characters. This may happen with the error
+`[Errno 2] No such file or directory`. Starting in Windows 10, path length
+limitations have been removed from common file and directory functions. However,
+you must opt-in to the new behavior. The user can explicitly enable long paths
+either by editing Group Policy or by editing registry keys following
+[this](https://www.howtogeek.com/266621/how-to-make-windows-10-accept-file-paths-over-260-characters/)
+guide.
 
 ## Fix or disable Search Indexing
 


### PR DESCRIPTION
To enable long paths it might be needed to set a registry key. This is not covered by the currently linked guide, so linked to an additional guide. In some (my) case there was no group policy regarding long paths until after I set the registry key. Add dvc repro as possible trigger and add expected error code.

> You may disregard these recommendations if you used the **Edit on GitHub** button from dvc.org to improve a doc in place.

❗ Please read the guidelines in the [Contributing to the Documentation](https://dvc.org/doc/user-guide/contributing/docs) list if you make any substantial changes to the documentation or JS engine.

🐛 Please make sure to mention `Fix #issue` (if applicable) in the description of the PR. This causes GitHub to close it automatically when the PR is merged.

Please choose to [allow us](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to edit your branch when creating the PR.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
