### PR TITLE
feat(scm): Update SCM settings examples

### DIFF
--- a/content/docs/studio/self-hosting/configuration/git-forges/github.md
+++ b/content/docs/studio/self-hosting/configuration/git-forges/github.md
@@ -50,6 +50,12 @@ marked with `<>` with the values the steps above:
 ```yaml
 global:
   scmProviders:
+    # Optional
+    # This is useful in cases where DVC Studio is on an internal
+    # network, but the webhook endpoint is on an external network.
+    # Default: `global.host` value.
+    #webhookHost: ""
+
     github:
       enabled: true
 
@@ -63,9 +69,4 @@ global:
       clientId: <GitHub OAuth App Client ID>
       clientSecret: <GitHub OAuth App Client Secret>
       privateKey: <GitHub OAuth App Private Key>
-
-      # Optional
-      # This is useful in cases where DVC Studio is on an internal
-      # network, but the webhook endpoint is on an external network
-      # webhookUrl: https://webhook.studio.company.com/webhook/github/
 ```

--- a/content/docs/studio/self-hosting/configuration/git-forges/gitlab.md
+++ b/content/docs/studio/self-hosting/configuration/git-forges/gitlab.md
@@ -30,22 +30,23 @@ got created:
 Merge the `values.yaml` file with the following contents:
 
 ```yaml
-scmProviders:
-  gitlab:
-    enabled: true
-
-    # Set this if you're hosting GitLab on a
-    # custom domain
-    url: ''
-
-    clientId: <GitLab OAuth App Client ID>
-    secretKey: <GitLab OAuth App Secret Key>
-    webhookSecret: <GitLab Webhook Secret>
-
+global:
+  scmProviders:
     # Optional
     # This is useful in cases where DVC Studio is on an internal
-    # network, but the webhook endpoint is on an external network
-    # webhookUrl: https://webhook.studio.company.com/webhook/gitlab/
+    # network, but the webhook endpoint is on an external network.
+    # Default: `global.host` value.
+    #webhookHost: ""
+    gitlab:
+      enabled: true
+
+      # Set this if you're hosting GitLab on a
+      # custom domain
+      url: <GitLab URL>
+
+      clientId: <GitLab OAuth App Client ID>
+      secretKey: <GitLab OAuth App Secret Key>
+      webhookSecret: <GitLab Webhook Secret>
 ```
 
 <admon type="info">


### PR DESCRIPTION
Our examples were outdated, and made confusion to our client.

In GitLab I fixed the indentation.