### PR TITLE
Send live updates outside a git repo

### DIFF
--- a/content/docs/studio/user-guide/experiments/live-metrics-and-plots.md
+++ b/content/docs/studio/user-guide/experiments/live-metrics-and-plots.md
@@ -21,11 +21,11 @@ experiments using `dvc exp push`.
 Once you create your
 [DVC Studio client access token](/doc/studio/user-guide/account-and-billing#client-access-tokens)
 with Experiment operations scope, pass it to your experiment. If you are running
-the experiment locally, you can set the token in your [DVC config]. For example,
-to set it globally for all of a user's projects:
+the experiment locally, you can use `dvc studio login` to interactively set the
+token:
 
 ```cli
-$ dvc config --global studio.token ***
+$ dvc studio login
 ```
 
 If you are running the experiment as part of a CI job, a secure way to provide
@@ -40,6 +40,23 @@ steps:
     env:
       DVC_STUDIO_TOKEN: ${{ secrets.DVC_STUDIO_TOKEN }}
 ```
+
+<admon type="tip">
+
+If the code is running outside of your Git repository (for example, in
+[Databricks] or [SageMaker jobs]), you lose the benefit of automatically
+tracking metrics and plots with Git, but you can send live updates to Studio if
+you set the `DVC_STUDIO_TOKEN` and `DVC_STUDIO_REPO_URL` environment variables:
+
+```cli
+$ export DVC_STUDIO_TOKEN="<token>"
+$ export DVC_STUDIO_REPO_URL="https://github.com/<org>/<repo>"
+```
+
+</admon>
+
+[Databricks]: /doc/user-guide/integrations/databricks
+[SageMaker jobs]: /doc/user-guide/integrations/sagemaker#pipelines
 
 ## Send and view live metrics and plots
 

--- a/content/docs/user-guide/integrations/databricks.md
+++ b/content/docs/user-guide/integrations/databricks.md
@@ -1,10 +1,10 @@
 # Databricks
 
-As of September 2023 [Databricks Repos] don't expose the underlying Git repo, so
-Git-related DVC functionality within Databricks Repos is not supported (e.g.
-[experiments], `--rev/--all-commits/--all-tags/etc`). Everything will operate as
-normal if you `git clone` a project yourself or [use remote projects](#dvc-api)
-with DVC directly.
+[Databricks Repos] don't expose the underlying Git repo, so Git-related DVC
+functionality within Databricks Repos is not supported (e.g. [experiments],
+`--rev/--all-commits/--all-tags/etc`). Everything will operate as normal if you
+`git clone` a project yourself or [use remote projects](#dvc-api) with DVC
+directly.
 
 ## Setup
 
@@ -84,6 +84,20 @@ entries to corresponding `.gitignore`s, so you'll need to do that manually.
 !dvc import-url https://archive.ics.uci.edu/static/public/186/wine+quality.zip
 ```
 
+## Live experiment updates
+
+If working with [Databricks Repos], you will need to set both the
+`DVC_STUDIO_TOKEN` and `DVC_STUDIO_REPO_URL` to see [live experiment updates] in
+[DVC Studio].
+
+```python
+import getpass
+import os
+
+os.environ["DVC_STUDIO_TOKEN"] = getpass.getpass()
+os.environ["DVC_STUDIO_REPO_URL"] = "https://github.com/<org>/<repo>"
+```
+
 [Databricks Repos]: https://docs.databricks.com/en/repos/index.html
 [experiments]: /doc/start/experiments
 [Python API]: /doc/api-reference
@@ -91,3 +105,6 @@ entries to corresponding `.gitignore`s, so you'll need to do that manually.
 [magic commands]:
   https://ipython.readthedocs.io/en/stable/interactive/magics.html
 [web terminal]: https://docs.databricks.com/en/clusters/web-terminal.html
+[live experiment updates]:
+  /doc/studio/user-guide/experiments/live-metrics-and-plots
+[DVC Studio]: https://studio.iterative.ai

--- a/content/docs/user-guide/integrations/sagemaker.md
+++ b/content/docs/user-guide/integrations/sagemaker.md
@@ -31,13 +31,9 @@ you would in any other environment. Take a look at DVC [experiments] for how to
 get started with DVC in notebooks (if you have setup [code-server] on SageMaker,
 you can also install the [DVC extension for VS Code]).
 
-If you would like to see live experiment updates in [DVC Studio], get your
-[token] and save it in your [dvc config] or `DVC_STUDIO_TOKEN` environment
-variable. For example, to set it globally for all of a user's projects:
-
-```cli
-$ dvc config --global studio.token ***
-```
+If you would like to see [live experiment updates] in [DVC Studio], first set
+your [token]. The simplest method to set the token is to run `dvc studio login`,
+which will save it globally for your user.
 
 While the experiment runs, you will see live updates like this in DVC Studio:
 
@@ -125,6 +121,50 @@ The end result of running the pipeline looks like this:
 
 ![Pipeline](/img/sagemaker-pipeline.png)
 
+### Live experiment updates in SageMaker jobs
+
+SageMaker jobs run outside of your Git repository, so experiment metrics and
+plots will not be automatically tracked in the repository. However, you can see
+[live experiment updates] in [DVC Studio].
+
+First, set the `DVC_STUDIO_TOKEN` and `DVC_STUDIO_REPO_URL` environment
+variables.
+
+```cli
+$ export DVC_STUDIO_TOKEN="<token>"
+$ export DVC_STUDIO_REPO_URL="https://github.com/<org>/<repo>"
+```
+
+<admon type="tip">
+
+If you are running DVC [pipelines] and logged in to Studio, these environment
+variables will be automatically set by DVC, and you can skip the first step. You
+still must pass the environment variables to the SageMaker job.
+
+</admon>
+
+Then pass them to the SageMaker job:
+
+```python
+import os
+from sagemaker.estimator import Estimator
+
+env = {name: value for name, value in os.environ.items() if name.startswith("DVC")}
+
+estimator = Estimator(
+    environment=env,
+    entry_point="train.py",
+    source_dir="src",
+    ...
+)
+```
+
+For any [DVCLive] metrics and plots logged in the `entry_point` script, you
+should now see live updates in Studio. To use DVCLive in the script, you must
+also include `dvclive` in a `requirements.txt` file inside your `source_dir`.
+
+[DVCLive]: /doc/dvclive
+
 ## Deployment
 
 Use the <abbr>model registry</abbr> to automate deployment with SageMaker in
@@ -140,8 +180,10 @@ For a full example of how to deploy with SageMaker, see our [blog post].
 [code-server]:
   https://aws.amazon.com/blogs/machine-learning/host-code-server-on-amazon-sagemaker/
 [dvc extension for vs code]: /doc/vs-code-extension
+[live experiment updates]:
+  /doc/studio/user-guide/experiments/live-metrics-and-plots
 [dvc studio]: https://studio.iterative.ai
-[token]: https://studio.iterative.ai/user/_/profile?section=accessToken
+[token]: /doc/studio/user-guide/account-and-billing#client-access-tokens
 [dvc config]: /doc/user-guide/project-structure/configuration#studio
 [pipelines]: /doc/user-guide/pipelines
 [external dependencies and outputs]:


### PR DESCRIPTION
Docs for https://github.com/iterative/dvclive/pull/646. That PR is for DVCLive, but it's really about logging to Studio from platforms where code is not run inside a Git repo.

The docs PR covers:
- Live updates in Studio when working outside a Git repo
- Live updates in SageMaker jobs
- Live updates in Databricks Repos