### PR TITLE
use exp git remote to set studio repo url

### DIFF
--- a/content/docs/studio/user-guide/experiments/live-metrics-and-plots.md
+++ b/content/docs/studio/user-guide/experiments/live-metrics-and-plots.md
@@ -46,11 +46,11 @@ steps:
 If the code is running outside of your Git repository (for example, in
 [Databricks] or [SageMaker jobs]), you lose the benefit of automatically
 tracking metrics and plots with Git, but you can send live updates to Studio if
-you set the `DVC_STUDIO_TOKEN` and `DVC_STUDIO_REPO_URL` environment variables:
+you set the `DVC_STUDIO_TOKEN` and `DVC_EXP_GIT_REMOTE` environment variables:
 
 ```cli
 $ export DVC_STUDIO_TOKEN="<token>"
-$ export DVC_STUDIO_REPO_URL="https://github.com/<org>/<repo>"
+$ export DVC_EXP_GIT_REMOTE="https://github.com/<org>/<repo>"
 ```
 
 </admon>

--- a/content/docs/user-guide/env.md
+++ b/content/docs/user-guide/env.md
@@ -6,8 +6,9 @@ List of environment variables to configure DVC behavior.
   git remote `DVC_EXP_GIT_REMOTE`. Overrides `dvc config exp.auto_push`.
 - `DVC_EXP_BASELINE_REV`: Git revision for the baseline commit from which an
   <abbr>experiment</abbr> derives. Automatically set by DVC.
-- `DVC_EXP_GIT_REMOTE`: Git remote used to [push the experiments]. If not
-  specified, push to `origin`. Overrides `dvc config exp.git_remote`.
+- `DVC_EXP_GIT_REMOTE`: Git remote name or URL used to [push the experiments]
+  and [send live metrics and plots] to [DVC Studio]. If not specified, push to
+  `origin`. Overrides `dvc config exp.git_remote`.
 - `DVC_EXP_NAME`: Name of the <abbr>experiment</abbr>. Automatically set by DVC.
 - `DVC_GLOBAL_CONFIG_DIR`: Directory in which DVC will look for global
   [configuration](/doc/user-guide/project-structure/configuration).
@@ -23,16 +24,17 @@ List of environment variables to configure DVC behavior.
 - `DVC_STUDIO_OFFLINE`: If `true`, disables sharing
   [live experiments](/doc/studio/user-guide/experiments/live-metrics-and-plots)
   even if the DVC Studio token is set. Overrides `dvc config studio.offline`.
-- `DVC_STUDIO_REPO_URL`: Set URL of Git remote associated with the DVC Studio
-  project. Overrides `dvc config studio.repo_url`.
-- `DVC_STUDIO_TOKEN`: Set DVC Studio access token to use. Overrides
+- `DVC_STUDIO_TOKEN`: Set [DVC Studio] access token to use. Overrides
   `dvc config studio.token`.
-- `DVC_STUDIO_URL`: Set URL of Studio to use (in case of self-hosted DVC Studio
-  instance). Overrides `dvc config studio.url`.
+- `DVC_STUDIO_URL`: Set URL of [DVC Studio] to use (in case of self-hosted DVC
+  Studio instance). Overrides `dvc config studio.url`.
 - `DVC_SYSTEM_CONFIG_DIR`: Directory in which DVC will look for system
   [configuration](/doc/user-guide/project-structure/configuration).
 
 See also [DVCLive environment variables](/doc/dvclive/env).
 
 [push the experiments]:
-  doc/user-guide/experiment-management/sharing-experiments#push-experiments
+  /doc/user-guide/experiment-management/sharing-experiments#push-experiments
+[send live metrics and plots]:
+  /doc/studio/user-guide/experiments/live-metrics-and-plots
+[dvc studio]: https://studio.iterative.ai

--- a/content/docs/user-guide/integrations/databricks.md
+++ b/content/docs/user-guide/integrations/databricks.md
@@ -87,7 +87,7 @@ entries to corresponding `.gitignore`s, so you'll need to do that manually.
 ## Live experiment updates
 
 If working with [Databricks Repos], you will need to set both the
-`DVC_STUDIO_TOKEN` and `DVC_STUDIO_REPO_URL` to see [live experiment updates] in
+`DVC_STUDIO_TOKEN` and `DVC_EXP_GIT_REMOTE` to see [live experiment updates] in
 [DVC Studio].
 
 ```python
@@ -95,7 +95,7 @@ import getpass
 import os
 
 os.environ["DVC_STUDIO_TOKEN"] = getpass.getpass()
-os.environ["DVC_STUDIO_REPO_URL"] = "https://github.com/<org>/<repo>"
+os.environ["DVC_EXP_GIT_REMOTE"] = "https://github.com/<org>/<repo>"
 ```
 
 [Databricks Repos]: https://docs.databricks.com/en/repos/index.html

--- a/content/docs/user-guide/integrations/sagemaker.md
+++ b/content/docs/user-guide/integrations/sagemaker.md
@@ -130,12 +130,12 @@ SageMaker jobs run outside of your Git repository, so experiment metrics and
 plots will not be automatically tracked in the repository. However, you can see
 [live experiment updates] in [DVC Studio].
 
-First, set the `DVC_STUDIO_TOKEN` and `DVC_STUDIO_REPO_URL` environment
+First, set the `DVC_STUDIO_TOKEN` and `DVC_EXP_GIT_REMOTE` environment
 variables.
 
 ```cli
 $ export DVC_STUDIO_TOKEN="<token>"
-$ export DVC_STUDIO_REPO_URL="https://github.com/<org>/<repo>"
+$ export DVC_EXP_GIT_REMOTE="https://github.com/<org>/<repo>"
 ```
 
 <admon type="tip">

--- a/content/docs/user-guide/project-structure/configuration.md
+++ b/content/docs/user-guide/project-structure/configuration.md
@@ -256,9 +256,13 @@ Sets the defaults for <abbr>experiment</abbr> configuration.
 
 - `exp.auto_push` - [push experiment] automatically after `dvc exp run` and
   `dvc exp save`. Accepts values `true` and `false` (default).
-- `exp.git_remote` - Git remote to [push experiment] to. Defaults to `origin`.
+- `exp.git_remote` - Git remote name or URL used to [push experiment] and [send
+  live metrics and plots] to [DVC Studio]. Defaults to `origin`.
 
 [push experiment]: /doc/user-guide/experiment-management/sharing-experiments
+[send live metrics and plots]:
+  /doc/studio/user-guide/experiments/live-metrics-and-plots
+[dvc studio]: https://studio.iterative.ai
 
 </details>
 
@@ -432,15 +436,9 @@ have no effect.
   variable, which will override any value in `studio.url`. If not set,
   `https://studio.iterative.ai` is used.
 
-- `studio.repo_url` - URL of Git remote associated with the DVC Studio project.
-  This can also be specified through `DVC_STUDIO_REPO_URL` environment variable,
-  which will override any value in `studio.repo_url`. If not set, the URL is set
-  to the [upstream remote] or, failing that, the `origin` remote.
-
 [live experiments]:
   /docs/studio/user-guide/projects-and-experiments/live-metrics-and-plots
 [pushed experiments]: /docs/user-guide/experiment-management/sharing-experiments
-[upstream remote]: https://git-scm.com/book/en/v2/Git-Branching-Remote-Branches
 
 </details>
 


### PR DESCRIPTION
Docs PR for #10345. This drops `DVC_STUDIO_REPO_URL` and instead uses `DVC_EXP_GIT_REMOTE` to set the URL for both live updates in Studio and pushing the final exp ref to the Git remote.