### PR TITLE
chore: use jost font only for docs

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,3 +1,13 @@
+@import url('https://fonts.googleapis.com/css2?family=Jost:ital,wght@0,100..900;1,100..900&display=swap');
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+#markdown-root {
+  font-family: jost, ui-sans-serif, system-ui, sans-serif;
+
+  .markdown-body {
+    color: #2c3e50;
+  }
+}


### PR DESCRIPTION
 - testing with https://fonts.google.com/specimen/Jost font
 - use font only for docs
 - preview: https://dvc-org-font-jost-only--cmpzmk.herokuapp.com

PR using it for whole website
- https://github.com/iterative/dvc.org/pull/5201

