### PR TITLE
Studio: Update text to match screenshot updates

### DIFF
--- a/content/docs/studio/user-guide/projects-and-experiments/visualize-and-compare.md
+++ b/content/docs/studio/user-guide/projects-and-experiments/visualize-and-compare.md
@@ -24,15 +24,15 @@ your repository:
 To open the `Plots` pane and display plots, select one or more experiments and
 click on the `Show plots` button.
 
-![](https://static.iterative.ai/img/studio/plots.png)
-
-## Live plots
+### Live plots
 
 You can [send live updates to your plots][live-metrics-and-plots] with
 [DVCLive]. The number of recent updates to the live metrics are
 [displayed](/doc/studio/user-guide/projects-and-experiments/explore-ml-experiments#git-history-and-live-metrics)
 in the `Live` icon. Live plots are also shown and updated in real-time in the
 plots pane along with all other plots.
+
+![Live plots](https://static.iterative.ai/img/studio/live-plots.gif)
 
 ## Generate trend charts
 

--- a/content/docs/studio/user-guide/team-collaboration/teams.md
+++ b/content/docs/studio/user-guide/team-collaboration/teams.md
@@ -123,7 +123,7 @@ Once you have created the team, the team's workspace opens up.
 
 ![](https://static.iterative.ai/img/studio/team_page_v6.png)
 
-In this workspace, there are 2 pages - [Projects](#projects), [Models](#models)
+In this workspace, there are 3 pages - [Projects](#projects), [Models](#models)
 and [Settings](#settings).
 
 ## Projects


### PR DESCRIPTION
Some screenshots of Studio have been updated in [a related PR](https://github.com/iterative/static/commit/e05dd3735bd427dc29ea931cbd54c2384b0b8af1).

This PR makes one small restructuring to better accommodate the plots gif (which replaces the old plots png), and makes a correction in the number of pages in a team dashboard.