### PR TITLE
Update pytorch-lightning.md to remove reference to live argument for …

### DIFF
--- a/content/docs/dvclive/ml-frameworks/pytorch-lightning.md
+++ b/content/docs/dvclive/ml-frameworks/pytorch-lightning.md
@@ -48,7 +48,7 @@ Where:
 
 ## Examples
 
-- Using `live` to pass an existing [`Live`] instance.
+- Using `experiment` to pass an existing [`Live`] instance.
 
 ```python
 from dvclive import Live
@@ -56,7 +56,7 @@ from dvclive.lightning import DVCLiveLogger
 
 with Live("custom_dir") as live:
     trainer = Trainer(
-        logger=DVCLiveLogger(live=live))
+        logger=DVCLiveLogger(experiment=live))
     trainer.fit(model)
     # Log additional metrics after training
     live.summary["additional_metric"] = 1.0


### PR DESCRIPTION
…dvclive.lightning.DVCLiveLogger class

Some of the documentation still referred to passing a `dvclive.Live` instance through the `live` parameter rather than `experiment`.

> You may disregard these recommendations if you used the **Edit on GitHub** button from dvc.org to improve a doc in place.

❗ Please read the guidelines in the [Contributing to the Documentation](https://dvc.org/doc/user-guide/contributing/docs) list if you make any substantial changes to the documentation or JS engine.

🐛 Please make sure to mention `Fix #issue` (if applicable) in the description of the PR. This causes GitHub to close it automatically when the PR is merged.

Please choose to [allow us](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to edit your branch when creating the PR.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
