### PR TITLE
Fix a re-direct related to the docs re-org merged earlier today

### DIFF
--- a/redirects-list.json
+++ b/redirects-list.json
@@ -127,8 +127,8 @@
   "^/doc/studio/user-guide/change-team-plan-and-size$                                     /doc/studio/user-guide/team-collaboration/change-team-plan-and-size",
 
   "^/doc/studio/get-started$                                                              /doc/studio/experiments",
-  "^/doc/studio/user-guide/projects-and-experiments(/.*)?$                                /doc/studio/user-guide/experiments$1",
   "^/doc/studio/user-guide/projects-and-experiments/what-is-a-project$                    /doc/studio/user-guide/experiments",
+  "^/doc/studio/user-guide/projects-and-experiments(/.*)?$                                /doc/studio/user-guide/experiments$1",
   "^/doc/studio/user-guide/model-registry/what-is-a-model-registry$                       /doc/studio/user-guide/model-registry",
   "^/doc/studio/user-guide/team-collaboration/teams$                                      /doc/studio/user-guide/team-collaboration",
   "^/doc/studio/user-guide/account-management$                                            /doc/studio/user-guide/account-and-billing",


### PR DESCRIPTION
This is a change I forgot to add to https://github.com/iterative/dvc.org/pull/4852.