### PR TITLE
chore: use jost font everywhere

### DIFF
--- a/src/@dvcorg/gatsby-theme-iterative/components/MainLayout/fonts.css
+++ b/src/@dvcorg/gatsby-theme-iterative/components/MainLayout/fonts.css
@@ -1,78 +1,10 @@
+@import url('https://fonts.googleapis.com/css2?family=Jost:ital,wght@0,100..900;1,100..900&display=swap');
+
 /* Prevent mobile browsers from changing font-size */
 * {
   text-size-adjust: none;
 }
 
 :root {
-  --font-base: brandongrotesque, tahoma, arial, sans-serif;
-}
-
-@font-face {
-  font-family: BrandonGrotesque;
-  src:
-    url('./fonts/brandon_light.woff2') format('woff2'),
-    url('./fonts/brandon_light.woff') format('woff');
-  font-style: normal;
-  font-weight: 300;
-  font-display: swap;
-}
-
-@font-face {
-  font-family: BrandonGrotesque;
-  src:
-    url('./fonts/brandon_light_it.woff2') format('woff2'),
-    url('./fonts/brandon_light_it.woff') format('woff');
-  font-style: italic;
-  font-weight: 300;
-  font-display: swap;
-}
-
-@font-face {
-  font-family: BrandonGrotesque;
-  src:
-    url('./fonts/brandon_reg.woff2') format('woff2'),
-    url('./fonts/brandon_reg.woff') format('woff');
-  font-style: normal;
-  font-weight: 400;
-  font-display: swap;
-}
-
-@font-face {
-  font-family: BrandonGrotesque;
-  src:
-    url('./fonts/brandon_reg_it.woff2') format('woff2'),
-    url('./fonts/brandon_reg_it.woff') format('woff');
-  font-style: italic;
-  font-weight: 400;
-  font-display: swap;
-}
-
-@font-face {
-  font-family: BrandonGrotesque;
-  src:
-    url('./fonts/brandon_med.woff2') format('woff2'),
-    url('./fonts/brandon_med.woff') format('woff');
-  font-style: normal;
-  font-weight: 500;
-  font-display: swap;
-}
-
-@font-face {
-  font-family: BrandonGrotesque;
-  src:
-    url('./fonts/brandon_med_it.woff2') format('woff2'),
-    url('./fonts/brandon_med_it.woff') format('woff');
-  font-style: italic;
-  font-weight: 500;
-  font-display: swap;
-}
-
-@font-face {
-  font-family: BrandonGrotesque;
-  src:
-    url('./fonts/brandon_bld.woff2') format('woff2'),
-    url('./fonts/brandon_bld.woff') format('woff');
-  font-style: normal;
-  font-weight: 700;
-  font-display: swap;
+  --font-base: jost, arial, sans-serif;
 }

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,12 +1,8 @@
-@import url('https://fonts.googleapis.com/css2?family=Jost:ital,wght@0,100..900;1,100..900&display=swap');
-
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
 
 #markdown-root {
-  font-family: jost, ui-sans-serif, system-ui, sans-serif;
-
   .markdown-body {
     color: #2c3e50;
   }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -36,7 +36,7 @@ module.exports = {
     },
     fontFamily: {
       ...themeConfig.theme.fontFamily,
-      sans: ['BrandonGrotesque', 'Tahoma', 'Arial', 'sans-serif'],
+      sans: ['Jost', 'Arial', 'sans-serif'],
       mono: ['Consolas', '"Liberation Mono"', 'Menlo', 'Courier', 'monospace']
     }
   },


### PR DESCRIPTION
- testing with [fonts.google.com/specimen/Jost](https://fonts.google.com/specimen/Jost) font
- use font for full website 
- https://dvc-org-font-jost-otx8fdrfdxhb.herokuapp.com/


PR for using only for docs
- https://github.com/iterative/dvc.org/pull/5200)