### PR TITLE
Mention VSCode Plot Debugging in docs

### DIFF
--- a/content/docs/user-guide/experiment-management/visualizing-plots.md
+++ b/content/docs/user-guide/experiment-management/visualizing-plots.md
@@ -268,6 +268,10 @@ view.
 
 ![VS Code Comparison](/img/dvclive-vscode-compare.png)
 
+The extension can also make plots debugging easier.
+
+https://youtu.be/XH0v3x7lBDg?si=6YheW-ocPU9MMoIq
+
 </tab>
 
 <tab title="DVC Studio">

--- a/content/docs/user-guide/experiment-management/visualizing-plots.md
+++ b/content/docs/user-guide/experiment-management/visualizing-plots.md
@@ -108,6 +108,10 @@ to define plots inside your `dvc.yaml`.
 
 https://youtu.be/qG2gfTuQWtk?si=ffpkBLX-odowXK-G
 
+Along with defining plots, the extension can make plot debugging easier.
+
+https://youtu.be/XH0v3x7lBDg?si=6YheW-ocPU9MMoIq
+
 You can also manually edit `dvc.yaml` to configure plots like this:
 
 ```yaml
@@ -267,10 +271,6 @@ you can compare in the
 view.
 
 ![VS Code Comparison](/img/dvclive-vscode-compare.png)
-
-The extension can also make plots debugging easier.
-
-https://youtu.be/XH0v3x7lBDg?si=6YheW-ocPU9MMoIq
 
 </tab>
 


### PR DESCRIPTION
Adds video on plots debugging to `/doc/user-guide/experiment-management/visualizing-plots?tab=VSCode-Extension#visualizing-plots`

## Demo

~https://github.com/iterative/dvc.org/assets/43496356/7180c824-c003-46ef-bfb0-1cbf41b20c78~

![Screenshot 2024-02-02 at 2 51 00 PM](https://github.com/iterative/dvc.org/assets/43496356/219968fa-70e7-4687-95b2-661183dadd41)

Fixes #5057 