### PR TITLE
Address feedback

### DIFF
--- a/content/data/dvcx.yml
+++ b/content/data/dvcx.yml
@@ -3,9 +3,9 @@
     Datasets are getting larger, but the ability to iterate rapidly and
     efficiently is as important as ever.
   terminal: |
-    from dql.query import C, DatasetQuery
-    from dql.lib.webdataset import WebDataset
-    from dql.lib.gpt4_vision import DescribeImage
+    from dvcx.query import C, DatasetQuery
+    from dvcx.lib.webdataset import WebDataset
+    from dvcx.lib.gpt4_vision import DescribeImage
 
     prompt = "How many people in the image?"
 

--- a/src/@dvcorg/gatsby-theme-iterative/components/LayoutFooter/index.tsx
+++ b/src/@dvcorg/gatsby-theme-iterative/components/LayoutFooter/index.tsx
@@ -109,7 +109,7 @@ const footerListsData: Array<IFooterListData> = [
       },
       {
         href: 'https://studio.iterative.ai/',
-        text: 'Studio',
+        text: 'DVC Studio',
         icon: <StudioSVG className={styles.productIcon} />,
         target: '_blank'
       },

--- a/src/@dvcorg/gatsby-theme-iterative/components/LayoutFooter/index.tsx
+++ b/src/@dvcorg/gatsby-theme-iterative/components/LayoutFooter/index.tsx
@@ -13,7 +13,6 @@ import { ReactComponent as LogoSVG } from '../../../../../static/img/dvc_icon-co
 import { ReactComponent as GithubSVG } from '@dvcorg/gatsby-theme-iterative/src/components/SocialIcon/github.svg'
 import { ReactComponent as TwitterSVG } from '@dvcorg/gatsby-theme-iterative/src/components/SocialIcon/twitter.svg'
 import { ReactComponent as DiscordSVG } from '@dvcorg/gatsby-theme-iterative/src/components/SocialIcon/discord.svg'
-import { ReactComponent as CmlSVG } from '../../../../../static/img/cml_icon-color--square_vector.svg'
 import { ReactComponent as StudioSVG } from '../../../../../static/img/studio_icon-color--square_vector.svg'
 import { ReactComponent as IterativeSVG } from '../../../../../static/img/iterative_icon-color--square_vector.svg'
 
@@ -107,12 +106,6 @@ const footerListsData: Array<IFooterListData> = [
         href: '/',
         text: 'DVC',
         icon: <LogoSVG className={styles.productIcon} />
-      },
-      {
-        href: 'https://cml.dev/',
-        text: 'CML',
-        icon: <CmlSVG className={styles.productIcon} />,
-        target: '_blank'
       },
       {
         href: 'https://studio.iterative.ai/',

--- a/src/@dvcorg/gatsby-theme-iterative/data/menu.ts
+++ b/src/@dvcorg/gatsby-theme-iterative/data/menu.ts
@@ -148,14 +148,6 @@ const menuData: IMenuData = {
       href: 'https://marketplace.visualstudio.com/items?itemName=Iterative.dvc',
       img: '/img/dvc_icon-color--square_vector.svg',
       imgAlt: 'DVC logo'
-    },
-    {
-      title: 'CML',
-      description: 'Open-source CI/CD for ML projects',
-      iconClass: styles.cmlIcon,
-      href: 'https://cml.dev/',
-      img: '/img/cml_icon-color--square_vector.svg',
-      imgAlt: 'CML logo'
     }
   ]
 }

