### PR TITLE
download: re-enable osx pkg

### DIFF
--- a/src/components/DownloadButton/index.tsx
+++ b/src/components/DownloadButton/index.tsx
@@ -14,8 +14,7 @@ const VERSION = `3.0.0`
 const dropdownItems = [
   OS.UNKNOWN,
   null,
-  // temporarily disabled, re-enable if pkg gets built
-  // OS.OSX,
+  OS.OSX,
   OS.WINDOWS,
   OS.LINUX,
   OS.LINUX_RPM


### PR DESCRIPTION
With osxpkg building fixed and 3.0 package already available, we can now re-enable osx download button on dvc.org.