### PR TITLE
Studio: drop support for custom metrics/params files

### DIFF
--- a/content/docs/studio/user-guide/experiments/configure-a-project.md
+++ b/content/docs/studio/user-guide/experiments/configure-a-project.md
@@ -117,15 +117,3 @@ are imported.
 
 [display preferences]:
   /doc/studio/user-guide/experiments/explore-ml-experiments#columns
-
-## Custom metrics and parameters
-
-If you are creating a project for a non-DVC repository, you will need to specify
-the custom files that contain the metrics and hyperparameters that you want to
-visualize.
-
-To connect to a custom file, click the `Add file` button, enter the full file
-path within your Git repository, and specify whether the file is for `Metrics`
-or `Parameters`.
-
-![](https://static.iterative.ai/img/studio/project_settings_custom_files.png)

--- a/content/docs/studio/user-guide/experiments/index.md
+++ b/content/docs/studio/user-guide/experiments/index.md
@@ -113,15 +113,6 @@ To set up, run and track
   as Git commits and PRs as well as
   [remove unnecessary experiments](/doc/start/experiments/experiment-collaboration#removing).
 
-<admon type="tip">
-
-If you are working with a **non-DVC repository**, you can
-[indicate which files contain metrics and hyperparameters](/doc/studio/user-guide/experiments/configure-a-project#custom-metrics-and-parameters)
-that Iterative Studio should display in the project. However, we strongly
-recommend using DVC to avail of all the features of Iterative Studio.
-
-</admon>
-
 ## Visualize, compare and run experiments
 
 Within a project, you can:

--- a/content/docs/studio/user-guide/team-collaboration/index.md
+++ b/content/docs/studio/user-guide/team-collaboration/index.md
@@ -91,7 +91,6 @@ even if the project belongs to a team where you are an `Editor` or `Admin`.
 | Use existing cloud / data remote credentials | No      | No     | Yes    | Yes   |
 | Configure cloud / data remote credentials    | No      | No     | No     | Yes   |
 | Manage columns                               | No      | No     | Yes    | Yes   |
-| Manage custom files                          | No      | No     | Yes    | Yes   |
 
 ### Privileges in the team's model registry
 

--- a/content/docs/studio/user-guide/troubleshooting.md
+++ b/content/docs/studio/user-guide/troubleshooting.md
@@ -127,14 +127,7 @@ the root.
 This could be a typical situation when your DVC repository is part of a
 [monorepo](https://en.wikipedia.org/wiki/Monorepo).
 
-To solve this, you can either:
-
-- specify the full path to the sub-directory that contains the DVC repo, or
-- specify custom files that contain the metrics and hyperparameters that you
-  want to visualize.
-
-Instructions on how to specify the sub-directory or custom files can be found
-[here][project-settings].
+To solve this, you should [specify the full path to the sub-directory][project-settings] that contains the DVC repo.
 
 Note that if you're connecting to a repository just to fetch models for the
 model registry, and you are not working with DVC repositories, you can ignore
@@ -153,41 +146,24 @@ contains sub-directories A and B. If A contains the DVC repository which you
 want to connect from Iterative Studio, but you specify B when creating the
 project, then you will get the above error.
 
-To solve this, you can either:
-
-- specify the full path to the correct sub-directory that contains the DVC repo,
-  or
-- specify custom files that contain the metrics and hyperparameters that you
-  want to visualize.
-
-Instructions on how to specify the sub-directory or custom files can be found
-[here][project-settings].
+To solve this, you should [specify the full path to the correct sub-directory][project-settings] that contains the DVC repo.
 
 ## Error: No commits were found for the sub-directory
 
 If you get this message when you try to add a project, then it means that you
 have specified an empty or non-existent sub-directory.
 
-To solve this, you need to change the sub-directory and specify the full path to
-the correct sub-directory that contains the DVC repo.
-
-If you did not intend to work with a DVC repo, you can also specify custom files
-that contain the metrics and hyperparameters that you want to visualize.
-
-Instructions on how to specify the sub-directory or custom files can be found
-[here][project-settings].
+To solve this, you need to change the sub-directory and [specify the full path to
+the correct sub-directory][project-settings] that contains the DVC repo.
 
 ## Project got created, but does not contain any data
 
 If you initialized a DVC repository, but did not push any commit with data,
 metrics or hyperparameters, then even though you will be able to connect to this
-repository, the project will appear empty in Iterative Studio. To solve this,
-either make relevant commits to your DVC repository, or specify custom files
-with the metrics or hyperparameters that you want to visualize.
+repository, the project will appear empty in Iterative Studio. To solve this, make relevant commits to your DVC repository.
 
 Refer to the [DVC documentation](https://dvc.org/doc) for help on making commits
-to a DVC repository. Instructions on how to specify custom files can be found
-[here][project-settings].
+to a DVC repository.
 
 Note that if you're connecting to a repository just to fetch models for the
 model registry, and your repository is not expected to contain experiment data,


### PR DESCRIPTION
Drop support for custom files as suggested in https://github.com/iterative/studio/issues/5957.