### PR TITLE
install(ubuntu): place key in /etc/apt/keyrings

### DIFF
--- a/content/docs/install/linux.md
+++ b/content/docs/install/linux.md
@@ -108,7 +108,7 @@ $ snap install --classic dvc
 $ sudo apt install wget gpg
 $ sudo mkdir -p /etc/apt/keyrings
 $ wget -qO - https://dvc.org/deb/iterative.asc | sudo gpg --dearmor -o /etc/apt/keyrings/packages.iterative.gpg
-$ echo "deb [signed-by=/etc/apt/keyrings/packages.iterative.gpg] https://dvc.org/deb/ stable main" | sudo tee /etc/apt/sources.list.d/dvc.list
+$ echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/packages.iterative.gpg] https://dvc.org/deb/ stable main" | sudo tee /etc/apt/sources.list.d/dvc.list
 $ sudo chmod 644 /etc/apt/keyrings/packages.iterative.gpg /etc/apt/sources.list.d/dvc.list
 $ sudo apt update
 $ sudo apt install dvc

--- a/content/docs/install/linux.md
+++ b/content/docs/install/linux.md
@@ -106,7 +106,7 @@ $ snap install --classic dvc
 
 ```cli
 $ sudo mkdir -p /etc/apt/keyrings
-$ wget -qO - https://dvc.org/deb/iterative.asc | gpg --dearmor -o /etc/apt/keyrings/packages.iterative.gpg
+$ wget -qO - https://dvc.org/deb/iterative.asc | sudo gpg --dearmor -o /etc/apt/keyrings/packages.iterative.gpg
 $ echo "deb [signed-by=/etc/apt/keyrings/packages.iterative.gpg] https://dvc.org/deb/ stable main" | sudo tee /etc/apt/sources.list.d/dvc.list
 $ sudo chmod 644 /etc/apt/keyrings/packages.iterative.gpg /etc/apt/sources.list.d/dvc.list
 $ sudo apt update

--- a/content/docs/install/linux.md
+++ b/content/docs/install/linux.md
@@ -105,12 +105,10 @@ $ snap install --classic dvc
 ### On Debian/Ubuntu
 
 ```cli
-$ sudo wget \
-       https://dvc.org/deb/dvc.list \
-       -O /etc/apt/sources.list.d/dvc.list
-$ wget -qO - https://dvc.org/deb/iterative.asc | gpg --dearmor > packages.iterative.gpg
-$ sudo install -o root -g root -m 644 packages.iterative.gpg /etc/apt/trusted.gpg.d/
-$ rm -f packages.iterative.gpg
+$ sudo mkdir -p /etc/apt/keyrings
+$ wget -qO - https://dvc.org/deb/iterative.asc | gpg --dearmor -o /etc/apt/keyrings/packages.iterative.gpg
+$ echo "deb [signed-by=/etc/apt/keyrings/packages.iterative.gpg] https://dvc.org/deb/ stable main" | sudo tee /etc/apt/sources.list.d/dvc.list
+$ sudo chmod 644 /etc/apt/keyrings/packages.iterative.gpg /etc/apt/sources.list.d/dvc.list
 $ sudo apt update
 $ sudo apt install dvc
 ```

--- a/content/docs/install/linux.md
+++ b/content/docs/install/linux.md
@@ -105,6 +105,7 @@ $ snap install --classic dvc
 ### On Debian/Ubuntu
 
 ```cli
+$ sudo apt install wget gpg
 $ sudo mkdir -p /etc/apt/keyrings
 $ wget -qO - https://dvc.org/deb/iterative.asc | sudo gpg --dearmor -o /etc/apt/keyrings/packages.iterative.gpg
 $ echo "deb [signed-by=/etc/apt/keyrings/packages.iterative.gpg] https://dvc.org/deb/ stable main" | sudo tee /etc/apt/sources.list.d/dvc.list


### PR DESCRIPTION
The script that we have is a huge security risk. We were adding our key unconditionally to be trusted by apt for any package from any repo.

Instead, we should create a `.list` file for the repository to tell apt where to find the key for that specific repo, which is what this PR does.

As recommended in https://manpages.ubuntu.com/manpages/jammy/en/man8/apt-key.8.html#deprecation.

Also, see https://askubuntu.com/questions/1286545/what-commands-exactly-should-replace-the-deprecated-apt-key.

Also related: https://github.com/iterative/dvc.org/pull/3683.
