### PR TITLE
Change 'dvc get' to 'artifacts get'

### DIFF
--- a/content/docs/studio/user-guide/model-registry/use-models.md
+++ b/content/docs/studio/user-guide/model-registry/use-models.md
@@ -28,6 +28,8 @@ Git repository, and you do not need to install DVC.
 [DVC Studio Access token]:
   /doc/studio/user-guide/account-management#studio-access-token
 [download a model artifact with DVC]: /doc/command-reference/artifacts/get
+[REST API]: /doc/studio/rest-api
+[Python API]: /doc/api-reference
 
 You can download the files that make up your model directly from DVC Studio.
 Head to the model details page of the model you would like to download and click

--- a/content/docs/studio/user-guide/model-registry/use-models.md
+++ b/content/docs/studio/user-guide/model-registry/use-models.md
@@ -7,7 +7,8 @@ capabilities.
 ## Download models
 
 If your model file is DVC-tracked, you can download any of its registered
-versions using the DVC Studio [REST API], `dvc get`, or DVC [Python API].
+versions using the DVC Studio [REST API], `dvc artifacts get`, or DVC [Python
+API].
 
 Prerequisites:
 


### PR DESCRIPTION
This edits the `Use models` page (https://dvc.org/doc/studio/user-guide/model-registry/use-models) to link to `dvc artifacts get`'s command documentation page, rather than the `dvc get` one. Further down the doc we do still refer to `dvc get`, but as an alternative if you don't have access to Studio:

> ... Without these prerequisites, you can still [download a model artifact with DVC](http://localhost:8000/doc/command-reference/artifacts/get). ...

☝️ which does correctly link to the `dvc get` command doc page.