### PR TITLE
start: correct plots configuration

### DIFF
--- a/content/docs/start/data-pipelines/metrics-parameters-plots.md
+++ b/content/docs/start/data-pipelines/metrics-parameters-plots.md
@@ -77,27 +77,27 @@ configuration to `dvc.yaml`:
 
 ```yaml
 metrics:
-  - eval/metrics.json
+- eval/metrics.json
 plots:
-  - ROC:
-      template: simple
-      x: fpr
-      y:
-        eval/plots/sklearn/roc/train.json: tpr
-        eval/plots/sklearn/roc/test.json: tpr
-  - Confusion-Matrix:
-      template: confusion
-      x: actual
-      y:
-        eval/plots/sklearn/cm/train.json: predicted
-        eval/plots/sklearn/cm/test.json: predicted
-  - Precision-Recall:
-      template: simple
-      x: recall
-      y:
-        eval/plots/sklearn/prc/train.json: precision
-        eval/plots/sklearn/prc/test.json: precision
-  - eval/plots/images/importance.png
+- ROC:
+    template: simple
+    x: fpr
+    y:
+      eval/plots/sklearn/roc/train.json: tpr
+      eval/plots/sklearn/roc/test.json: tpr
+- Confusion-Matrix:
+    template: confusion
+    x: actual
+    y:
+      eval/plots/sklearn/cm/train.json: predicted
+      eval/plots/sklearn/cm/test.json: predicted
+- Precision-Recall:
+    template: simple
+    x: recall
+    y:
+      eval/plots/sklearn/prc/train.json: precision
+      eval/plots/sklearn/prc/test.json: precision
+- eval/plots/images/importance.png
 ```
 
 This flexibility to define your own metrics and plots configuration means that

--- a/content/docs/start/data-pipelines/metrics-parameters-plots.md
+++ b/content/docs/start/data-pipelines/metrics-parameters-plots.md
@@ -70,7 +70,10 @@ customize them by editing `dvc.yaml` to combine train and test plots.
 ### 💡 Expand to see how to customize metrics and plots
 
 To combine train and test data, and to set other custom attributes like titles,
-we add the following to `dvc.yaml`:
+first disable DVCLive's default configuration by opening `src/evaluate.py`,
+finding `with Live(EVAL_PATH) as live:`, and modifying it to
+`with Live(EVAL_PATH, dvcyaml=False) as live:`. Then add the following custom
+configuration to `dvc.yaml`:
 
 ```yaml
 metrics:
@@ -92,9 +95,9 @@ plots:
       template: simple
       x: recall
       y:
-        eval/prc/train.json: precision
-        eval/prc/test.json: precision
-  - eval/importance.png
+        eval/plots/sklearn/prc/train.json: precision
+        eval/plots/sklearn/prc/test.json: precision
+  - eval/plots/images/importance.png
 ```
 
 This flexibility to define your own metrics and plots configuration means that

--- a/content/docs/start/data-pipelines/metrics-parameters-plots.md
+++ b/content/docs/start/data-pipelines/metrics-parameters-plots.md
@@ -75,6 +75,7 @@ finding `with Live(EVAL_PATH) as live:`, and modifying it to
 `with Live(EVAL_PATH, dvcyaml=False) as live:`. Then add the following custom
 configuration to `dvc.yaml`:
 
+<!-- prettier-ignore-start -->
 ```yaml
 metrics:
 - eval/metrics.json
@@ -99,6 +100,7 @@ plots:
       eval/plots/sklearn/prc/test.json: precision
 - eval/plots/images/importance.png
 ```
+<!-- prettier-ignore-end -->
 
 This flexibility to define your own metrics and plots configuration means that
 you can even [generate your own] metrics and plots data without using DVCLive!


### PR DESCRIPTION
Depends on https://github.com/iterative/example-repos-dev/pull/282. Corrects issues with how plots are configured in the docs by fixing the dvc.yaml and explaining `Live(dvcyaml=False)`.