### PR TITLE
docs: contrib: fix formatting

### DIFF
--- a/content/docs/contributing/core.md
+++ b/content/docs/contributing/core.md
@@ -77,8 +77,8 @@ you experience any problems, don't hesitate to ping us in our [chat](/chat).
 ## Debugging
 
 The DVC command line interface has several debugging tools that are hidden by
-default in the `--help`, but will be shown if `--verbose` is also specified.
-See [The DVC Debugging Wiki](https://github.com/iterative/dvc/wiki/Debugging,-Profiling-and-Benchmarking-DVC) 
+default in the `--help`, but will be shown if `--verbose` is also specified. See
+[The DVC Debugging Wiki](https://github.com/iterative/dvc/wiki/Debugging,-Profiling-and-Benchmarking-DVC)
 for more information on these debugging options.
 
 ## Writing tests


### PR DESCRIPTION
Formatting is broken on main.

`main` glows green, while PR CI was broken and is broken for new PRs https://github.com/iterative/dvc.org/pull/4727 