### PR TITLE
link between imports and external deps/outputs

### DIFF
--- a/content/docs/user-guide/data-management/importing-external-data.md
+++ b/content/docs/user-guide/data-management/importing-external-data.md
@@ -5,6 +5,14 @@ import it. You can choose whether to download that data and whether to push
 copies to your [DVC remote]. This makes importing the data useful even if you
 want to track the data in-place at its original source location.
 
+<admon type="tip">
+
+See
+[external dependencies and outputs](/doc/user-guide/pipelines/external-dependencies-and-outputs)
+if you want to work with external data in a <abbr>pipeline</abbr>.
+
+</admon>
+
 ## How importing external data works
 
 Import external data using `import-url`:
@@ -51,6 +59,12 @@ $ dvc update data.xml.dvc
 During `dvc push`, DVC will upload the version of the data tracked by
 `data.xml.dvc` to the [DVC remote] so that it is backed up in case you need to
 recover it.
+
+DVC will never overwrite the source location of the data. Instead, DVC can
+checkout any version of that data locally. DVC is designed to protect the
+original data from accidental overwrites or changes that might be unexpected to
+other users, so you can recover old versions without losing what's currently
+stored in the source location.
 
 ## Avoiding duplication
 

--- a/content/docs/user-guide/pipelines/external-dependencies-and-outputs.md
+++ b/content/docs/user-guide/pipelines/external-dependencies-and-outputs.md
@@ -4,6 +4,13 @@ Sometimes you need to stream your data dependencies directly from their source
 locations outside your local <abbr>project</abbr>, or stream your data outputs
 directly to some external location, like cloud storage or HDFS.
 
+<admon type="tip">
+
+To version external data without a pipeline, see
+[importing external data](/doc/user-guide/data-management/importing-external-data).
+
+</admon>
+
 ## How external dependencies work
 
 External <abbr>dependencies</abbr> will be tracked by DVC, detecting when they


### PR DESCRIPTION
Explains that imported data does not overwrite the source data, and adds cross-links between importing external data and external deps/outs.
