### PR TITLE
fix(css): add alpha on selection background color

### DIFF
--- a/packages/gatsby-theme/src/components/Documentation/Markdown/Main/theme.module.css
+++ b/packages/gatsby-theme/src/components/Documentation/Markdown/Main/theme.module.css
@@ -70,7 +70,7 @@
     code[class*='language-']::selection,
     code[class*='language-'] ::selection {
       color: inherit;
-      background: #445262fe;
+      background: rgb(68 82 98 / 99%);
     }
 
     /* Code blocks. */


### PR DESCRIPTION
Safari doesn't fully apply a solid background-color to ::selection element unless the color includes an alpha value. Including an alpha value tells Safari it's a custom color and should be rendered exactly.

FE is the closest hex value to being fully opaque (99.6% opacity).

References:
- https://stackoverflow.com/questions/71567352/how-do-you-fix-the-darkened-text-selection-color-in-safari-css
- https://github.com/w3c/csswg-drafts/issues/6853

Related:
- https://github.com/iterative/gatsby-theme-iterative/issues/287
