### PR TITLE
fix(config): update file mode in group shared cache

### DIFF
--- a/content/docs/user-guide/project-structure/configuration.md
+++ b/content/docs/user-guide/project-structure/configuration.md
@@ -201,7 +201,7 @@ section):
 
 - `cache.shared` - permissions for newly created or downloaded cache files and
   directories. The only accepted value right now is `group`, which makes DVC use
-  `664` (rw-rw-r--) for files and `775` (rwxrwxr-x) for directories. This is
+  `444` (r--r--r--) for files and `775` (rwxrwxr-x) for directories. This is
   useful when [sharing a cache] among projects. The default permissions for
   cache files is system dependent. In Linux and macOS for example, they're
   determined using [`os.umask`].


### PR DESCRIPTION
Based on research triggered by the support:

https://discuss.dvc.org/t/unexpected-changed-outs-on-status-and-link-type-reflink-is-not-available-on-pull/1739/3

Seems that we have the default value set to `0o444` for files and `0o2775` for dirs.
