### PR TITLE
Upgrade guide edits

### DIFF
--- a/content/docs/user-guide/upgrade.md
+++ b/content/docs/user-guide/upgrade.md
@@ -83,3 +83,9 @@ Note that when using `--dvc-files` option, DVC will only migrate DVC files in
 <abbr>workspace</abbr> (and Git history will not be re-written).
 
 </admon>
+
+For [DVC remotes](/doc/user-guide/data-magement/remote-storage), there is no
+equivalent migration command since it is not possible to link between old and
+new locations on many remote filesystems. Instead, once you have migrated data
+locally and pushed to the remote, you may use `dvc gc -c` commands to remove
+outdated data from the remote.

--- a/content/docs/user-guide/upgrade.md
+++ b/content/docs/user-guide/upgrade.md
@@ -2,8 +2,8 @@
 
 DVC 3.0 introduced changes to how DVC hashes files and to where DVC-tracked data
 is stored in the <abbr>cache</abbr>. DVC 3.0 remains compatible with
-pre-existing data tracked by older DVC releases, but there are a few important
-points that users should note when upgrading to DVC 3.0.
+pre-existing data tracked by DVC 2.0, but there are a few important points that
+users should note when upgrading to DVC 3.0.
 
 <admon type="info">
 
@@ -52,8 +52,8 @@ In order to avoid hash collisions between files tracked in DVC 3.0 and older
 releases, files tracked in DVC 3.0 are stored separately from files tracked in
 older releases. By default, DVC does not automatically de-duplicate any data
 between files tracked in DVC 3.0 and files tracked in older releases. DVC will
-still read cached files from older releases and will only duplicate for new or
-modified data.
+still read cached files from DVC 2.0 and will only duplicate for new or modified
+data.
 
 Users can manually migrate existing local DVC cache data to the DVC 3.0 location
 by running the `dvc cache migrate` command. On most local filesystems,


### PR DESCRIPTION
Adds a couple changes to the upgrade guide:
1. Mentions backwards compatibility only extends back to 2.0 (see https://github.com/iterative/dvc/issues/9878).
2. Mentions how to handle dvc remote migration (see https://github.com/iterative/dvc/issues/9924).