### PR TITLE
fix: correct import from `DVCLive` to `dvclive`

### DIFF
--- a/content/docs/dvclive/ml-frameworks/scikit-learn.md
+++ b/content/docs/dvclive/ml-frameworks/scikit-learn.md
@@ -25,7 +25,7 @@ DVCLive provides built-in functions to generate
 The following snippet is used inside the Colab Notebook linked above:
 
 ```python
-from DVCLive import Live
+from dvclive import Live
 
 ...
 


### PR DESCRIPTION
This PR fixes a typo in the documentation by correcting the import statement from `DVCLive` to `dvclive`.