### PR TITLE
clarifying language for dvc queue remove docs

### DIFF
--- a/content/docs/command-reference/queue/remove.md
+++ b/content/docs/command-reference/queue/remove.md
@@ -25,7 +25,7 @@ For completed tasks, this will also remove any associated output logs.
 <admon type="warn">
 
 Note that for successfully completed tasks, this command is not the same as
-`dvc exp remove`, which does not remove any data associated with a the
+`dvc exp remove`, because `dvc queue remove` does not remove any data associated with an
 experiment, only the queue entry and any output logs for that task.
 
 </admon>

--- a/content/docs/command-reference/queue/remove.md
+++ b/content/docs/command-reference/queue/remove.md
@@ -25,8 +25,8 @@ For completed tasks, this will also remove any associated output logs.
 <admon type="warn">
 
 Note that for successfully completed tasks, this command is not the same as
-`dvc exp remove`, because `dvc queue remove` does not remove any data associated with an
-experiment, only the queue entry and any output logs for that task.
+`dvc exp remove`, because `dvc queue remove` does not remove any data associated
+with an experiment, only the queue entry and any output logs for that task.
 
 </admon>
 


### PR DESCRIPTION
Old language made it sound like `dvc exp remove` only removes queue entries, but `dvc queue remove` removes the queue entries

> You may disregard these recommendations if you used the **Edit on GitHub** button from dvc.org to improve a doc in place.

❗ Please read the guidelines in the [Contributing to the Documentation](https://dvc.org/doc/user-guide/contributing/docs) list if you make any substantial changes to the documentation or JS engine.

🐛 Please make sure to mention `Fix #issue` (if applicable) in the description of the PR. This causes GitHub to close it automatically when the PR is merged.

Please choose to [allow us](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to edit your branch when creating the PR.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
