### PR TITLE
feat: add banner to hero section

### DIFF
--- a/src/components/Home/Alert/index.tsx
+++ b/src/components/Home/Alert/index.tsx
@@ -10,19 +10,13 @@ const banner = {
 
 const Alert = () => (
   <>
-    <div
-      className={cn(
-        'py-2',
-        'bg-orange text-white',
-        `w-full transition-[height] ease-in-out delay-75 duration-300 text-right px-2`
-      )}
-    >
-      <div className="flex items-center gap-2 justify-center">
-        <div className="ml-2">
+    <div className={cn('py-2', 'bg-orange text-white', `w-full`)}>
+      <div className="flex items-center gap-3 justify-center">
+        <div className="text-right">
           <strong>{banner.title}</strong>
           <div>{banner.subtitle}</div>
         </div>
-        <div className="ml-2">
+        <div>
           <Link
             href={banner.link}
             className={cn(

--- a/src/components/Home/Alert/index.tsx
+++ b/src/components/Home/Alert/index.tsx
@@ -1,0 +1,46 @@
+import Link from '@dvcorg/gatsby-theme-iterative/src/components/Link'
+import React from 'react'
+import { cn } from '../../../utils'
+
+const banner = {
+  title: 'Expert Insights on Developing Safe, Secure, and Trustworthy AI!',
+  subtitle: 'Webinar | Wednesday, February 14th | 11 am ET',
+  link: 'https://www.linkedin.com/events/expertinsightsondevelopingsafe-7158518681906413569/about'
+}
+
+const Alert = () => (
+  <>
+    <div
+      className={cn(
+        'py-2',
+        'bg-orange text-white',
+        `w-full transition-[height] ease-in-out delay-75 duration-300 text-right px-2`
+      )}
+    >
+      <div className="flex items-center gap-2 justify-center">
+        <div className="ml-2">
+          <strong>{banner.title}</strong>
+          <div>{banner.subtitle}</div>
+        </div>
+        <div className="ml-2">
+          <Link
+            href={banner.link}
+            className={cn(
+              'no-underline',
+              'px-2 py-1',
+              'rounded',
+              'font-medium',
+              'whitespace-nowrap',
+              'bg-orange-50 text-orange-700',
+              'hover:bg-white'
+            )}
+          >
+            Register Now
+          </Link>
+        </div>
+      </div>
+    </div>
+  </>
+)
+
+export default Alert

--- a/src/components/Home/Hero/HeroTitleSection.tsx
+++ b/src/components/Home/Hero/HeroTitleSection.tsx
@@ -9,7 +9,7 @@ const HeroTitleSection = ({ className }: { className?: string }) => {
       <div
         className={cn(
           'text-center',
-          'px-6 py-10 md:pt-24 md:pb-12',
+          'px-6 py-10 md:pb-12',
           'flex flex-col gap-6 md:flex-row md:gap-0 items-center',
           'max-w-screen-lg'
         )}

--- a/src/components/Home/index.tsx
+++ b/src/components/Home/index.tsx
@@ -6,11 +6,13 @@ import SubscribeSection from '../SubscribeSection'
 
 import CompanySlider from './LogosSlider'
 import Hero from './Hero'
+import Alert from './Alert'
 
 const Home: React.FC = () => {
   return (
     <>
       <WhatsNewModal />
+      <Alert />
       <Hero />
       <CompanySlider />
       <SubscribeSection />

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -15,6 +15,7 @@ module.exports = {
         gray: { hover: '#40364d', dark: 'rgb(26, 30, 35)' },
         purple: { DEFAULT: '#945dd6' },
         blue: { DEFAULT: 'rgb(56, 179, 220)' },
+        orange: { DEFAULT: '#F46737' },
         indigo: { DEFAULT: '#4B2E70' },
         dark: { DEFAULT: '#1A1E23' },
         light: { DEFAULT: '#EEF4F8' }


### PR DESCRIPTION
- adds a banner to the hero section
- If we move forward with this, it closes https://github.com/iterative/dvc.org/issues/5113

Preview: 

<img width="1728" alt="Screenshot 2024-02-12 at 11 38 41" src="https://github.com/iterative/dvc.org/assets/20840228/40d82bdc-a188-4652-be27-330ebf6d6415">

This attracts complete attention to the section. Since we are really looking forward to the event, and this will be there only for a few days, it might be worth it.

Here is also a subtile version; let me know if we prefer that:

<img width="1728" alt="Screenshot 2024-02-12 at 11 37 57" src="https://github.com/iterative/dvc.org/assets/20840228/8c4806ea-d6ac-472d-86b8-d04e814e3b58">
