### PR TITLE
remove unneeded operator foranyvalue

### DIFF
--- a/content/docs/studio/user-guide/openid-connect.md
+++ b/content/docs/studio/user-guide/openid-connect.md
@@ -81,7 +81,7 @@ data "aws_iam_policy_document" "studio_assume_role" {
     }
 
     condition {
-      test     = "ForAnyValue:StringLike"
+      test     = "StringLike"
       variable = "${aws_iam_openid_connect_provider.studio.url}:sub"
       values   = [local.condition]
     }


### PR DESCRIPTION
> You may disregard these recommendations if you used the **Edit on GitHub** button from dvc.org to improve a doc in place.

Hey I work for AWS. There is no need to use 'ForAnyValue' With a single valued condition key it doesn't do anything except take up unnecessary characters and cause confusion.

