### PR TITLE
Update 'Create datasets from query' example and capitalization of DataChain

### DIFF
--- a/content/data/datachain.yml
+++ b/content/data/datachain.yml
@@ -9,10 +9,10 @@
 
     prompt = "How many people in the image?"
 
-    people = Dataset("s3://my-storage/")                       \
-                  .filter(C.name.glob("*.jpg"))                \
-                  .map(DescribeImage(prompt, max_token = 300)) \
-                  .mutate(num_people = int(C.descr))
+    people = DataChain.from_storage("s3://my-storage/", type="image") \
+                      .filter(C.name.glob("*.jpg"))                   \
+                      .map(DescribeImage(prompt, max_token = 300))    \
+                      .mutate(num_people = int(C.descr))
 
     people.filter(C.num_people > 3)
 
@@ -21,6 +21,9 @@
     Save the results of a query in a dataset that you can use to train your ML
     models.
   terminal: |
-    $ datachain query my-query.py my-dataset
-    ..........
-    Dataset 'my-dataset' created
+    from datachain.lib.dc import C, DataChain
+
+    images = DataChain.from_storage("s3://my-storage/", type="image") \
+                      .filter(C.name.glob("*.jpg"))
+
+    images.save("fashion-product-images")

--- a/src/components/Home/Hero/BetterTogether/index.tsx
+++ b/src/components/Home/Hero/BetterTogether/index.tsx
@@ -5,7 +5,7 @@ const BetterTogether = () => {
   return (
     <HeroContainer className="py-14 bg-blue-100">
       <h2 className={cn('text-center text-3xl font-medium')}>
-        Datachain and DVC: Better Together
+        DataChain and DVC: Better Together
       </h2>
       <p className={cn('mt-8', 'text-xl font-normal')}>
         Build the datasets you need without modifying your data sources. Create

--- a/src/components/Home/Hero/HeroSection.tsx
+++ b/src/components/Home/Hero/HeroSection.tsx
@@ -190,7 +190,7 @@ const HeroSection = () => {
               })
             }}
           >
-            <span>Learn about Datachain</span>
+            <span>Learn about DataChain</span>
             <ArrowDown className="w-4 md:w-6 animate-bounce" />
           </CTAButton>
         </Section>


### PR DESCRIPTION
Updates one of the DataChain code examples on the home page, and fixes a couple of uses of 'DataChain' that were not capitalized correctly.