### PR TITLE
add more env vars

### DIFF
--- a/content/docs/user-guide/env.md
+++ b/content/docs/user-guide/env.md
@@ -2,10 +2,20 @@
 
 List of environment variables to configure DVC behavior.
 
+- `DVC_EXP_BASELINE_REF`: Git revision for the baseline commit from which an
+  <abbr>experiment</abbr> derives. Automatically set by DVC.
+- `DVC_EXP_NAME`: Name of the <abbr>experiment</abbr>. Automatically set by DVC.
+- `DVC_GLOBAL_CONFIG_DIR`: Directory in which DVC will look for global
+  [configuration](/doc/user-guide/project-structure/configuration).
 - `DVC_NO_ANALYTICS`: If `true`, disables
   [analytics](/doc/user-guide/analytics). Overrides `dvc config core.analytics`.
 - `DVC_PAGER`: Set what program DVC uses for paging output (for example,
   `more`).
+- `DVC_ROOT`: Root directory of your <abbr>DVC repository</abbr>. Automatically
+  set by DVC.
+- `DVC_SITE_CACHE_DIR`: Directory for the
+  [site cache dir](/doc/user-guide/project-structure/internal-files#site-cache-dir).
+  Overrides `dvc config core.site_cache_dir`.
 - `DVC_STUDIO_OFFLINE`: If `true`, disables sharing
   [live experiments](/doc/studio/user-guide/experiments/live-metrics-and-plots)
   even if the DVC Studio token is set. Overrides `dvc config studio.offline`.
@@ -15,5 +25,7 @@ List of environment variables to configure DVC behavior.
   `dvc config studio.token`.
 - `DVC_STUDIO_URL`: Set URL of Studio to use (in case of self-hosted DVC Studio
   instance). Overrides `dvc config studio.url`.
+- `DVC_SYSTEM_CONFIG_DIR`: Directory in which DVC will look for system
+  [configuration](/doc/user-guide/project-structure/configuration).
 
 See also [DVCLive environment variables](/doc/dvclive/env).


### PR DESCRIPTION
Closes #4914. @mnrozhkov is using some of these like `DVC_EXP_NAME` in an upcoming blog post, and it seems good to have all of these documented anyway (except for few that look to either have unclear behavior or are intended to be private).