### PR TITLE
registry: add info for non-models

### DIFF
--- a/content/docs/use-cases/data-registry/tutorial.md
+++ b/content/docs/use-cases/data-registry/tutorial.md
@@ -180,3 +180,64 @@ others can obtain them!
 ```cli
 $ dvc push
 ```
+
+## Managing registries
+
+Now you know how to to build a lightweight data registry, update it, and get
+files from it. As your registry or team continues to grow, you may have trouble
+managing all artifacts across multiple projects. How do you keep them organized,
+or know which version to use, or share them with others outside your team? DVC
+along with [DVC Studio] can help you scale your registry and address these
+questions.
+
+### Adding metadata
+
+You can record additional metadata about data and model <abbr>artifacts</abbr>
+to help organize them and make it easy for others to discover them and
+understand basic info about them. Add aliases and other metadata to a `dvc.yaml`
+file in your project:
+
+```yaml
+# dvc.yaml
+artifacts:
+  get-started-data:
+    path: get-started/data.xml.dvc
+    type: data
+    desc: 'Stack Overflow questions'
+    labels:
+      - nlp
+      - classification
+```
+
+Once you `git commit` and `git push` this info to a project that's connected to
+[DVC Studio], anyone on your team can see it and filter or search across all
+your projects in the <abbr>model registry</abbr>. Although the artifact above is
+not a model, you can remove the models filter to use it for any type of
+artifact:
+
+### Assigning versions and stages
+
+You can use version numbers and stages to signal which artifact versions to use
+or to trigger automated workflows. Just like with software, you can use
+[semantic versioning] to tag releases of your artifacts and to mark artifact
+versions as in production, development, or other stages of their lifecycle:
+
+Versions and stages are saved as Git tags by [GTO]. This means that you have the
+full release history in Git, and you can [trigger] deployments, tests, or other
+actions in your CI/CD workflows when you register a version or assign a stage.
+
+### Accessing artifacts
+
+Others can download or stream artifacts by their version or stage without
+needing access to your Git repository or cloud storage. If you connect your
+[cloud credentials] in [DVC Studio], anyone on your team can access that
+artifact using only a [Studio token]:
+
+[remote storage]: /doc/user-guide/data-management/remote-storage
+[DVC Studio]: https://studio.iterative.ai
+[semantic versioning]: https://semver.org
+[GTO]: /doc/gto
+[trigger]: /doc/studio/user-guide/model-registry/use-models
+[cloud credentials]:
+  /doc/studio/user-guide/account-and-billing#cloud-credentials
+[Studio token]: /doc/studio/user-guide/account-and-billing#tokens

--- a/content/docs/use-cases/data-registry/tutorial.md
+++ b/content/docs/use-cases/data-registry/tutorial.md
@@ -192,10 +192,9 @@ questions.
 
 ### Adding metadata
 
