### PR TITLE
Minor fix to remove https://dvc.org from a link to a docs page

### DIFF
--- a/content/docs/studio/user-guide/projects-and-experiments/explore-ml-experiments.md
+++ b/content/docs/studio/user-guide/projects-and-experiments/explore-ml-experiments.md
@@ -30,8 +30,7 @@ located above the project table.
 
 One simple way to briefly describe your experiments is to use meaningful commit
 messages. If you're running experiments with `dvc exp run`, use the
-[`--message` option](https://dvc.org/doc/command-reference/exp/run#-m) to
-provide the message.
+[`--message` option](/doc/command-reference/exp/run#-m) to provide the message.
 
 </admon>
 


### PR DESCRIPTION
I had missed it in [this PR](https://github.com/iterative/dvc.org/pull/4812).