### PR TITLE
fix(dvclive): Add a note on installing pillow for log_image

### DIFF
--- a/content/docs/dvclive/live/log_image.md
+++ b/content/docs/dvclive/live/log_image.md
@@ -43,7 +43,10 @@ Supported values for `val` are:
 - A path to an image file (`str` or
   [`Path`](https://docs.python.org/3/library/pathlib.html#pathlib.Path)). It
   should be in a format that is readable by
-  [`PIL.Image.open()`](https://pillow.readthedocs.io/en/stable/reference/Image.html#PIL.Image.open)
+  [`PIL.Image.open()`](https://pillow.readthedocs.io/en/stable/reference/Image.html#PIL.Image.open).
+  `dvclive` does not install `Pillow` automatically, so you will need to make
+  sure `PIL` is available to import yourself. You can install it with
+  `pip install pillow`.
 
 The images will be saved in `{Live.plots_dir}/images/{name}`. When using
 [`Live(cache_images=True)`](/doc/dvclive/live#parameters), the images directory


### PR DESCRIPTION
This PR adds a note that the user is responsible for having `Pillow` available, so `import PIL` will not error out if the `live.log_image("name", "path/to/image") receives a path instead of an image object.

> You may disregard these recommendations if you used the **Edit on GitHub** button from dvc.org to improve a doc in place.

❗ Please read the guidelines in the [Contributing to the Documentation](https://dvc.org/doc/user-guide/contributing/docs) list if you make any substantial changes to the documentation or JS engine.

🐛 Please make sure to mention `Fix #issue` (if applicable) in the description of the PR. This causes GitHub to close it automatically when the PR is merged.

Please choose to [allow us](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to edit your branch when creating the PR.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
