### PR TITLE
Fix `scmProviders.github` naming conventions

### DIFF
--- a/content/docs/studio/self-hosting/configuration/git-forges/github.md
+++ b/content/docs/studio/self-hosting/configuration/git-forges/github.md
@@ -52,18 +52,18 @@ global:
   scmProviders:
     github:
       enabled: true
-   
+
       # Set this if you're using the selfhosted version
       url: <GitHub Enterprise URL>
       # Set this if you're using the selfhosted version
       apiUrl: <GitHub Enterprise API URL>
-   
+
       appName: <GitHub OAuth App Name>
       appId: <GitHub OAuth App ID>
       clientId: <GitHub OAuth App Client ID>
       clientSecret: <GitHub OAuth App Client Secret>
       privateKey: <GitHub OAuth App Private Key>
-   
+
       # Optional
       # This is useful in cases where DVC Studio is on an internal
       # network, but the webhook endpoint is on an external network

--- a/content/docs/studio/self-hosting/configuration/git-forges/github.md
+++ b/content/docs/studio/self-hosting/configuration/git-forges/github.md
@@ -48,25 +48,26 @@ Click **Generate a new client secret**, copy the output
 Merge the `values.yaml` file with the following contents:
 
 ```yaml
-scmProviders:
-  github:
-    enabled: true
-
-    # Set this if you're using the selfhosted version
-    url: <GitHub Enterprise URL>
-    # Set this if you're using the selfhosted version
-    apiUrl: <GitHub Enterprise API URL>
-
-    appName: <GitHub OAuth App Name>
-    appId: <GitHub OAuth App ID>
-    clientId: <GitHub OAuth App Client ID>
-    clientSecret: <GitHub OAuth App Client Secret>
-    privateKey: <GitHub OAuth App Private Key>
-
-    # Optional
-    # This is useful in cases where DVC Studio is on an internal
-    # network, but the webhook endpoint is on an external network
-    # webhookUrl: https://webhook.studio.company.com/webhook/github/
+global:
+  scmProviders:
+    github:
+      enabled: true
+   
+      # Set this if you're using the selfhosted version
+      url: <GitHub Enterprise URL>
+      # Set this if you're using the selfhosted version
+      apiUrl: <GitHub Enterprise API URL>
+   
+      appName: <GitHub OAuth App Name>
+      appId: <GitHub OAuth App ID>
+      clientId: <GitHub OAuth App Client ID>
+      clientSecret: <GitHub OAuth App Client Secret>
+      privateKey: <GitHub OAuth App Private Key>
+   
+      # Optional
+      # This is useful in cases where DVC Studio is on an internal
+      # network, but the webhook endpoint is on an external network
+      # webhookUrl: https://webhook.studio.company.com/webhook/github/
 ```
 
 <admon type="info">

--- a/content/docs/studio/self-hosting/configuration/git-forges/github.md
+++ b/content/docs/studio/self-hosting/configuration/git-forges/github.md
@@ -57,10 +57,10 @@ scmProviders:
     # Set this if you're using the selfhosted version
     apiUrl: <GitHub Enterprise API URL>
 
-    clientId: <GitHub OAuth App Client ID>
     appName: <GitHub OAuth App Name>
     appId: <GitHub OAuth App ID>
-    appSecret: <GitHub OAuth App Secret>
+    clientId: <GitHub OAuth App Client ID>
+    clientSecret: <GitHub OAuth App Client Secret>
     privateKey: <GitHub OAuth App Private Key>
 
     # Optional


### PR DESCRIPTION
* https://github.com/iterative/helm-charts/pull/70 ([current naming convention](https://github.com/iterative/helm-charts/blob/1340959594feb240c268e55e56a8b13836e3cd60/charts/studio/values.yaml#L129-L150))