### PR TITLE
Fix typo in dvclive/live codeblock

### DIFF
--- a/content/docs/dvclive/live/next_step.md
+++ b/content/docs/dvclive/live/next_step.md
@@ -40,7 +40,7 @@ from dvclive import Live
 live = Live()
 
 for custom_step in [0, 15, 20]:
-    live.step = step
+    live.step = custom_step
     live.log_metric("metric_1", 0.9)
     live.log_metric("metric_2", 0.7)
     live.make_summary()


### PR DESCRIPTION
Fix a small typo in the example code block in the `dvclive/live` page.