### PR TITLE
Fix #5325 : added --keep flag to dvc exp remove documentation

### DIFF
--- a/content/docs/command-reference/exp/remove.md
+++ b/content/docs/command-reference/exp/remove.md
@@ -40,7 +40,9 @@ With `--queue`, the list of experiments awaiting execution is cleared instead.
 - `-g`, `--git-remote` - Name or URL of the Git remote to remove the experiment
   from
 
-- `--keep` - keep only the selected experiments and remove all others
+- `--keep` - changes the default behavior to the opposite for options like -n, --rev.
+   For example -n <num> --keep keeps experiments from the last num commits and removes
+   all other experiments.
 
 - `-h`, `--help` - shows the help message and exit.
 

--- a/content/docs/command-reference/exp/remove.md
+++ b/content/docs/command-reference/exp/remove.md
@@ -40,9 +40,9 @@ With `--queue`, the list of experiments awaiting execution is cleared instead.
 - `-g`, `--git-remote` - Name or URL of the Git remote to remove the experiment
   from
 
-- `--keep` - changes the default behavior to the opposite for options like -n, --rev.
-   For example -n <num> --keep keeps experiments from the last num commits and removes
-   all other experiments.
+- `--keep` - changes the default behavior to the opposite for options like `-n`,
+  `--rev`. For example `-n <num> --keep` keeps experiments from the last `num`
+  commits and removes all other experiments.
 
 - `-h`, `--help` - shows the help message and exit.
 
@@ -126,7 +126,8 @@ master:
         conic-ease
 ```
 
-Conversely, to keep only specific experiments (and remove all others), give their names to `dvc exp remove` with the `--keep` flag :
+Conversely, to keep only specific experiments (and remove all others), give
+their names to `dvc exp remove` with the `--keep` flag :
 
 ```cli
 $ dvc exp list
@@ -142,7 +143,7 @@ master:
         major-mela
 
 ```
-In this case, the experiments named `conic-ease` and `lucid-lair` are removed, and only `major-mela` is kept.
-The `--keep` flag also works with `--num` (`-n`) and `--rev`, but *not* with `--queue`.
 
-
+In this case, the experiments named `conic-ease` and `lucid-lair` are removed,
+and only `major-mela` is kept. The `--keep` flag also works with `--num` (`-n`)
+and `--rev`, but _not_ with `--queue`.

--- a/content/docs/command-reference/exp/remove.md
+++ b/content/docs/command-reference/exp/remove.md
@@ -8,7 +8,7 @@ Delete specific experiments from the <abbr>project</abbr>.
 
 ```usage
 usage: dvc exp remove [-h] [-q | -v] [-A] [--rev <commit>] [-n <num>]
-                      [--queue | -g <git_remote>]
+                      [--queue | -g <git_remote>] [--keep]
                       [<name> [<name> ...]]
 
 positional arguments:
@@ -39,6 +39,8 @@ With `--queue`, the list of experiments awaiting execution is cleared instead.
 
 - `-g`, `--git-remote` - Name or URL of the Git remote to remove the experiment
   from
+
+- `--keep` - keep only the selected experiments and remove all others
 
 - `-h`, `--help` - shows the help message and exit.
 

--- a/content/docs/command-reference/exp/remove.md
+++ b/content/docs/command-reference/exp/remove.md
@@ -125,3 +125,24 @@ $ dvc exp list myremote
 master:
         conic-ease
 ```
+
+Conversely, to keep only specific experiments (and remove all others), give their names to `dvc exp remove` with the `--keep` flag :
+
+```cli
+$ dvc exp list
+master:
+        major-mela
+        conic-ease
+        lucid-lair
+
+$ dvc exp remove --keep major-mela
+
+$ dvc exp list
+master:
+        major-mela
+
+```
+In this case, the experiments named `conic-ease` and `lucid-lair` are removed, and only `major-mela` is kept.
+The `--keep` flag also works with `--num` (`-n`) and `--rev`, but *not* with `--queue`.
+
+


### PR DESCRIPTION
## Description 

Fix #5325 : added --keep flag to dvc exp remove documentation as needed by the corresponding PR in the code : https://github.com/iterative/dvc/pull/10633