### PR TITLE
dvclive: log_metric(plot=False)

### DIFF
--- a/content/docs/dvclive/how-it-works.md
+++ b/content/docs/dvclive/how-it-works.md
@@ -46,7 +46,7 @@ with Live(save_dvc_exp=True) as live:
 
     live.log_artifact("model.pt")
     live.log_sklearn_plot("confusion_matrix", [0, 0, 1, 1], [0, 1, 0, 1])
-    live.summary["additional_metric"] = 1.0
+    live.log_metric("summary_metric", 1.0, plot=False)
 # live.end() has been called at this point
 ```
 

--- a/content/docs/dvclive/live/log_metric.md
+++ b/content/docs/dvclive/live/log_metric.md
@@ -1,7 +1,7 @@
 # Live.log_metric()
 
 ```py
- def log_metric(name: str, val: float):
+ def log_metric(name: str, val: float, plot: Optional[bool] = True):
 ```
 
 ## Usage
@@ -92,6 +92,9 @@ dvc metrics diff dvclive/metrics.json
 - `name` - Name of the metric being logged.
 
 - `val` - The value to be logged.
+
+- `plot` - Whether to add the metric value to the _metrics history_ file for
+  plotting. If `false`, the metric will only be saved to the metrics summary.
 
 ## Exceptions
 

--- a/content/docs/dvclive/ml-frameworks/catalyst.md
+++ b/content/docs/dvclive/ml-frameworks/catalyst.md
@@ -62,7 +62,7 @@ with Live("custom_dir") as live:
           DVCLiveCallback(live=live)])
 
     # Log additional metrics after training
-    live.summary["additional_metric"] = 1.0
+    live.log_metric("summary_metric", 1.0, plot=False)
 ```
 
 - Using `model_file`.

--- a/content/docs/dvclive/ml-frameworks/fastai.md
+++ b/content/docs/dvclive/ml-frameworks/fastai.md
@@ -59,7 +59,7 @@ with Live("custom_dir") as live:
       cbs=[DVCLiveCallback(live=live)])
 
     # Log additional metrics after training
-    live.summary["additional_metric"] = 1.0
+    live.log_metric("summary_metric", 1.0, plot=False)
 ```
 
 - Using `model_file`.

--- a/content/docs/dvclive/ml-frameworks/huggingface.md
+++ b/content/docs/dvclive/ml-frameworks/huggingface.md
@@ -65,7 +65,7 @@ with Live("custom_dir") as live:
         DVCLiveCallback(live=live))
 
     # Log additional metrics after training
-    live.summary["additional_metric"] = 1.0
+    live.log_metric("summary_metric", 1.0, plot=False)
 ```
 
 - Using `model_file`.

--- a/content/docs/dvclive/ml-frameworks/keras.md
+++ b/content/docs/dvclive/ml-frameworks/keras.md
@@ -62,8 +62,8 @@ with Live("custom_dir") as live:
 
     # Log additional data after training
     test_loss, test_acc = model.evaluate(test_dataset)
-    live.summary["test_loss"] = test_loss
-    live.summary["test_acc"] = test_acc
+    live.log_metric("test_loss", test_loss, plot=False)
+    live.log_metric("test_acc", test_acc, plot=False)
 ```
 
 - Using `model_file` and `save_weights_only`.

--- a/content/docs/dvclive/ml-frameworks/lightgbm.md
+++ b/content/docs/dvclive/ml-frameworks/lightgbm.md
@@ -47,7 +47,7 @@ with Live("custom_dir") as live:
         callbacks=[DVCLiveCallback(live=live)])
 
     # Log additional metrics after training
-    live.summary["additional_metric"] = 1.0
+    live.log_metric("summary_metric", 1.0, plot=False)
 ```
 
 - Using `model_file`.

--- a/content/docs/dvclive/ml-frameworks/pytorch-lightning.md
+++ b/content/docs/dvclive/ml-frameworks/pytorch-lightning.md
@@ -59,7 +59,7 @@ with Live("custom_dir") as live:
         logger=DVCLiveLogger(experiment=live))
     trainer.fit(model)
     # Log additional metrics after training
-    live.summary["additional_metric"] = 1.0
+    live.log_metric("summary_metric", 1.0, plot=False)
 ```
 
 - Using `**kwargs` to customize [`Live`].

--- a/content/docs/dvclive/ml-frameworks/xgboost.md
+++ b/content/docs/dvclive/ml-frameworks/xgboost.md
@@ -48,7 +48,7 @@ with Live("custom_dir") as live:
         evals=[(dval, "eval_data")])
 
     # Log additional metrics after training
-    live.summary["additional_metric"] = 1.0
+    live.log_metric("summary_metric", 1.0, plot=False)
 ```
 
 - Using `**kwargs` to customize [`Live`].


### PR DESCRIPTION
Docs for https://github.com/iterative/dvclive/pull/584

Closes #4568 

I separated into two commits:
1. Basic docs update
2. Changed summary metric examples to use this

WDYT about 2? I think it's a more consistent API to suggest `live.log_metric("metric", val, plot=False)` over `live.summary["metric"] = val`. I left the summary dict in `live.make_summary()` so that it's still valid and can be found by people who want to use it (maybe they need to add an entire dict of metrics at once).