### PR TITLE
start: drop extra eval step

### DIFF
--- a/content/docs/start/data-management/metrics-parameters-plots.md
+++ b/content/docs/start/data-management/metrics-parameters-plots.md
@@ -30,10 +30,6 @@ $ dvc stage add -n evaluate \
   python src/evaluate.py model.pkl data/features
 ```
 
-[`evaluate.py`] uses [DVCLive] to write scalar metrics values (e.g. `AUC`) and
-plots data (e.g. `ROC curve`) to files in the `eval` directory that DVC can
-parse to compare and visualize across iterations.
-
 [earlier pipeline]: /doc/start/data-management/data-pipelines
 
 <details>
@@ -59,15 +55,19 @@ stage outputs the same way outputs were added in previous stages.
 
 </details>
 
+[`evaluate.py`] uses [DVCLive] to write scalar metrics values (e.g. `AUC`) and
+plots data (e.g. `ROC curve`) to files in the `eval` directory that DVC can
+parse to compare and visualize across iterations. DVCLive can configure metrics
+and plots for you if you call `Live.make_dvcyaml()`, or you can customize
+metrics and plots by [configuring them][plots files] in the same `dvc.yaml` file
+where your stage definitions are saved.
+
 <details>
 
 ### 💡 Expand to see how to customize metrics and plots
 
-DVCLive can configure metrics and plots for you if you call
-`Live.make_dvcyaml()`, or you can customize metrics and plots by [configuring
-them][plots files] in the same `dvc.yaml` file where your stage definitions are
-saved. For example, to combine train and test data, and to set other custom
-attributes like titles, we add the following to `dvc.yaml`:
+To combine train and test data, and to set other custom attributes like titles,
+we add the following to `dvc.yaml`:
 
 ```yaml
 metrics:
@@ -106,6 +106,8 @@ $ dvc repro
 $ git add .gitignore dvc.yaml dvc.lock eval
 $ git commit -a -m "Create evaluation stage"
 ```
+
+## Viewing metrics and plots
 
 You can view metrics and plots from the command line, or you can load your
 project in VS Code and use the [DVC Extension] to view metrics, plots, and more.

--- a/content/docs/start/data-management/metrics-parameters-plots.md
+++ b/content/docs/start/data-management/metrics-parameters-plots.md
@@ -21,15 +21,13 @@ iterations of your ML project.
 
 ## Collecting metrics and plots
 
-First, let's see the mechanism to capture values for these ML attributes. Add
-and run a final evaluation stage to our [earlier pipeline]:
+First, let's see the mechanism to capture values for these ML attributes. Add a
+final evaluation stage to our [earlier pipeline]:
 
 ```cli
 $ dvc stage add -n evaluate \
   -d src/evaluate.py -d model.pkl -d data/features \
   python src/evaluate.py model.pkl data/features
-
-$ dvc repro
 ```
 
 [`evaluate.py`] uses [DVCLive] to write scalar metrics values (e.g. `AUC`) and
@@ -59,37 +57,17 @@ dependencies of downstream stages, so we can ignore them from our stage
 definition. If you want to cache your plots with DVC, add `eval/plots` to the
 stage outputs the same way outputs were added in previous stages.
 
-Let's save this iteration so we can compare it later:
-
-```cli
-$ git add .gitignore dvc.yaml dvc.lock eval
-$ git commit -a -m "Create evaluation stage"
-```
-
 </details>
-
-You can view metrics and plots from the command line, or you can load your
-project in VS Code and use the [DVC Extension] to view metrics, plots, and more.
-
-You can view tracked metrics with `dvc metrics show `:
-
-```dvc
-$ dvc metrics show
-Path                    avg_prec.test    avg_prec.train    roc_auc.test    roc_auc.train
-eval/metrics.json  0.94496          0.97723           0.96191         0.98737
-```
-
-You can view plots with `dvc plots show` (shown below), which generates an HTML
-file you can open in a browser.
 
 <details>
 
 ### 💡 Expand to see how to customize metrics and plots
 
-You can customize metrics and plots by [configuring them][plots files] in the
-same `dvc.yaml` file where your stage definitions are saved. For example, to
-combine train and test data, and to set other custom attributes like titles, add
-the following to `dvc.yaml`:
+DVCLive can configure metrics and plots for you if you call
+`Live.make_dvcyaml()`, or you can customize metrics and plots by [configuring
+them][plots files] in the same `dvc.yaml` file where your stage definitions are
+saved. For example, to combine train and test data, and to set other custom
+attributes like titles, we add the following to `dvc.yaml`:
 
 ```yaml
 metrics:
@@ -116,22 +94,32 @@ plots:
   - eval/importance.png
 ```
 
-To avoid duplicating the plots already configured by DVCLive, we set
-`Live(dvcyaml=False)` in [`evaluate.py`], which prevents DVCLive from
-[automatically configuring] them for us (it's also why we also need to add
-`metrics` above since DVCLive will no longer configure these for us either).
 This flexibility to define your own metrics and plots configuration means that
 you can even [generate your own] metrics and plots data without using DVCLive!
 
-Let's run again and save these changes:
+</details>
+
+Let's run and save these changes:
 
 ```cli
 $ dvc repro
 $ git add .gitignore dvc.yaml dvc.lock eval
-$ git commit -a -m "Customize evaluation plots"
+$ git commit -a -m "Create evaluation stage"
 ```
 
-</details>
+You can view metrics and plots from the command line, or you can load your
+project in VS Code and use the [DVC Extension] to view metrics, plots, and more.
+
+You can view tracked metrics with `dvc metrics show `:
+
+```dvc
+$ dvc metrics show
+Path                    avg_prec.test    avg_prec.train    roc_auc.test    roc_auc.train
+eval/metrics.json  0.94496          0.97723           0.96191         0.98737
+```
+
+You can view plots with `dvc plots show` (shown below), which generates an HTML
+file you can open in a browser.
 
 ```cli
 $ dvc plots show
@@ -145,12 +133,6 @@ file:///Users/dvc/example-get-started/dvc_plots/index.html
 
 [`evaluate.py`]:
   https://github.com/iterative/example-get-started/blob/master/src/evaluate.py
-[roc-auc]:
-  https://scikit-learn.org/stable/modules/model_evaluation.html#receiver-operating-characteristic-roc
-[average precision]:
-  https://scikit-learn.org/stable/modules/model_evaluation.html#precision-recall-and-f-measures
-[metrics file]: /doc/command-reference/metrics#supported-file-formats
-[automatically configuring]: /doc/dvclive/live/make_dvcyaml
 [generate your own]: /doc/user-guide/experiment-management/visualizing-plots
 
 Later we will see how to


### PR DESCRIPTION
Updates to https://dvc.org/doc/start/data-management/metrics-parameters-plots to mirror the repo changes in https://github.com/iterative/example-repos-dev/pull/247.