### PR TITLE
Write about start date/time setting, and related content adjustment

### DIFF
--- a/content/docs/studio/user-guide/experiments/configure-a-project.md
+++ b/content/docs/studio/user-guide/experiments/configure-a-project.md
@@ -1,88 +1,42 @@
 # Configure a Project
 
-You can configure additional settings for your projects. Some of these settings,
-such as project name, are optional. Some other settings, such as data remotes,
-may be required depending on how your Git repository has been set up.
+You can configure additional settings for your projects, including the project name, directory, etc. Some of these settings are optional while others may be mandatory depending on how your Git repository has been set up.
 
-## Scenarios where project settings are required
-
-If you are connecting to a DVC repo which is at the root of the Git repository
-and does not reference remote/cloud storage, then you can successfully visualize
-it without configuring additional settings. But in the following scenarios, you
-will need to configure project settings:
-
-### Non-DVC repositories
-
-If you are creating a project for a non-DVC repository, you will need to
-[specify the custom files] that contain the metrics and hyperparameters that you
-want to visualize.
-
-[specify the custom files]: #custom-metrics-and-parameters
-
-### Monorepo
-
-If the DVC repo for which you are creating the project is not in the root of
-your Git repo but is in a [sub-directory] of a
-[monorepo](https://en.wikipedia.org/wiki/Monorepo), you will need to specify the
-full path to the sub-directory that contains the data you want to visualize in
-Iterative Studio.
-
-[sub-directory]: /doc/command-reference/init#initializing-dvc-in-subdirectories
-
-### Data remotes (cloud/remote storage)
-
-If you want to include data stored in [data remotes] (cloud storage or another
-location outside the Git repo), you will have to grant Iterative Studio access
-to the data remotes.
-
-[data remotes]: /doc/user-guide/data-management/remote-storage
-
-Additionally, you can also configure project settings to
-[change the name](#project-name) of your project and to
-[select columns](#columns) to import in your project.
-
-## Configuring project settings
-
-You can configure a project's settings at any time after creating the project.
-For this, open the 3-dot menu for the project and click on `Settings`.
+To configure a project's settings , open the 3-dot menu for the project and click on `Settings`.
 
 ![](https://static.iterative.ai/img/studio/project_open_settings.png)
 
-### Project name
+## Project name
 
 To change the project name, enter the new name for your project as shown below.
 
 ![](https://static.iterative.ai/img/studio/project_settings_view_name.png)
 
-### Project directory
+## Project directory
 
-If you have connected to a [monorepo](https://en.wikipedia.org/wiki/Monorepo),
-then specify the full path to the sub-directory that contains the DVC repo to
+If the DVC repo for which you are creating the project is not in the root of your Git repository but is in a [sub-directory] of a [monorepo](https://en.wikipedia.org/wiki/Monorepo), then [specify the full path](/doc/studio/user-guide/experiments/configure-a-project#project-directory) to the sub-directory that contains the DVC repo to
 which you are trying to connect.
 
-   <admon type="note">
+<admon type="note">
 
 Create multiple projects at once by providing up to 10 comma-separated values
 during the initial [create project] flow.
 
-   </admon>
+</admon>
 
 ![](https://static.iterative.ai/img/studio/project_settings_sub_directory.png)
 
 [create project]:
   /doc/studio/user-guide/experiments/create-a-project#create-multiple-projects-from-a-single-git-repository
 
-### Data remotes / cloud storage credentials
+## Data remotes / cloud storage credentials
 
-If you need to provide credentials for [data remotes], you will need to do it
-after your project has been created. First, create your project without
-specifying the data remotes. Then, open project settings and go to the
-`Data remotes / cloud storage credentials` section. The data remotes that are
-used in your DVC repo will be listed.
+Here, the [data remotes](/doc/user-guide/data-management/remote-storage) (cloud storage or another location outside the Git repo) that are used in your DVC repo will be listed. If you want your project to include data stored in these data remotes, you will have to add credentials to grant Iterative Studio access
+to the data remotes. Credentials that you have already added to your account are listed in this section, and you can select them to add them to the project.
 
 ![](https://static.iterative.ai/img/studio/view_settings_credentials.png)
 
-Click on `Add new credentials`. In the form that opens up, select the provider
+To add new credentials, click on `Add new credentials` and select the provider
 (Amazon S3, GCP, etc.). For details on what types of remote storage (protocols)
 are supported, refer to the DVC documentation on [supported storage types].
 
@@ -110,10 +64,22 @@ is not used in your Git repository.
 [dvc remote config parameters]:
   /doc/command-reference/remote/modify#available-parameters-per-storage-type
 
+## Commits and columns
+
+You can specify which Git commits and columns should be imported from your Git repository to
+your project in Iterative Studio, and which ones should be excluded.
+
+### Start date/time
+
+If your Git history has old commits that are not relevant to your project anymore, you can set a cut-off date so that these outdated commits are not imported in your project. Your old commits will remain in your Git repository, but will not over-crowd your projects any more. This will let you focus on recent experiments, metrics and plots.
+
+<!-- TODO: Add the following gif -->
+<!-- ![](https://static.iterative.ai/img/studio/project_settings_start_date_time.gif) -->
+
 ### Columns
 
 You can specify which columns should be imported from your Git repository to
-your project in Iterative Studio. Any unselected column cannot be displayed in
+your project. Any unselected column cannot be displayed in
 your project table.
 
 ![](https://static.iterative.ai/img/studio/project_settings_columns.png)
@@ -138,10 +104,14 @@ are imported.
 [display preferences]:
   /doc/studio/user-guide/experiments/explore-ml-experiments#columns
 
-### Custom metrics and parameters
+## Custom metrics and parameters
 
-If you want to connect custom files, you can add them by clicking the `Add file`
-button. Enter the full file path within your Git repository, and specify whether
+If you are creating a project for a non-DVC repository, you will need to
+specify the custom files that contain the metrics and hyperparameters that you
+want to visualize.
+
+To connect to a custom file, click the `Add file`
+button, enter the full file path within your Git repository, and specify whether
 the file is for `Metrics` or `Parameters`.
 
 ![](https://static.iterative.ai/img/studio/project_settings_custom_files.png)

--- a/content/docs/studio/user-guide/experiments/configure-a-project.md
+++ b/content/docs/studio/user-guide/experiments/configure-a-project.md
@@ -1,8 +1,11 @@
 # Configure a Project
 
-You can configure additional settings for your projects, including the project name, directory, etc. Some of these settings are optional while others may be mandatory depending on how your Git repository has been set up.
+You can configure additional settings for your projects, including the project
+name, directory, etc. Some of these settings are optional while others may be
+mandatory depending on how your Git repository has been set up.
 
-To configure a project's settings , open the 3-dot menu for the project and click on `Settings`.
+To configure a project's settings , open the 3-dot menu for the project and
+click on `Settings`.
 
 ![](https://static.iterative.ai/img/studio/project_open_settings.png)
 
@@ -14,8 +17,12 @@ To change the project name, enter the new name for your project as shown below.
 
 ## Project directory
 
-If the DVC repo for which you are creating the project is not in the root of your Git repository but is in a [sub-directory] of a [monorepo](https://en.wikipedia.org/wiki/Monorepo), then [specify the full path](/doc/studio/user-guide/experiments/configure-a-project#project-directory) to the sub-directory that contains the DVC repo to
-which you are trying to connect.
+If the DVC repo for which you are creating the project is not in the root of
+your Git repository but is in a [sub-directory] of a
+[monorepo](https://en.wikipedia.org/wiki/Monorepo), then
+[specify the full path](/doc/studio/user-guide/experiments/configure-a-project#project-directory)
+to the sub-directory that contains the DVC repo to which you are trying to
+connect.
 
 <admon type="note">
 
@@ -31,8 +38,12 @@ during the initial [create project] flow.
 
 ## Data remotes / cloud storage credentials
 
-Here, the [data remotes](/doc/user-guide/data-management/remote-storage) (cloud storage or another location outside the Git repo) that are used in your DVC repo will be listed. If you want your project to include data stored in these data remotes, you will have to add credentials to grant Iterative Studio access
-to the data remotes. Credentials that you have already added to your account are listed in this section, and you can select them to add them to the project.
+Here, the [data remotes](/doc/user-guide/data-management/remote-storage) (cloud
+storage or another location outside the Git repo) that are used in your DVC repo
+will be listed. If you want your project to include data stored in these data
+remotes, you will have to add credentials to grant Iterative Studio access to
+the data remotes. Credentials that you have already added to your account are
+listed in this section, and you can select them to add them to the project.
 
 ![](https://static.iterative.ai/img/studio/view_settings_credentials.png)
 
@@ -66,12 +77,17 @@ is not used in your Git repository.
 
 ## Commits and columns
 
-You can specify which Git commits and columns should be imported from your Git repository to
-your project in Iterative Studio, and which ones should be excluded.
+You can specify which Git commits and columns should be imported from your Git
+repository to your project in Iterative Studio, and which ones should be
+excluded.
 
 ### Start date/time
 
-If your Git history has old commits that are not relevant to your project anymore, you can set a cut-off date so that these outdated commits are not imported in your project. Your old commits will remain in your Git repository, but will not over-crowd your projects any more. This will let you focus on recent experiments, metrics and plots.
+If your Git history has old commits that are not relevant to your project
+anymore, you can set a cut-off date so that these outdated commits are not
+imported in your project. Your old commits will remain in your Git repository,
+but will not over-crowd your projects any more. This will let you focus on
+recent experiments, metrics and plots.
 
 <!-- TODO: Add the following gif -->
 <!-- ![](https://static.iterative.ai/img/studio/project_settings_start_date_time.gif) -->
@@ -79,8 +95,7 @@ If your Git history has old commits that are not relevant to your project anymor
 ### Columns
 
 You can specify which columns should be imported from your Git repository to
-your project. Any unselected column cannot be displayed in
-your project table.
+your project. Any unselected column cannot be displayed in your project table.
 
 ![](https://static.iterative.ai/img/studio/project_settings_columns.png)
 
@@ -106,12 +121,12 @@ are imported.
 
 ## Custom metrics and parameters
 
-If you are creating a project for a non-DVC repository, you will need to
-specify the custom files that contain the metrics and hyperparameters that you
-want to visualize.
+If you are creating a project for a non-DVC repository, you will need to specify
+the custom files that contain the metrics and hyperparameters that you want to
+visualize.
 
-To connect to a custom file, click the `Add file`
-button, enter the full file path within your Git repository, and specify whether
-the file is for `Metrics` or `Parameters`.
+To connect to a custom file, click the `Add file` button, enter the full file
+path within your Git repository, and specify whether the file is for `Metrics`
+or `Parameters`.
 
 ![](https://static.iterative.ai/img/studio/project_settings_custom_files.png)

--- a/content/docs/studio/user-guide/experiments/configure-a-project.md
+++ b/content/docs/studio/user-guide/experiments/configure-a-project.md
@@ -89,8 +89,7 @@ imported in your project. Your old commits will remain in your Git repository,
 but will not over-crowd your projects any more. This will let you focus on
 recent experiments, metrics and plots.
 
-<!-- TODO: Add the following gif -->
-<!-- ![](https://static.iterative.ai/img/studio/project_settings_start_date_time.gif) -->
+![](https://static.iterative.ai/img/studio/project_settings_start_date_time.gif)
 
 ### Columns
 

--- a/content/docs/studio/user-guide/experiments/create-a-project.md
+++ b/content/docs/studio/user-guide/experiments/create-a-project.md
@@ -17,12 +17,20 @@ To add a new project, follow these steps.
    be listed.
 
    <admon type="info">
- 
-   If you do not see your desired organizations or Git repositories, make sure that [the connection to your Git server has been set up](/doc/studio/user-guide/account-and-billing#git-integrations).
 
-   To connect to your GitHub repositories, you must install the Iterative Studio GitHub app. Refer to the section on [GitHub app installation](/doc/studio/user-guide/git-integrations/github-app) for more details.
+   If you do not see your desired organizations or Git repositories, make sure
+   that
+   [the connection to your Git server has been set up](/doc/studio/user-guide/account-and-billing#git-integrations).
 
-   To connect to repositories on your self-hosted GitLab server, you must first add a connection to this server and create a team. Refer to the section on [self-hosted GitLab server support](/doc/studio/user-guide/git-integrations/custom-gitlab-server) for more details.
+   To connect to your GitHub repositories, you must install the Iterative Studio
+   GitHub app. Refer to the section on
+   [GitHub app installation](/doc/studio/user-guide/git-integrations/github-app)
+   for more details.
+
+   To connect to repositories on your self-hosted GitLab server, you must first
+   add a connection to this server and create a team. Refer to the section on
+   [self-hosted GitLab server support](/doc/studio/user-guide/git-integrations/custom-gitlab-server)
+   for more details.
 
    </admon>
 
@@ -33,20 +41,26 @@ To add a new project, follow these steps.
 
 4. Click on the Git repository that you want to connect to.
 
-5. In the `Project settings` page that opens up, you can edit the project name, directory and visibility (public accessibility). These settings can also be [edited after the project has been created](/doc/studio/user-guide/experiments/configure-a-project).
+5. In the `Project settings` page that opens up, you can edit the project name,
+   directory and visibility (public accessibility). These settings can also be
+   [edited after the project has been created](/doc/studio/user-guide/experiments/configure-a-project).
 
    <admon type = "info">
 
-   If your DVC repo is in a [sub-directory] of a [monorepo](https://en.wikipedia.org/wiki/Monorepo), then you should specify the full path to the sub-directory in the `Project directory` setting.
+   If your DVC repo is in a [sub-directory] of a
+   [monorepo](https://en.wikipedia.org/wiki/Monorepo), then you should specify
+   the full path to the sub-directory in the `Project directory` setting.
 
-   [sub-directory]: /doc/command-reference/init#initializing-dvc-in-subdirectories
+   [sub-directory]:
+     /doc/command-reference/init#initializing-dvc-in-subdirectories
 
    </admon>
 
    <admon type = "tip">
 
-   You can create multiple projects at once by providing up to 10 comma-separated values. Iterative Studio will create one project for each sub-directory in the list.
-
+   You can create multiple projects at once by providing up to 10
+   comma-separated values. Iterative Studio will create one project for each
+   sub-directory in the list.
 
    </admon>
 

--- a/content/docs/studio/user-guide/experiments/create-a-project.md
+++ b/content/docs/studio/user-guide/experiments/create-a-project.md
@@ -16,47 +16,43 @@ To add a new project, follow these steps.
 2. Click on `Add a Project`. All the organizations that you have access to will
    be listed.
 
-<admon type="info">
+   <admon type="info">
+ 
+   If you do not see your desired organizations or Git repositories, make sure that [the connection to your Git server has been set up](/doc/studio/user-guide/account-and-billing#git-integrations).
 
-If you do not see your desired organizations or Git repositories, make sure that
-[the connection to your Git server has been set up](/doc/studio/user-guide/account-and-billing#git-integrations).
+   To connect to your GitHub repositories, you must install the Iterative Studio GitHub app. Refer to the section on [GitHub app installation](/doc/studio/user-guide/git-integrations/github-app) for more details.
 
-To connect to your GitHub repositories, you must install the Iterative Studio
-GitHub app. Refer to the section on
-[GitHub app installation](/doc/studio/user-guide/git-integrations/github-app)
-for more details.
+   To connect to repositories on your self-hosted GitLab server, you must first add a connection to this server and create a team. Refer to the section on [self-hosted GitLab server support](/doc/studio/user-guide/git-integrations/custom-gitlab-server) for more details.
 
-To connect to repositories on your self-hosted GitLab server, you must first add
-a connection to this server and create a team. Refer to the section on
-[self-hosted GitLab server support](/doc/studio/user-guide/git-integrations/custom-gitlab-server)
-for more details.
-
-</admon>
+   </admon>
 
 3. Open the organization whose repository you want to connect to. You can also
    use the search bar to directly look for a repository.
 
    ![](https://static.iterative.ai/img/studio/select_repo_v3.png)
 
-4. Specify additional settings if required.
+4. Click on the Git repository that you want to connect to.
 
-   ![](https://static.iterative.ai/img/studio/project_settings.png)
+5. In the `Project settings` page that opens up, you can edit the project name, directory and visibility (public accessibility). These settings can also be [edited after the project has been created](/doc/studio/user-guide/experiments/configure-a-project).
 
-> Project settings must be configured if you are connecting to a non-DVC
-> repository, if you are connecting to a monorepo, or if your metrics are in
-> cloud or other remote storage. You can configure the [Project Settings] after
-> the project has been created.
+   <admon type = "info">
 
-You should now see that a project has been added in your dashboard.
+   If your DVC repo is in a [sub-directory] of a [monorepo](https://en.wikipedia.org/wiki/Monorepo), then you should specify the full path to the sub-directory in the `Project directory` setting.
 
-5. If your project requires any of the additional settings, then remember to
-   configure them by opening the [project settings]. Otherwise, your project may
-   not work as expected. To go to project settings, open the 3-dot menu for the
-   project and click on `Settings`.
+   [sub-directory]: /doc/command-reference/init#initializing-dvc-in-subdirectories
 
-![](https://static.iterative.ai/img/studio/project_open_settings.png)
+   </admon>
 
-[project settings]: /doc/studio/user-guide/experiments/configure-a-project
+   <admon type = "tip">
+
+   You can create multiple projects at once by providing up to 10 comma-separated values. Iterative Studio will create one project for each sub-directory in the list.
+
+
+   </admon>
+
+6. Click on `Create Project`.
+
+You should now see that the project has been added in your dashboard.
 
 ## Create multiple projects from a single Git repository
 


### PR DESCRIPTION
Earlier, we had a separate section called `Scenarios where project settings are required`. This more-or-less duplicated what was already presented in the following section: `Configuring project settings`. Now, I've merged these into one. They don't need a separate section heading now, because of which the individual settings are at header level 2 (not 3). This has allowed me to create a `Commits and columns` header and include `Start date/time` and `Columns` within it - similar to how it is in Studio.

I also made some small changes to the create-a-project doc, coz it was based on an earlier version of the create project flow, where settings like data remotes were presented during the create project flow.



