### PR TITLE
fix inline code syntax in callout

### DIFF
--- a/content/docs/user-guide/data-management/large-dataset-optimization.md
+++ b/content/docs/user-guide/data-management/large-dataset-optimization.md
@@ -98,7 +98,7 @@ efficiency:
 
 [replace them]: /doc/user-guide/how-to/update-tracked-files
 
-<admon type="tip">   
+<admon type="tip">
 
 Use `dvc version` in a DVC repository (with an existing cache folder) to display
 supported file link types.

--- a/content/docs/user-guide/data-management/large-dataset-optimization.md
+++ b/content/docs/user-guide/data-management/large-dataset-optimization.md
@@ -99,8 +99,10 @@ efficiency:
 [replace them]: /doc/user-guide/how-to/update-tracked-files
 
 <admon type="tip">   
+
 Use `dvc version` in a DVC repository (with an existing cache folder) to display
 supported file link types.
+
 </admon>
 
 ## Configuring DVC cache file link type


### PR DESCRIPTION
Looks the admonition tags need a line break before the next paragraph for inline code to be properly recognized (see [here on the _Upgrading to DVC 3.0_ page](https://github.com/iterative/dvc.org/blob/dadb739a68e7ea354ab8e659f4bb5ac9207eff4b/content/docs/user-guide/upgrade.md?plain=1#L41)).