### PR TITLE
fix(dvclive): add timestamp param to log metrics

### DIFF
--- a/content/docs/dvclive/how-it-works.md
+++ b/content/docs/dvclive/how-it-works.md
@@ -100,8 +100,8 @@ make Git ignore it. It will generate a `model.pt.dvc` metadata file, which can
 be tracked in Git and becomes part of the experiment. With this metadata file,
 you can [retrieve](/doc/start/data-management/data-versioning#retrieving) the
 versioned artifact from the Git commit. You can also use
-`Live.log_artifact("model.pt", type="model")` to add it to the [DVC Studio Model
-Registry](/doc/studio/model-registry).
+`Live.log_artifact("model.pt", type="model")` to add it to the
+[DVC Studio Model Registry](/doc/studio/model-registry).
 
 Using `Live.log_image()` to log multiple images may also grow too large to track
 with Git, in which case you can use

--- a/content/docs/dvclive/live/log_metric.md
+++ b/content/docs/dvclive/live/log_metric.md
@@ -1,7 +1,12 @@
 # Live.log_metric()
 
 ```py
- def log_metric(name: str, val: Union[int, float, str], plot: Optional[bool] = True):
+def log_metric(
+    name: str,
+    val: Union[int, float, str],
+    timestamp: bool = False,
+    plot: Optional[bool] = True
+):
 ```
 
 ## Usage
@@ -41,7 +46,7 @@ timestamp      step  loss
 The metrics history can be visualized with `dvc plots`:
 
 ```
-dvc plots diff dvclive/plots
+$ dvc plots diff dvclive/plots
 ```
 
 </admon>
@@ -51,8 +56,8 @@ Each subsequent call to `live.log_metric(name, val)` will add a new row to
 
 ```python
 live.next_step()
-live.log_metric("train/loss", 0.2)
-live.log_metric("val/loss", 0.4)
+live.log_metric("train/loss", 0.2, timestamp=True)
+live.log_metric("val/loss", 0.4, timestamp=True)
 ```
 
 ```ts
@@ -81,19 +86,22 @@ when exiting the `with` block:
 
 The metrics summary can be visualized with `dvc metrics`:
 
-```
-dvc metrics diff dvclive/metrics.json
+```cli
+$ dvc metrics diff dvclive/metrics.json
 ```
 
 </admon>
 
 ## Parameters
 
-- `name` - Name of the metric being logged.
+- `name` - name of the metric being logged.
 
-- `val` - The value to be logged.
+- `val` - the value to be logged.
 
-- `plot` - Whether to add the metric value to the _metrics history_ file for
+- `timestamp` - whether to automatically log timestamp in the _metrics history_
+  file.
+
+- `plot` - whether to add the metric value to the _metrics history_ file for
   plotting. If `false`, the metric will only be saved to the metrics summary.
 
 ## Exceptions

--- a/content/docs/dvclive/live/log_param.md
+++ b/content/docs/dvclive/live/log_param.md
@@ -1,7 +1,7 @@
 # Live.log_param()
 
 ```py
- def log_param(name: str, val: ParamLike):
+def log_param(name: str, val: ParamLike):
 ```
 
 Also see `Live.log_params()`.
@@ -41,9 +41,9 @@ automatically, and you can skip logging them with DVCLive.
 
 ## Parameters
 
-- `name` - Name of the parameter being logged.
+- `name` - name of the parameter being logged.
 
-- `val` - The value to be logged.
+- `val` - the value to be logged.
 
 ## Exceptions
 

--- a/content/docs/dvclive/live/log_params.md
+++ b/content/docs/dvclive/live/log_params.md
@@ -1,7 +1,7 @@
 # Live.log_params()
 
 ```py
- def log_params(params: Dict[ParamLike]):
+def log_params(params: Dict[ParamLike]):
 ```
 
 Also see `Live.log_param()`.


### PR DESCRIPTION
Adds `timestamp` param description to the `dvclive.log_metric` call. Plus a bit of cleanup around.

------------

> You may disregard these recommendations if you used the **Edit on GitHub** button from dvc.org to improve a doc in place.

❗ Please read the guidelines in the [Contributing to the Documentation](https://dvc.org/doc/user-guide/contributing/docs) list if you make any substantial changes to the documentation or JS engine.

🐛 Please make sure to mention `Fix #issue` (if applicable) in the description of the PR. This causes GitHub to close it automatically when the PR is merged.

Please choose to [allow us](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to edit your branch when creating the PR.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
