### PR TITLE
Replace Brandon with Roboto

### DIFF
--- a/src/@dvcorg/gatsby-theme-iterative/components/MainLayout/fonts.css
+++ b/src/@dvcorg/gatsby-theme-iterative/components/MainLayout/fonts.css
@@ -1,5 +1,7 @@
-@import url('https://fonts.googleapis.com/css2?family=Roboto+Mono:ital,wght@0,100..700;1,100..700&family=Roboto:ital,wght@0,100;0,300;0,400;0,500;0,700;0,900;1,100;1,300;1,400;1,500;1,700;1,900&display=swap')
-  /* Prevent mobile browsers from changing font-size */ * {
+@import url('https://fonts.googleapis.com/css2?family=Roboto+Mono:ital,wght@0,100..700;1,100..700&family=Roboto:ital,wght@0,100;0,300;0,400;0,500;0,700;0,900;1,100;1,300;1,400;1,500;1,700;1,900&display=swap');
+
+/* Prevent mobile browsers from changing font-size */
+* {
   text-size-adjust: none;
 }
 

--- a/src/@dvcorg/gatsby-theme-iterative/components/MainLayout/fonts.css
+++ b/src/@dvcorg/gatsby-theme-iterative/components/MainLayout/fonts.css
@@ -1,78 +1,8 @@
-/* Prevent mobile browsers from changing font-size */
-* {
+@import url('https://fonts.googleapis.com/css2?family=Roboto+Mono:ital,wght@0,100..700;1,100..700&family=Roboto:ital,wght@0,100;0,300;0,400;0,500;0,700;0,900;1,100;1,300;1,400;1,500;1,700;1,900&display=swap')
+  /* Prevent mobile browsers from changing font-size */ * {
   text-size-adjust: none;
 }
 
 :root {
-  --font-base: brandongrotesque, tahoma, arial, sans-serif;
-}
-
-@font-face {
-  font-family: BrandonGrotesque;
-  src:
-    url('./fonts/brandon_light.woff2') format('woff2'),
-    url('./fonts/brandon_light.woff') format('woff');
-  font-style: normal;
-  font-weight: 300;
-  font-display: swap;
-}
-
-@font-face {
-  font-family: BrandonGrotesque;
-  src:
-    url('./fonts/brandon_light_it.woff2') format('woff2'),
-    url('./fonts/brandon_light_it.woff') format('woff');
-  font-style: italic;
-  font-weight: 300;
-  font-display: swap;
-}
-
-@font-face {
-  font-family: BrandonGrotesque;
-  src:
-    url('./fonts/brandon_reg.woff2') format('woff2'),
-    url('./fonts/brandon_reg.woff') format('woff');
-  font-style: normal;
-  font-weight: 400;
-  font-display: swap;
-}
-
-@font-face {
-  font-family: BrandonGrotesque;
-  src:
-    url('./fonts/brandon_reg_it.woff2') format('woff2'),
-    url('./fonts/brandon_reg_it.woff') format('woff');
-  font-style: italic;
-  font-weight: 400;
-  font-display: swap;
-}
-
-@font-face {
-  font-family: BrandonGrotesque;
-  src:
-    url('./fonts/brandon_med.woff2') format('woff2'),
-    url('./fonts/brandon_med.woff') format('woff');
-  font-style: normal;
-  font-weight: 500;
-  font-display: swap;
-}
-
-@font-face {
-  font-family: BrandonGrotesque;
-  src:
-    url('./fonts/brandon_med_it.woff2') format('woff2'),
-    url('./fonts/brandon_med_it.woff') format('woff');
-  font-style: italic;
-  font-weight: 500;
-  font-display: swap;
-}
-
-@font-face {
-  font-family: BrandonGrotesque;
-  src:
-    url('./fonts/brandon_bld.woff2') format('woff2'),
-    url('./fonts/brandon_bld.woff') format('woff');
-  font-style: normal;
-  font-weight: 700;
-  font-display: swap;
+  --font-base: roboto, tahoma, arial, sans-serif;
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -36,8 +36,14 @@ module.exports = {
     },
     fontFamily: {
       ...themeConfig.theme.fontFamily,
-      sans: ['BrandonGrotesque', 'Tahoma', 'Arial', 'sans-serif'],
-      mono: ['Consolas', '"Liberation Mono"', 'Menlo', 'Courier', 'monospace']
+      sans: ['Roboto', 'Tahoma', 'Arial', 'sans-serif'],
+      mono: [
+        '"Roboto Mono"',
+        '"Liberation Mono"',
+        'Menlo',
+        'Courier',
+        'monospace'
+      ]
     }
   },
   plugins: [...themeConfig.plugins, require(`tailwindcss-animate`)]


### PR DESCRIPTION
Proof of concept, carbon copy to @shcheklein.

Some font sizes may need a bit of downscaling to fit in the same number of lines, but that's fairly minor. In fact, I would rather try to keep the bigger size and adjust the paddings. The current design is a tribute to [horror vacui](https://en.wikipedia.org/wiki/Horror_vacui_(art)).

**Update: on a second thought, I would even suggest keeping Brandon for the main page, and using Roboto for the documentation**