### PR TITLE
docs(dvclive/xgboost): corrects code example

### DIFF
--- a/content/docs/dvclive/ml-frameworks/xgboost.md
+++ b/content/docs/dvclive/ml-frameworks/xgboost.md
@@ -51,7 +51,7 @@ with Live("custom_dir") as live:
         n_estimators=100,
         early_stopping_rounds=5,
         eval_metric=["merror", "mlogloss"],
-        callbacks=[DVCLiveCallback()]
+        callbacks=[DVCLiveCallback(live)]
     )
 
     model.fit(


### PR DESCRIPTION
Previously, the "Using `live` to pass an existing `Live` instance"
code example was missing the `Live` instance being
passed into the `DVCLiveCallback`.

This PR properly includes the `Live` instance.

<!--
> You may disregard these recommendations if you used the **Edit on GitHub** button from dvc.org to improve a doc in place.

❗ Please read the guidelines in the [Contributing to the Documentation](https://dvc.org/doc/user-guide/contributing/docs) list if you make any substantial changes to the documentation or JS engine.

🐛 Please make sure to mention `Fix #issue` (if applicable) in the description of the PR. This causes GitHub to close it automatically when the PR is merged.

Please choose to [allow us](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to edit your branch when creating the PR.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
-->