### PR TITLE
fix: video missing in docs

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -6,7 +6,8 @@ const app = server.app
 const helmetOptions = {
   contentSecurityPolicy: {
     directives: {
-      frameSrc: ['https://embed.testimonial.to']
+      frameSrc: ['https://embed.testimonial.to'],
+      mediaSrc: ['https://static.iterative.ai']
     }
   }
 }


### PR DESCRIPTION
- Fix the video added on https://github.com/iterative/dvc.org/pull/5121 was not showing up in https://dvc.org/doc/studio/user-guide/experiments/explore-ml-experiments

- It was due to CSP policy. Added https://static.iterative.ai to allowed list.