### PR TITLE
doc: install: remove github releases mention

### DIFF
--- a/content/docs/install/linux.md
+++ b/content/docs/install/linux.md
@@ -134,8 +134,7 @@ $ sudo yum install dvc
 
 ## Install from package
 
-Get the binary package from the big "Download" button on the [home page](/), or
-from the [release page](https://github.com/iterative/dvc/releases/) on GitHub.
+Get the binary package from the big "Download" button on the [home page](/).
 Then install it with the following command.
 
 <details id="from-pkg-on-debian-ubuntu">

--- a/content/docs/install/macos.md
+++ b/content/docs/install/macos.md
@@ -26,8 +26,7 @@ $ brew install dvc
 
 ## Install from package
 
-Get the PKG (binary) from the big "Download" button on the [home page](/), or
-from the [release page](https://github.com/iterative/dvc/releases/) on GitHub.
+Get the PKG (binary) from the big "Download" button on the [home page](/).
 
 > Note that currently, in order to open the PKG file, you must go to the
 > **Downloads** directory in Finder and do a

--- a/content/docs/install/windows.md
+++ b/content/docs/install/windows.md
@@ -102,9 +102,7 @@ In this case it installs the `boto3` library along with DVC.
 ## Windows installer
 
 A quick way is to use the self-contained, executable installer (binary), which
-is available from the big "Download" button on the [home page](/). You can also
-get it from the [release page](https://github.com/iterative/dvc/releases/) on
-GitHub.
+is available from the big "Download" button on the [home page](/).
 
 You'll need to download and run the installer again each time you want to update
 DVC. You may use Windows Uninstaller to


### PR DESCRIPTION
https://github.com/iterative/dvc/releases does not have any packages now.