### PR TITLE
Update OpenID Connect documentation for studio.dvc.ai

### DIFF
--- a/content/docs/studio/user-guide/openid-connect.md
+++ b/content/docs/studio/user-guide/openid-connect.md
@@ -14,7 +14,7 @@ instructions.
 ### Generic configuration details
 
 - OpenID Connect Discovery URL:
-  https://studio.iterative.ai/api/.well-known/openid-configuration
+  https://studio.dvc.ai/api/.well-known/openid-configuration
 
 - Subject claim format: `credentials:{owner}/{name}` where `{owner}` is the name
   of the DVC Studio **user** or **team** owning the credentials, and `{name}` is
@@ -62,7 +62,7 @@ provider "aws" {
 }
 
 locals {
-  provider  = "studio.iterative.ai/api"
+  provider  = "studio.dvc.ai/api"
   condition = "credentials:example-team/example-credentials"
 }
 
@@ -137,7 +137,7 @@ provider "google" {
 }
 
 locals {
-  provider  = "studio.iterative.ai/api"
+  provider  = "studio.dvc.ai/api"
   condition = "credentials:example-team/example-credentials"
 }
 
@@ -226,7 +226,7 @@ provider "azurerm" {
 }
 
 locals {
-  provider  = "studio.iterative.ai/api"
+  provider  = "studio.dvc.ai/api"
   condition = "credentials:example-team/example-credentials"
 }
 


### PR DESCRIPTION
After https://studio.iterative.ai became https://studio.dvc.ai, authentication was failing on e.g. AWS:

```
InvalidIdentityTokenException:
An error occurred (InvalidIdentityToken) when calling the AssumeRoleWithWebIdentity operation: No OpenIDConnect provider found in your account for https://studio.dvc.ai/api
```