### PR TITLE
Add Plot Wizard inside "Visualizing Plots" User Guide

### DIFF
--- a/content/docs/user-guide/experiment-management/visualizing-plots.md
+++ b/content/docs/user-guide/experiment-management/visualizing-plots.md
@@ -172,6 +172,14 @@ file:///Users/usr/src/dvc_plots/index.html
 
 [template]: #plot-templates-data-series-only
 
+### VSCode Extension Plots Wizard
+
+Use the
+[DVC Extension for VS Code](https://marketplace.visualstudio.com/items?itemName=Iterative.dvc)
+to define plots inside your `dvc.yaml`.
+
+https://youtu.be/qG2gfTuQWtk?si=ffpkBLX-odowXK-G
+
 <admon icon="book">
 
 Refer to the [full format specification] and `dvc plots show` for more details.

--- a/content/docs/user-guide/experiment-management/visualizing-plots.md
+++ b/content/docs/user-guide/experiment-management/visualizing-plots.md
@@ -1,5 +1,11 @@
 # Visualizing Plots
 
+Use the
+[DVC Extension for VS Code](https://marketplace.visualstudio.com/items?itemName=Iterative.dvc)
+to define plots inside your `dvc.yaml`.
+
+https://youtu.be/qG2gfTuQWtk?si=ffpkBLX-odowXK-G
+
 DVC can generate and render plots based on your project's data. A typical
 workflow is:
 
@@ -171,14 +177,6 @@ file:///Users/usr/src/dvc_plots/index.html
 ![](/img/plots_show_spec_roc_train_test.svg)
 
 [template]: #plot-templates-data-series-only
-
-### VSCode Extension Plots Wizard
-
-Use the
-[DVC Extension for VS Code](https://marketplace.visualstudio.com/items?itemName=Iterative.dvc)
-to define plots inside your `dvc.yaml`.
-
-https://youtu.be/qG2gfTuQWtk?si=ffpkBLX-odowXK-G
 
 <admon icon="book">
 

--- a/content/docs/user-guide/experiment-management/visualizing-plots.md
+++ b/content/docs/user-guide/experiment-management/visualizing-plots.md
@@ -1,11 +1,5 @@
 # Visualizing Plots
 
-Use the
-[DVC Extension for VS Code](https://marketplace.visualstudio.com/items?itemName=Iterative.dvc)
-to define plots inside your `dvc.yaml`.
-
-https://youtu.be/qG2gfTuQWtk?si=ffpkBLX-odowXK-G
-
 DVC can generate and render plots based on your project's data. A typical
 workflow is:
 
@@ -104,6 +98,12 @@ file:///Users/usr/src/dvc_plots/index.html
 [dvc template anchors]: /doc/command-reference/plots/templates#custom-templates
 
 ## Defining plots
+
+Use the
+[DVC Extension for VS Code](https://marketplace.visualstudio.com/items?itemName=Iterative.dvc)
+to define plots inside your `dvc.yaml`.
+
+https://youtu.be/qG2gfTuQWtk?si=ffpkBLX-odowXK-G
 
 In order to create visualizations, users need to provide the data and
 (optionally) configuration that will help customize the plot in a `dvc.yaml`

--- a/content/docs/user-guide/experiment-management/visualizing-plots.md
+++ b/content/docs/user-guide/experiment-management/visualizing-plots.md
@@ -99,16 +99,16 @@ file:///Users/usr/src/dvc_plots/index.html
 
 ## Defining plots
 
-Use the
+In order to create visualizations, users need to provide the data and
+(optionally) configuration that will help customize the plot in a `dvc.yaml`
+file. If you are using [DVCLive](/doc/dvclive/), it will configure plots, but
+you can also add your own custom plots. The easiest way is to use the
 [DVC Extension for VS Code](https://marketplace.visualstudio.com/items?itemName=Iterative.dvc)
 to define plots inside your `dvc.yaml`.
 
 https://youtu.be/qG2gfTuQWtk?si=ffpkBLX-odowXK-G
 
-In order to create visualizations, users need to provide the data and
-(optionally) configuration that will help customize the plot in a `dvc.yaml`
-file. If you are using [DVCLive](/doc/dvclive/), it will configure plots, but
-you can also add your own custom plots like this example:
+You can also manually edit `dvc.yaml` to configure plots like this:
 
 ```yaml
 plots:


### PR DESCRIPTION
* updates `/doc/user-guide/experiment-management/visualizing-plots#defining-plots` with a section for the VSCode Extension's Plot Wizard

## Demo

<img width="1282" alt="image" src="https://github.com/iterative/dvc.org/assets/43496356/3271a232-15d6-47a1-9d3f-231121c6607b">

Fixes #4885