-You can record additional metadata about data and model <abbr>artifacts</abbr>
-to help organize them and make it easy for others to discover them and
-understand basic info about them. Add aliases and other metadata to a `dvc.yaml`
-file in your project:
+You can record additional metadata about <abbr>artifacts</abbr> to help organize
+them and make it easy for others to discover them. Add aliases and other
+metadata to a `dvc.yaml` file in your project:
 
 ```yaml
 # dvc.yaml
@@ -212,15 +211,18 @@ artifacts:
 Once you `git commit` and `git push` this info to a project that's connected to
 [DVC Studio], anyone on your team can see it and filter or search across all
 your projects in the <abbr>model registry</abbr>. Although the artifact above is
-not a model, you can remove the models filter to use it for any type of
-artifact:
+not a model, you can change the filters to use it for any type of artifact:
 
-### Assigning versions and stages
+![Show Registry Datasets](https://static.iterative.ai/img/registry-show-datasets.gif)
 
-You can use version numbers and stages to signal which artifact versions to use
-or to trigger automated workflows. Just like with software, you can use
-[semantic versioning] to tag releases of your artifacts and to mark artifact
-versions as in production, development, or other stages of their lifecycle:
+### Registering versions and assigning stages
+
+[Version numbers] and [stages] signal the commit to use and can trigger
+automated workflows. Just like with software, you can use [semantic versioning]
+to tag releases of your artifacts and to mark artifact versions as in
+production, development, or other stages of their lifecycle:
+
+![Assign Registry Datasets](https://static.iterative.ai/img/registry-assign-datasets.gif)
 
 Versions and stages are saved as Git tags by [GTO]. This means that you have the
 full release history in Git, and you can [trigger] deployments, tests, or other
@@ -228,16 +230,21 @@ actions in your CI/CD workflows when you register a version or assign a stage.
 
 ### Accessing artifacts
 
-Others can download or stream artifacts by their version or stage without
+Others can [download or stream artifacts] by their version or stage without
 needing access to your Git repository or cloud storage. If you connect your
 [cloud credentials] in [DVC Studio], anyone on your team can access that
-artifact using only a [Studio token]:
+artifact using only a [Studio token], either in the UI or programmatically:
+
+![Download Registry Datasets](https://static.iterative.ai/img/registry-download-datasets.gif)
 
 [remote storage]: /doc/user-guide/data-management/remote-storage
 [DVC Studio]: https://studio.iterative.ai
+[Version numbers]: /doc/studio/user-guide/model-registry/register-version
+[stages]: /doc/studio/user-guide/model-registry/assign-stage
 [semantic versioning]: https://semver.org
 [GTO]: /doc/gto
 [trigger]: /doc/studio/user-guide/model-registry/use-models
+[download or stream artifacts]: /doc/studio/user-guide/model-registry/use-models
 [cloud credentials]:
   /doc/studio/user-guide/account-and-billing#cloud-credentials
 [Studio token]: /doc/studio/user-guide/account-and-billing#tokens

--- a/content/docs/use-cases/model-registry.md
+++ b/content/docs/use-cases/model-registry.md
@@ -40,9 +40,10 @@ Model registry enables end-to-end workflows:
 These steps provide a streamlined workflow from model development to deployment,
 supporting all stages of ML model lifecycle.
 
-To begin with this integrated approach to managing your ML models, explore [DVC
-Studio model registry] docs and get started today!
+To begin with this integrated approach to managing your ML models, [start
+managing models] with DVC or explore [DVC Studio model registry] docs!
 
 [gitops]: https://www.gitops.tech/
 [DVC Studio model registry]: /doc/studio/user-guide/model-registry
 [versions]: /doc/use-cases/versioning-data-and-models
+[start managing models]: /doc/start/model-management

--- a/content/docs/user-guide/data-management/discovering-and-accessing-data.md
+++ b/content/docs/user-guide/data-management/discovering-and-accessing-data.md
@@ -2,9 +2,10 @@
 
 Assuming you've learned the basics of how to
 [track and version data](/doc/start/data-management/data-versioning) with DVC,
-you might wonder: How can we access and use these artifacts _outside_ of the DVC
-project? How do we download a model to deploy it? How to download a specific
-version of a model? How to reuse datasets across different projects?
+you might wonder: How can we access and use these <abbr>artifacts</abbr>
+_outside_ of the DVC project? How do we download a model to deploy it? How to
+download a specific version of a model? How to reuse datasets across different
+projects?
 
 <admon type="tip">
 
@@ -137,7 +138,15 @@ can help you organize your artifacts, and you can use `dvc artifacts get` and
 `dvc.api.artifacts_show()` to retrieve them by their alias rather than their
 path.
 
-## Model Registry
+## Model/Artifact Registry
+
+<admon type="tip">
+
+The [DVC Studio model registry] was built for models but since DVC tracks all
+kinds of files, it can be used just as easily for other artifact types. See our
+[tutorial] for how to manage artifacts using the registry.
+
+</admon>
 
 Artifacts become more useful as part of the <abbr>model registry</abbr>, where
 semantic versions can be registered and lifecycle stages (think
@@ -148,3 +157,6 @@ to trigger CICD workflows based on changes in the model registry. With
 across all projects, and you can download artifacts by name, version, and
 lifecycle stage, without needing to configure access to the underlying Git
 repository or remote storage.
+
+[DVC Studio model registry]: /doc/studio/model-registry
+[tutorial]: /doc/use-cases/data-registry/tutorial#sharing-and-managing-artifacts


### PR DESCRIPTION
Adds info about how to use the studio model registry for non-model artifacts. 

Closes #5027 and #5077. 

TODO: Add Studio gifs/screenshots. Depends on https://github.com/iterative/dataset-registry/pull/43.