### PR TITLE
Studio Self-hosted: Remove nginx from configs

### DIFF
--- a/content/docs/studio/self-hosting/installation/aws-ami.md
+++ b/content/docs/studio/self-hosting/installation/aws-ami.md
@@ -124,10 +124,6 @@ global:
       clientId: '<GitLab OAuth App Client ID>'
       secretKey: '<GitLab OAuth App Secret Key>'
       webhookSecret: '<GitLab Webhook Secret>'
-
-nginx:
-  ingress:
-    hostname: <Studio hostname>
 ```
 
 <admon type="info">

--- a/content/docs/studio/self-hosting/installation/k8s-helm.md
+++ b/content/docs/studio/self-hosting/installation/k8s-helm.md
@@ -90,10 +90,6 @@ global:
       clientId: '<GitLab OAuth App Client ID>'
       secretKey: '<GitLab OAuth App Secret Key>'
       webhookSecret: '<GitLab Webhook Secret>'
-
-nginx:
-  ingress:
-    hostname: <Studio hostname>
 ```
 
 Now let's deploy Studio with the command:


### PR DESCRIPTION
As of https://github.com/iterative/helm-charts/commit/235e6ebaedfee923b10bf2daed622d5ff28961da, the `nginx.ingress.hostname` configuration setting no longer has any effect, so let's remove it from our documentation.