### PR TITLE
cmd-ref: document `--keep-going|--ignore-errors` in repro

### DIFF
--- a/content/docs/command-reference/repro.md
+++ b/content/docs/command-reference/repro.md
@@ -193,7 +193,7 @@ final stage.
   on the failed stage. The other dependencies of the targets will still be
   executed.
 
-- `--ignore-errors` - Ignore all errors when executing the stages.
+- `--ignore-errors` - Ignore all errors when executing the stages. Unlike `--keep-going`, stages having dependencies on the failed stage will be executed.
 
 - `-h`, `--help` - prints the usage/help message, and exit.
 

--- a/content/docs/command-reference/repro.md
+++ b/content/docs/command-reference/repro.md
@@ -193,7 +193,9 @@ final stage.
   on the failed stage. The other dependencies of the targets will still be
   executed.
 
-- `--ignore-errors` - Ignore all errors when executing the stages. Unlike `--keep-going`, stages having dependencies on the failed stage will be executed.
+- `--ignore-errors` - Ignore all errors when executing the stages. Unlike
+  `--keep-going`, stages having dependencies on the failed stage will be
+  executed.
 
 - `-h`, `--help` - prints the usage/help message, and exit.
 

--- a/content/docs/command-reference/repro.md
+++ b/content/docs/command-reference/repro.md
@@ -7,10 +7,11 @@ Reproduce complete or partial <abbr>pipelines</abbr> by running their
 
 ```usage
 usage: dvc repro [-h] [-q | -v] [-f] [-i]
-                 [-s] [-p] [-P] [-R]
+                 [-s] [-p] [-k] [-P] [-R]
                  [--downstream] [--force-downstream]
                  [--pull] [--dry] [--allow-missing]
                  [--glob] [--no-commit] [--no-run-cache]
+                 [--ignore-errors]
                  [targets [<target> ...]]
 
 positional arguments:
@@ -187,6 +188,12 @@ final stage.
   [run cache] and the outputs of stages that are already present in it.
 
 - `--allow-missing` - skip stages with no other changes than missing data.
+
+- `-k`, `--keep-going` - Continue executing, skipping stages having dependencies
+  on the failed stage. The other dependencies of the targets will still be
+  executed.
+
+- `--ignore-errors` - Ignore all errors when executing the stages.
 
 - `-h`, `--help` - prints the usage/help message, and exit.
 


### PR DESCRIPTION
Closes #4692. 

`--keep-going`/`--ignore-errors` were introduced in https://github.com/iterative/dvc/pull/9712, and will be in the next release.