### PR TITLE
docs: show default remote in dvc remote list

### DIFF
--- a/content/docs/command-reference/pull.md
+++ b/content/docs/command-reference/pull.md
@@ -237,8 +237,10 @@ context for the example, let's define a default SSH remote:
 ```cli
 $ dvc remote add -d r1 ssh://user@example.com/path/to/dvc/remote/storage
 $ dvc remote list
-r1	ssh://user@example.com/path/to/dvc/remote/storage
+* r1	ssh://user@example.com/path/to/dvc/remote/storage
 ```
+
+(The prefixed `*` indicates `r1` is the default remote)
 
 <admon type="info">
 

--- a/content/docs/command-reference/pull.md
+++ b/content/docs/command-reference/pull.md
@@ -242,7 +242,8 @@ r1    ssh://user@example.com/project/data/cache   (default)
 r2    ssh://user@example.com/other/storage
 ```
 
-Note that the default remote (if set) is also indicated when you run `dvc remote list`.
+Note that the default remote (if set) is also indicated when you run
+`dvc remote list`.
 
 <admon type="info">
 

--- a/content/docs/command-reference/pull.md
+++ b/content/docs/command-reference/pull.md
@@ -235,12 +235,14 @@ use `dvc remote list` to check them. To remember how it's done, and set a
 context for the example, let's define a default SSH remote:
 
 ```cli
-$ dvc remote add -d r1 ssh://user@example.com/path/to/dvc/remote/storage
+$ dvc remote add -d r1 \
+                 ssh://user@example.com/project/data/cache
 $ dvc remote list
-* r1	ssh://user@example.com/path/to/dvc/remote/storage
+r1    ssh://user@example.com/project/data/cache   (default)
+r2    ssh://user@example.com/other/storage
 ```
 
-(The prefixed `*` indicates `r1` is the default remote)
+Note that the default remote (if set) is also indicated when you run `dvc remote list`.
 
 <admon type="info">
 

--- a/content/docs/command-reference/push.md
+++ b/content/docs/command-reference/push.md
@@ -127,8 +127,10 @@ use `dvc remote list` to check them:
 
 ```cli
 $ dvc remote list
-r1	ssh://user@example.com/path/to/dvc/cache/directory
+* r1	ssh://user@example.com/path/to/dvc/cache/directory
 ```
+
+(The prefixed `*` indicates r1 is the default remote.)
 
 </admon>
 

--- a/content/docs/command-reference/push.md
+++ b/content/docs/command-reference/push.md
@@ -117,7 +117,7 @@ also `dvc remote add --default`). Let's see an SSH remote example:
 
 ```cli
 $ dvc remote add --default r1 \
-                 ssh://user@example.com/path/to/dvc/cache/directory
+                 ssh://user@example.com/project/data/cache
 ```
 
 <admon type="info">
@@ -127,10 +127,9 @@ use `dvc remote list` to check them:
 
 ```cli
 $ dvc remote list
-* r1	ssh://user@example.com/path/to/dvc/cache/directory
+r1    ssh://user@example.com/project/data/cache   (default)
+r2    ssh://user@example.com/other/storage
 ```
-
-(The prefixed `*` indicates r1 is the default remote.)
 
 </admon>
 

--- a/content/docs/command-reference/remote/default.md
+++ b/content/docs/command-reference/remote/default.md
@@ -41,7 +41,8 @@ is omitted.
 You can also use `dvc config`, `dvc remote add`, or `dvc remote modify` commands
 to set/unset/change the default remote.
 
-If a default remote is set, the output of the `dvc remote list` command will specify it, see [the examples below](#examples). 
+If a default remote is set, the output of the `dvc remote list` command will
+specify it, see [the examples below](#examples).
 
 Remotes are read from the system, global, project, and local config files (in
 that order).

--- a/content/docs/command-reference/remote/default.md
+++ b/content/docs/command-reference/remote/default.md
@@ -41,8 +41,7 @@ is omitted.
 You can also use `dvc config`, `dvc remote add`, or `dvc remote modify` commands
 to set/unset/change the default remote.
 
-If a default remote is set that remote will be prefixed by a `*` in the output
-of the `dvc remote list` command.
+If a default remote is set, the output of the `dvc remote list` command will specify it, see [the examples below](#examples). 
 
 Remotes are read from the system, global, project, and local config files (in
 that order).
@@ -88,12 +87,12 @@ $ dvc remote default
 myremote
 ```
 
-See the default remote (prefixed with a `*`) by listing all remotes:
+See the default remote (if set) by listing all remotes:
 
 ```cli
 $ dvc remote list
-* myremote	/path/to/remote
-  otherremote /path/to/other/remote
+myremote    /path/to/remote    (default)
+otherremote    /path/to/other/remote
 ```
 
 Change default remote value:

--- a/content/docs/command-reference/remote/default.md
+++ b/content/docs/command-reference/remote/default.md
@@ -41,6 +41,9 @@ is omitted.
 You can also use `dvc config`, `dvc remote add`, or `dvc remote modify` commands
 to set/unset/change the default remote.
 
+If a default remote is set that remote will be prefixed by a `*` in the output
+of the `dvc remote list` command.
+
 Remotes are read from the system, global, project, and local config files (in
 that order).
 
@@ -83,6 +86,14 @@ Get default remote:
 $ dvc remote default
 
 myremote
