### PR TITLE
Studio minor change: Move one sentence around

### DIFF
--- a/content/docs/studio/user-guide/team-collaboration/change-team-plan-and-size.md
+++ b/content/docs/studio/user-guide/team-collaboration/change-team-plan-and-size.md
@@ -3,12 +3,12 @@
 ## Change the plan your team is on
 
 To change the plan for your team, go to the `Plan and billing` section within
-[team settings]. Then click on `Change plan` (under `Current plan`).
+[team settings].
 
 ![](https://static.iterative.ai/img/studio/team_settings_plan_and_billing_v2.png)
 
-An Iterative Studio plan comparison page will open. Your current plan will be
-marked.
+Click on `Change plan` (under `Current plan`). An Iterative Studio plan
+comparison page will open. Your current plan will be marked.
 
 ![](https://static.iterative.ai/img/studio/team_settings_plans_and_features_v2.png)
 


### PR DESCRIPTION
Moved one sentence around coz it explains what to do after the screenshot appeared, not before.