### PR TITLE
start: address external data

### DIFF
--- a/content/docs/start/data-management/data-pipelines.md
+++ b/content/docs/start/data-management/data-pipelines.md
@@ -190,6 +190,38 @@ stages:
 
 </details>
 
+<details id="external-data-pipelines">
+
+### 💡 What if my dependencies and outputs aren't inside my project?
+
+DVC can help simplify your workflow by keeping all your data inside your
+project, but this isn't always practical if you already have a large dataset
+stored elsewhere that you don't want to copy, or your stage writes data directly
+to cloud storage. DVC can still detect when these external datasets change. Your
+pipeline dependencies can point anywhere, not only local paths inside your
+project. Same with outputs, except that you need to set `cache: false` to tell
+DVC not to make a local copy of these external outputs. See the example below or
+read more in
+[External Dependencies and Outputs](/doc/user-guide/pipelines/external-dependencies-and-outputs).
+
+```yaml
+stages:
+  prepare:
+    cmd:
+      - wget
+        https://sagemaker-sample-data-us-west-2.s3-us-west-2.amazonaws.com/autopilot/direct_marketing/bank-additional.zip
+        -O bank-additional.zip
+      - python sm_prepare.py --bucket mybucket --prefix project-data
+    deps:
+      - sm_prepare.py
+      - https://sagemaker-sample-data-us-west-2.s3-us-west-2.amazonaws.com/autopilot/direct_marketing/bank-additional.zip
+    outs:
+      - s3://mybucket/project-data/input_data:
+          cache: false
+```
+
+</details>
+
 Once you've added a stage, you can run the pipeline with `dvc repro`.
 
 ## Dependency graphs

--- a/content/docs/start/data-management/data-versioning.md
+++ b/content/docs/start/data-management/data-versioning.md
@@ -91,6 +91,21 @@ outs:
 
 </details>
 
+<admon type="info">
+
+### Do I have to download my data?
+
+`dvc add` enables you to track and manage files and directories that would be
+unmanageable in pure Git, but in some cases even tracking with DVC may be
+impractical. For example, if you run Spark-based workflows directly on massive
+amounts of data stored in the cloud, you may not want to download and save a
+copy of each version. On the next page, you will see tips for how you can still
+use DVC's pipelines to
+[detect changes to external data](/doc/start/data-management/data-pipelines#external-data-pipelines)
+not managed by DVC.
+
+</admon>
+
 ## Storing and sharing
 
 You can upload DVC-tracked data to a variety of storage systems (remote or


### PR DESCRIPTION
Adds some info about how to manage external data in the get started guide so that we address use cases where `dvc add` doesn't make sense.