### PR TITLE
Revert "chore: drop macOS from download option"

### DIFF
--- a/src/components/DownloadButton/index.tsx
+++ b/src/components/DownloadButton/index.tsx
@@ -11,7 +11,14 @@ import { OS, useUserOS } from '../../utils/front/useUserOS'
 
 const VERSION = `3.50.0`
 
-const dropdownItems = [OS.UNKNOWN, null, OS.WINDOWS, OS.LINUX, OS.LINUX_RPM]
+const dropdownItems = [
+  OS.UNKNOWN,
+  null,
+  OS.OSX,
+  OS.WINDOWS,
+  OS.LINUX,
+  OS.LINUX_RPM
+]
 
 interface IDownloadButtonDropdownItemsProps {
   userOS: OS
@@ -33,6 +40,11 @@ const itemsByOs: Record<OS, IOSDescription> = {
     title: 'pip, conda, brew',
     url: `/doc/install`,
     download: false
+  },
+  [OS.OSX]: {
+    title: 'macOS',
+    url: `/download/osx/dvc-${VERSION}`,
+    download: true
   },
   [OS.WINDOWS]: {
     title: 'Windows',

--- a/src/utils/front/useUserOS.ts
+++ b/src/utils/front/useUserOS.ts
@@ -4,6 +4,7 @@ import { useEffect, useReducer } from 'react'
 
 export enum OS {
   UNKNOWN = 'unknown',
+  OSX = 'osx',
   WINDOWS = 'win',
   LINUX = 'linux',
   LINUX_RPM = 'linux_rpm'
@@ -17,6 +18,7 @@ const getUserOS = (): OS => {
 
   if (!isClient) return OSName
   if (userAgentIs('Win')) OSName = OS.WINDOWS
+  if (userAgentIs('Mac')) OSName = OS.OSX
   if (userAgentIs('Linux')) OSName = OS.LINUX
 
   return OSName


### PR DESCRIPTION
Reverts iterative/dvc.org#5218.
Fixed by https://github.com/iterative/dvc-osxpkg/pull/204.