+```
+
+See the default remote (prefixed with a `*`) by listing all remotes:
+
+```cli
+$ dvc remote list
+* myremote	/path/to/remote
+  otherremote /path/to/other/remote
 ```
 
 Change default remote value:

--- a/content/docs/command-reference/remote/index.md
+++ b/content/docs/command-reference/remote/index.md
@@ -82,12 +82,9 @@ The <abbr>project</abbr>'s config file should now look like this:
 
 ```cli
 $ dvc remote list
-* myremote	/path/to/remote
-  newremote	s3://mybucket/path
+myremote    /path/to/remote    (default)
+newremote    s3://mybucket/path
 ```
-
-The remote prefixed with a `*` indicates it is the default remote, see
-[`dvc remote default`](/doc/command-reference/remote/default)
 
 ## Example: Customize an additional S3 remote
 

--- a/content/docs/command-reference/remote/index.md
+++ b/content/docs/command-reference/remote/index.md
@@ -82,9 +82,12 @@ The <abbr>project</abbr>'s config file should now look like this:
 
 ```cli
 $ dvc remote list
-myremote	/path/to/remote
-newremote	s3://mybucket/path
+* myremote	/path/to/remote
+  newremote	s3://mybucket/path
 ```
+
+The remote prefixed with a `*` indicates it is the default remote, see
+[`dvc remote default`](/doc/command-reference/remote/default)
 
 ## Example: Customize an additional S3 remote
 

--- a/content/docs/command-reference/remote/list.md
+++ b/content/docs/command-reference/remote/list.md
@@ -13,7 +13,8 @@ usage: dvc remote list [-h] [--global | --system | --project | --local]
 
 Reads [DVC configuration] and prints the list of available remotes, including their
 names and URLs/paths. Remotes are read from the system, global, project, and local
-config files (in that order). The default remote (if set) will be specified in the output (see [the examples below](#examples)). 
+config files (in that order). The default remote (if set) will be specified in the
+output (see [the examples below](#examples)). 
 
 [dvc configuration]: /doc/user-guide/project-structure/configuration#remote
 

--- a/content/docs/command-reference/remote/list.md
+++ b/content/docs/command-reference/remote/list.md
@@ -14,7 +14,7 @@ usage: dvc remote list [-h] [--global | --system | --project | --local]
 Reads [DVC configuration] and prints the list of available remotes, including their
 names and URLs/paths. Remotes are read from the system, global, project, and local
 config files (in that order). The default remote (if set) will be specified in the
-output (see [the examples below](#examples)). 
+output (see [the examples below](#examples)).
 
 [dvc configuration]: /doc/user-guide/project-structure/configuration#remote
 
@@ -57,7 +57,7 @@ otherremote    /path/to/other/remote
 ```
 
 The list will also include any previously added remotes, and the default remote
-(if set). 
+(if set).
 
 [local remote]:
   /doc/user-guide/data-management/remote-storage#file-systems-local-remotes

--- a/content/docs/command-reference/remote/list.md
+++ b/content/docs/command-reference/remote/list.md
@@ -13,8 +13,7 @@ usage: dvc remote list [-h] [--global | --system | --project | --local]
 
 Reads [DVC configuration] and prints the list of available remotes, including their
 names and URLs/paths. Remotes are read from the system, global, project, and local
-config files (in that order). The default remote (if set) will be prefixed with a
-`*`.
+config files (in that order). The default remote (if set) will be specified in the output (see [the examples below](#examples)). 
 
 [dvc configuration]: /doc/user-guide/project-structure/configuration#remote
 
@@ -52,12 +51,12 @@ And now the list of remotes should look like:
 
 ```cli
 $ dvc remote list
-* myremote	/path/to/remote
-  otherremote	/path/to/other/remote
+myremote    /path/to/remote    (default)
+otherremote    /path/to/other/remote
 ```
 
 The list will also include any previously added remotes, and the default remote
-is indicated by a prefixed `*`.
+(if set). 
 
 [local remote]:
   /doc/user-guide/data-management/remote-storage#file-systems-local-remotes

--- a/content/docs/command-reference/remote/list.md
+++ b/content/docs/command-reference/remote/list.md
@@ -13,7 +13,8 @@ usage: dvc remote list [-h] [--global | --system | --project | --local]
 
 Reads [DVC configuration] and prints the list of available remotes, including their
 names and URLs/paths. Remotes are read from the system, global, project, and local
-config files (in that order).
+config files (in that order). The default remote (if set) will be prefixed with a
+`*`.
 
 [dvc configuration]: /doc/user-guide/project-structure/configuration#remote
 
@@ -51,10 +52,12 @@ And now the list of remotes should look like:
 
 ```cli
 $ dvc remote list
-myremote	/path/to/remote
+* myremote	/path/to/remote
+  otherremote	/path/to/other/remote
 ```
 
-The list will also include any previously added remotes.
+The list will also include any previously added remotes, and the default remote
+is indicated by a prefixed `*`.
 
 [local remote]:
   /doc/user-guide/data-management/remote-storage#file-systems-local-remotes


### PR DESCRIPTION
Update the documentation/usage of `dvc remote list` command to reference that the default remote is indicated in the output.

This relates to [issue 10708 in dvc](https://github.com/iterative/dvc/issues/10708) and the [ongoing PR for the fix in dvc]( https://github.com/iterative/dvc/pull/10711) 

Documentation updates to show the changes made there and hopefully make it clear to any end user what the asterisk means. 
