### PR TITLE
fix(gto): update push option descriptions

### DIFF
--- a/content/docs/gto/command-reference/assign.md
+++ b/content/docs/gto/command-reference/assign.md
@@ -40,7 +40,9 @@ GTO creates a special Git tag in
 - `--simple <text>` - Use simple notation, e.g. `rf#prod` instead of `rf#prod-5`
   [supported values: auto, true, false] [default: auto]
 - `--force` - Create the Git tag even if it already exists and is in effect
-- `--push` - Push created tag automatically (experimental)
+- `--push` - Push created git tag to `origin`. The value is ignored if the
+  `repo` option is set to a remote URL. In that case tags are pushed to or
+  created on the remote repo automatically.
 - `--sr`, `--skip-registration` - Don't register a version at specified commit
 - `-h`, `--help` - Show this message and exit.
 

--- a/content/docs/gto/command-reference/deprecate.md
+++ b/content/docs/gto/command-reference/deprecate.md
@@ -137,5 +137,7 @@ git push origin awesome-model@v0.0.1 awesome-model#prod#1 awesome-model#prod!#2 
   [supported values: auto, true, false] [default: auto]
 - `--force` - Create the Git tag even if it already exists and is in effect
 - `-d`, `--delete` - Delete the git tag(s) instead of creating the new one
-- `--push` - Push created tag automatically (experimental)
+- `--push` - Push created git tag to `origin`. The value is ignored if the
+  `repo` option is set to a remote URL. In that case tags are pushed to or
+  created on the remote repo automatically.
 - `-h`, `--help` - Show this message and exit.

--- a/content/docs/gto/command-reference/register.md
+++ b/content/docs/gto/command-reference/register.md
@@ -45,7 +45,9 @@ another Git commit if you provide it's hexsha as an additional argument, like
 - `--bump-major` - Bump major version
 - `--bump-minor` - Bump minor version
 - `--bump-patch` - Bump patch version
-- `--push` - Push created tag automatically (experimental)
+- `--push` - Push created git tag to `origin`. The value is ignored if the
+  `repo` option is set to a remote URL. In that case tags are pushed to or
+  created on the remote repo automatically.
 - `-h`, `--help` - Show this message and exit.
 
 ## Examples


### PR DESCRIPTION
Per https://github.com/iterative/gto/pull/417

Updates the `--push` CLI option in `gto register` and similar commands to reflect the current state of the commands.
