### PR TITLE
Fix Run Cache in Pipelines documentation

### DIFF
--- a/content/docs/user-guide/pipelines/run-cache.md
+++ b/content/docs/user-guide/pipelines/run-cache.md
@@ -2,7 +2,7 @@
 
 Every time you run a pipeline with DVC, it logs the unique signature of each
 stage run (in `.dvc/cache/runs`). If it never happened before, its command(s)
-are executed normally. Every subsequent time a <abbr>stage<abbr> runs under the
+are executed normally. Every subsequent time a <abbr>stage</abbr> runs under the
 same conditions, the previous results can be restored instantly -- without
 wasting time or computing resources.
 [More details](/doc/user-guide/project-structure/internal-files#run-cache)


### PR DESCRIPTION
Fixes an `<abbr>` that was not closed, which caused the rest of the paragraph not to appear in the documentation.
