### PR TITLE
fix: tutorial.md example import reaches an error

### DIFF
--- a/content/docs/use-cases/data-registry/tutorial.md
+++ b/content/docs/use-cases/data-registry/tutorial.md
@@ -117,7 +117,7 @@ with DVC, includes the `open` function to load/stream data directly from
 external <abbr>DVC projects</abbr>:
 
 ```python
-import dvc.api.open
+import dvc.api
 
 model_path = 'model.pkl'
 repo_url = 'https://github.com/example/registry'


### PR DESCRIPTION
fix: module import in example hitting ModuleNotFoundError

Going through the tutorial, and this specific example is hitting an error
```
ModuleNotFoundError: No module named 'dvc.api.open'
```

> You may disregard these recommendations if you used the **Edit on GitHub** button from dvc.org to improve a doc in place.

❗ Please read the guidelines in the [Contributing to the Documentation](https://dvc.org/doc/user-guide/contributing/docs) list if you make any substantial changes to the documentation or JS engine.

🐛 Please make sure to mention `Fix #issue` (if applicable) in the description of the PR. This causes GitHub to close it automatically when the PR is merged.

Please choose to [allow us](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to edit your branch when creating the PR.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
