### PR TITLE
Ask to include output of running the dvc command with --verbose flag

### DIFF
--- a/src/components/Support/index.tsx
+++ b/src/components/Support/index.tsx
@@ -108,8 +108,8 @@ const SupportPage: React.FC = () => (
                 support@dvc.org
               </Link>
               . For help with debugging DVC commands, run the commands with the{' '}
-              <span className={styles.accent}>--verbose</span>{' '}
-              flag and include the output if possible.
+              <span className={styles.accent}>--verbose</span> flag and include
+              the output if possible.
             </div>
             <div className={styles.featureFooter}>
               <Link

--- a/src/components/Support/index.tsx
+++ b/src/components/Support/index.tsx
@@ -103,11 +103,13 @@ const SupportPage: React.FC = () => (
               <h3 className={styles.featureName}>Email</h3>
             </div>
             <div className={styles.featureDescription}>
-              Don’t hesitate to shoot us an email at{' '}
+              Email us at{' '}
               <Link className={styles.accent} href="mailto:support@dvc.org">
                 support@dvc.org
-              </Link>{' '}
-              with any questions.
+              </Link>
+              . For help with debugging DVC commands, run the commands with the{' '}
+              <span className={styles.accent}>--verbose</span>{' '}
+              flag and include the output if possible.
             </div>
             <div className={styles.featureFooter}>
               <Link

--- a/src/components/Support/styles.module.css
+++ b/src/components/Support/styles.module.css
@@ -1,6 +1,6 @@
 .supportHero {
-  padding-top: 70px;
-  padding-bottom: 70px;
+  padding-top: 50px;
+  padding-bottom: 50px;
   overflow: hidden;
 }
 


### PR DESCRIPTION
I noticed that for most support emails requesting help to debug DVC commands, our first response is to ask for output of running the commands with the `--verbose` (`-v`) flag. So I think it will be helpful to guide the users to include this output in their email.