--- a/src/@dvcorg/gatsby-theme-iterative/data/menu.ts
+++ b/src/@dvcorg/gatsby-theme-iterative/data/menu.ts
@@ -125,7 +125,7 @@ const menuData: IMenuData = {
   ],
   products: [
     {
-      title: 'Studio',
+      title: 'DVC Studio',
       description: 'Track experiments and share insights from ML projects',
       iconClass: styles.studioIcon,
       href: 'https://studio.iterative.ai/',

--- a/src/components/Home/Hero/HeroSection.tsx
+++ b/src/components/Home/Hero/HeroSection.tsx
@@ -54,7 +54,7 @@ const Badge = ({ className, children }: ISectionProps) => (
   <div
     className={cn(
       'px-1.5 md:px-3 py-0 rounded-lg',
-      'w-fit',
+      'min-w-[95px] w-fit',
       'mx-auto',
       'flex items-center justify-center gap-2',
       'text-lg md:text-xl font-medium',
@@ -121,8 +121,12 @@ const HeroSection = () => {
               href="https://github.com/iterative/dvc"
               className="no-underline hover:opacity-80"
             >
-              <Badge className="bg-dark text-light">
-                {stars && shortenNumber(stars, 1)}
+              <Badge className={cn('bg-dark text-light')}>
+                {stars ? (
+                  shortenNumber(stars, 1)
+                ) : (
+                  <span className="animate-pulse">---</span>
+                )}
                 <StaticImage
                   src="../../../../static/img/landing/star-github.svg"
                   alt="Star Github"

--- a/src/components/Home/Hero/HeroTitleSection.tsx
+++ b/src/components/Home/Hero/HeroTitleSection.tsx
@@ -9,7 +9,7 @@ const HeroTitleSection = ({ className }: { className?: string }) => {
       <div
         className={cn(
           'text-center',
-          'px-6 py-10 md:py-24',
+          'px-6 py-10 md:pt-24 md:pb-12',
           'flex flex-col gap-6 md:flex-row md:gap-0 items-center',
           'max-w-screen-lg'
         )}

--- a/src/components/Home/Hero/index.tsx
+++ b/src/components/Home/Hero/index.tsx
@@ -8,7 +8,7 @@ import BetterTogether from './BetterTogether'
 const Hero = () => {
   return (
     <>
-      <HeroTitleSection className="pt-14" />
+      <HeroTitleSection />
       <HeroSection />
       <GetStartedWithDvcX />
       <BetterTogether />

--- a/src/components/MainLayout/index.tsx
+++ b/src/components/MainLayout/index.tsx
@@ -1,0 +1,20 @@
+import React from 'react'
+import { PageProps } from 'gatsby'
+import ThemeMainLayout, {
+  LayoutModifiers,
+  ILayoutComponentProps
+} from '@dvcorg/gatsby-theme-iterative/src/components/MainLayout'
+
+interface IMainLayoutProps extends ILayoutComponentProps {
+  location: PageProps['location']
+}
+
+const MainLayout = ({ children, ...props }: IMainLayoutProps) => {
+  return (
+    <ThemeMainLayout {...props} modifiers={[LayoutModifiers.HideAlert]}>
+      {children}
+    </ThemeMainLayout>
+  )
+}
+
+export default MainLayout

--- a/src/pages/404.tsx
+++ b/src/pages/404.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { PageProps } from 'gatsby'
 import SEO from '@dvcorg/gatsby-theme-iterative/src/components/SEO'
-import MainLayout from '@dvcorg/gatsby-theme-iterative/src/components/MainLayout'
+import MainLayout from '../components/MainLayout'
 
 import NotFound from '../components/NotFound'
 

--- a/src/pages/community.tsx
+++ b/src/pages/community.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { PageProps } from 'gatsby'
-import MainLayout from '@dvcorg/gatsby-theme-iterative/src/components/MainLayout'
+import MainLayout from '../components/MainLayout'
 import SEO from '@dvcorg/gatsby-theme-iterative/src/components/SEO'
 
 import Community from '../components/Community'

--- a/src/pages/doc/user-guide/glossary.tsx
+++ b/src/pages/doc/user-guide/glossary.tsx
@@ -1,9 +1,7 @@
 import React from 'react'
 import cn from 'classnames'
 import { PageProps } from 'gatsby'
-import MainLayout, {
-  LayoutModifiers
-} from '@dvcorg/gatsby-theme-iterative/src/components/MainLayout'
+import MainLayout from '../../../components/MainLayout'
 import AutoLinkElement from '@dvcorg/gatsby-theme-iterative/src/components/Documentation/WithJSX/AutoLinkElement'
 import useGlossary from '@dvcorg/gatsby-theme-iterative/src/utils/front/glossary'
 
@@ -15,7 +13,7 @@ const Glossary = ({ location }: PageProps) => {
   const pagePath = '/doc/user-guide/glossary'
 
   return (
-    <MainLayout location={location} modifiers={[LayoutModifiers.HideAlert]}>
+    <MainLayout location={location}>
       <DocLayout currentPath={pagePath}>
         <DocWithJsx path={pagePath} headings={[]}>
           <div className={cn('markdown-body')}>

--- a/src/pages/enterprise.tsx
+++ b/src/pages/enterprise.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { PageProps } from 'gatsby'
-import MainLayout from '@dvcorg/gatsby-theme-iterative/src/components/MainLayout'
+import MainLayout from '../components/MainLayout'
 import Typeform from '../components/Typeform'
 
 const EnterpriseTypeform = ({ location }: PageProps) => (

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { PageProps } from 'gatsby'
-import MainLayout from '@dvcorg/gatsby-theme-iterative/src/components/MainLayout'
+import MainLayout from '../components/MainLayout'
 
 import Home from '../components/Home'
 

--- a/src/pages/subscriber-thank-you.tsx
+++ b/src/pages/subscriber-thank-you.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { PageProps } from 'gatsby'
-import MainLayout from '@dvcorg/gatsby-theme-iterative/src/components/MainLayout'
+import MainLayout from '../components/MainLayout'
 import ThankYou from '../components/ThankYou'
 
 const ThankYouPage = ({ location }: PageProps) => (

--- a/src/pages/support.tsx
+++ b/src/pages/support.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { PageProps } from 'gatsby'
 
-import MainLayout from '@dvcorg/gatsby-theme-iterative/src/components/MainLayout'
+import MainLayout from '../components/MainLayout'
 import SEO from '@dvcorg/gatsby-theme-iterative/src/components/SEO'
 import Support from '../components/Support'
 


### PR DESCRIPTION
This pull request includes the following changes:

- Optimized spacing to fit the homepage to desktop screens

- Hidden the alert banner

- Removed CML from the footer and menu

- Added a simple loading effect to GitHub stars

- Updated "Studio" to "DVC Studio" in the footer and menu

- Renamed "dql" to "dvcx"

- Fixes #5031

TODO:
-[ ] replace `by iterative.ai` with `by dvc.ai` 
    - depends on https://github.com/iterative/gatsby-theme-iterative/pull/248