### PR TITLE
Add DVC for VS Code Extension sorting demo 

### DIFF
--- a/content/docs/command-reference/exp/show.md
+++ b/content/docs/command-reference/exp/show.md
@@ -53,19 +53,11 @@ should be displayed.
 Experiments in the table are first grouped (by parent commit). They are then
 sorted inside each group, chronologically by default. The `--sort-by` and
 `--sort-order` options can change this ordering, based on any single, visible
-metric or param.
-
-<details>
-
-### Sort Commits And Experiments With the DVC Extension for VS Code
-
-While `--sort-by` sorts experiments only, you can sort both experiment and
-commit rows with the
+metric or param. While these options sort experiments only, you can sort both
+experiment and commit rows with the
 [DVC Extension for VS Code](https://marketplace.visualstudio.com/items?itemName=Iterative.dvc).
 
 https://youtu.be/Flpu_-D_zDI?si=8G1NgC4n1RqfrIXg
-
-</details>
 
 ### Paginating the output
 

--- a/content/docs/command-reference/exp/show.md
+++ b/content/docs/command-reference/exp/show.md
@@ -55,6 +55,18 @@ sorted inside each group, chronologically by default. The `--sort-by` and
 `--sort-order` options can change this ordering, based on any single, visible
 metric or param.
 
+<details>
+
+### Sort Commits And Experiments With the DVC Extension for VS Code
+
+While `--sort-by` sorts experiments only, you can sort both experiment and
+commit rows with the
+[DVC Extension for VS Code](https://marketplace.visualstudio.com/items?itemName=Iterative.dvc).
+
+https://youtu.be/Flpu_-D_zDI?si=8G1NgC4n1RqfrIXg
+
+</details>
+
 ### Paginating the output
 
 This command's output is automatically piped to
@@ -280,18 +292,6 @@ $ dvc exp show --only-changed --sort-by=roc_auc --sort-order desc
   └── 56f3be3 [freed-roam]        10:21 PM        0.51799   0.92333   500                      cfbfed4     64ed644
  ───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
 ```
-
-<details>
-
-### Sort Commits And Experiments With the DVC Extension for VS Code
-
-While `--sort-by` sorts experiments only, you can sort both experiment and
-commit rows with the
-[DVC Extension for VS Code](https://marketplace.visualstudio.com/items?itemName=Iterative.dvc).
-
-https://youtu.be/Flpu_-D_zDI?si=8G1NgC4n1RqfrIXg
-
-</details>
 
 To see all experiments throughout the Git history:
 

--- a/content/docs/command-reference/exp/show.md
+++ b/content/docs/command-reference/exp/show.md
@@ -281,6 +281,18 @@ $ dvc exp show --only-changed --sort-by=roc_auc --sort-order desc
  ───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
 ```
 
+<details>
+
+### Sort Commits And Experiments With the DVC Extension for VS Code
+
+While `--sort-by` sorts experiments only, you can sort both experiment and
+commit rows with the
+[DVC Extension for VS Code](https://marketplace.visualstudio.com/items?itemName=Iterative.dvc).
+
+https://youtu.be/Flpu_-D_zDI?si=8G1NgC4n1RqfrIXg
+
+</details>
+
 To see all experiments throughout the Git history:
 
 ```cli

--- a/content/docs/user-guide/experiment-management/comparing-experiments.md
+++ b/content/docs/user-guide/experiment-management/comparing-experiments.md
@@ -84,10 +84,14 @@ filter columns, sort rows, and otherwise customize the table.
 
 <tab title="VSCode Extension">
 
-You can hide and move columns and sort and filter rows in the `Show Experiments`
-action in the [DVC extension for VS Code].
+You can hide and move columns and filter rows in the `Show Experiments` action
+in the [DVC extension for VS Code].
 
 ![VS Code Customize Table](/img/vscode-customize-table.gif)
+
+You can also sort both experiment and commit rows in the extension.
+
+https://youtu.be/Flpu_-D_zDI?si=8G1NgC4n1RqfrIXg
 
 </tab>
 


### PR DESCRIPTION
* As discussed in planning, adds a mention of sorting in the vscode extension to the docs

## Demo

In `/doc/command-reference/exp/show`

~https://github.com/iterative/dvc.org/assets/43496356/94663389-820d-485e-9982-c07ed3c6f7f8~

<img width="1265" alt="image" src="https://github.com/iterative/dvc.org/assets/43496356/c753979a-2c52-433f-a94d-b13ed5b98afb">

In `/doc/user-guide/experiment-management`:

<img width="1312" alt="image" src="https://github.com/iterative/dvc.org/assets/43496356/03b2a13c-5193-461c-b2b7-68a5d9f5fee8">
